### PR TITLE
Ensure `permute` stays within bounds

### DIFF
--- a/src/Feldspar/Vector/Internal.hs
+++ b/src/Feldspar/Vector/Internal.hs
@@ -202,11 +202,15 @@ inits1 :: Vector a -> Vector (Vector a)
 inits1 = tail . inits
 
 -- | Permute a single-segment vector
+-- The result of the @perm@ function is passed through @mod l@ to ensure
+-- that the new index is within bounds
 permute' :: (Data Length -> Data Index -> Data Index) -> (Vector a -> Vector a)
 permute' _    Empty                 = Empty
-permute' perm (Indexed l ixf Empty) = indexed l (ixf . perm l)
+permute' perm (Indexed l ixf Empty) = indexed l (ixf . (`mod` l) . perm l)
 
 -- | Permute a vector
+-- The result of the @perm@ function is passed through @mod l@ to ensure
+-- that the new index is within bounds
 permute :: Syntax a =>
     (Data Length -> Data Index -> Data Index) -> (Vector a -> Vector a)
 permute perm = permute' perm . mergeSegments


### PR DESCRIPTION
The `permute` function accepts a user defined function to rearrange the
elements of a `Vector`. However, the user had to ensure that the resulting
indices were within the bounds of the `Vector` size.

This fix introduces a modulo with the length of the `Vector` after the user
supplied function to wrap all indices into the `Vector` bounds.

If the range of the result of the user supplied function is within the
range of the length, then the modulo will not show up in the syntax tree.
