### PR TITLE
Make it possible to float expressions to in-between lambdas.

### DIFF
--- a/src/Feldspar/Core/Constructs/Loop.hs
+++ b/src/Feldspar/Core/Constructs/Loop.hs
@@ -128,6 +128,7 @@ instance ( LoopM Mut :<: dom
          , CLambda Type :<: dom
          , MONAD Mut :<: dom
          , MutableReference :<: dom
+         , Let :<: dom
          , Optimize (CLambda Type) dom
          , Optimize (MONAD Mut) dom
          , Optimize dom dom
@@ -169,6 +170,7 @@ instance ( (Literal  :|| Type) :<: dom
          , (Loop     :|| Type) :<: dom
          , (Variable :|| Type) :<: dom
          , CLambda Type :<: dom
+         , Let :<: dom
          , OptimizeSuper dom
          )
       => Optimize (Loop :|| Type) dom

--- a/src/Feldspar/Core/Constructs/Mutable.hs
+++ b/src/Feldspar/Core/Constructs/Mutable.hs
@@ -96,6 +96,7 @@ monadProxy = P
 instance ( MONAD Mut :<: dom
          , (Variable :|| Type) :<: dom
          , CLambda Type :<: dom
+         , Let :<: dom
          , OptimizeSuper dom)
       => Optimize (MONAD Mut) dom
   where

--- a/src/Feldspar/Core/Constructs/Par.hs
+++ b/src/Feldspar/Core/Constructs/Par.hs
@@ -117,6 +117,7 @@ instance SizeProp (MONAD Par)
 instance ( MONAD Par :<: dom
          , (Variable :|| Type) :<: dom
          , CLambda Type :<: dom
+         , Let :<: dom
          , OptimizeSuper dom
          )
       => Optimize (MONAD Par) dom


### PR DESCRIPTION
The code in this patch is based on Emil's code. 

There's a corresponding patch necessary for the compiler to remain buildable. 
