### PR TITLE
Enable Sharable GetIx.

### DIFF
--- a/src/Feldspar/Core/Constructs/Array.hs
+++ b/src/Feldspar/Core/Constructs/Array.hs
@@ -105,7 +105,6 @@ instance AlphaEq dom dom dom env => AlphaEq Array Array dom env
 
 instance Sharable Array
   where
-    sharable GetIx = False
     sharable _     = True
 
 instance SizeProp (Array :|| Type)


### PR DESCRIPTION
With the latest merge we can enable Sharable GetIx without suffering from insane copy penalties. 

This pull request should be merged at the same time as pull request #90 in feldspar-compiler  since that contains updated test outputs for -compiler.
