### PR TITLE
Make sure to beta-reduce "let v1 = v2 in e".

### DIFF
--- a/src/Feldspar/Core/Constructs/Binding.hs
+++ b/src/Feldspar/Core/Constructs/Binding.hs
@@ -234,6 +234,10 @@ instance
         , v1 == v2
         = return $ fromJust $ gcast a
 
+    constructFeatOpt opts Let (var :* f :* Nil)
+        | Just (C' (Variable v)) <- prjF var
+        = optimizeM opts $ betaReduce (stripDecor var) (stripDecor f)
+
       -- (letBind (letBind e1 (\x -> e2)) (\y -> e3) ==>
       --           letBind e1 (\x -> letBind e2 (\y-> e3))
       --


### PR DESCRIPTION
I've only spotted terms on this form when using explicit force/shares, but the
current situation is that the rest of the optimizations in the compiler fail
to match with these junk terms in the AST.
