### PR TITLE
Add basic support for the Elements language.

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -48,6 +48,7 @@ library
     Feldspar.Core.Constructs.Conversion
     Feldspar.Core.Constructs.Eq
     Feldspar.Core.Constructs.Error
+    Feldspar.Core.Constructs.Elements
     Feldspar.Core.Constructs.Floating
     Feldspar.Core.Constructs.Fractional
     Feldspar.Core.Constructs.Future
@@ -79,6 +80,7 @@ library
     Feldspar.Core.Frontend.Condition
     Feldspar.Core.Frontend.ConditionM
     Feldspar.Core.Frontend.Conversion
+    Feldspar.Core.Frontend.Elements
     Feldspar.Core.Frontend.Eq
     Feldspar.Core.Frontend.Error
     Feldspar.Core.Frontend.Floating

--- a/src/Feldspar/Core/Constructs.hs
+++ b/src/Feldspar/Core/Constructs.hs
@@ -55,6 +55,7 @@ import Feldspar.Core.Constructs.Complex
 import Feldspar.Core.Constructs.Condition
 import Feldspar.Core.Constructs.ConditionM
 import Feldspar.Core.Constructs.Conversion
+import Feldspar.Core.Constructs.Elements
 import Feldspar.Core.Constructs.Eq
 import Feldspar.Core.Constructs.Error
 import Feldspar.Core.Constructs.FFI
@@ -122,6 +123,7 @@ type FeldSymbols
     :+: MutableToPure
     :+: MONAD Par
     :+: ParFeature
+    :+: (ElementsFeat :|| Type)
     :+: Empty
 
 -- TODO We are currently a bit inconsistent in that `Type` constraints are sometimes attached

--- a/src/Feldspar/Core/Constructs/Elements.hs
+++ b/src/Feldspar/Core/Constructs/Elements.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Feldspar.Core.Constructs.Elements where
+
+import Language.Syntactic
+import Language.Syntactic.Constructs.Monad
+import Language.Syntactic.Constructs.Binding.HigherOrder
+
+import Feldspar.Lattice
+import Feldspar.Core.Types
+import Feldspar.Core.Interpretation
+import Feldspar.Core.Constructs.Binding
+import Feldspar.Core.Constructs.Literal
+
+import Data.List
+import Data.Function (on)
+
+data ElementsFeat a
+  where
+    EMaterialize :: Type a => ElementsFeat (Length :-> Elements a :-> Full [a])
+    EWrite       :: Type a => ElementsFeat (Index :-> a :-> Full (Elements a))
+    ESkip        :: Type a => ElementsFeat (Full (Elements a))
+    EPar         :: Type a => ElementsFeat (Elements a :-> Elements a :-> Full (Elements a))
+    EparFor        :: Type a => ElementsFeat (Length :-> (Index -> Elements a) :-> Full (Elements a))
+
+instance Semantic ElementsFeat
+  where
+    semantics EMaterialize    = Sem "materialize" ematerialize
+    semantics EWrite          = Sem "write" (\ix e -> Elements [(ix, e)])
+    semantics ESkip           = Sem "skip" (Elements [])
+    semantics EPar            = Sem "par" (\(Elements l) (Elements r) -> Elements (l ++ r))
+    semantics EparFor         = Sem "parFor" eparFor
+
+ematerialize :: Length -> Elements a -> [a]
+ematerialize l (Elements xs) = map snd xs'
+  where xs' = genericTake l $ sortBy (compare `on` fst) xs
+
+eparFor :: Length -> (Index -> Elements a) -> Elements a
+eparFor len ixf = Elements $ concatMap (\(Elements vs) -> vs) xs
+      where xs = genericTake len $ map ixf [0..]
+
+semanticInstances ''ElementsFeat
+
+instance EvalBind ElementsFeat where evalBindSym = evalBindSymDefault
+
+instance AlphaEq dom dom dom env => AlphaEq ElementsFeat ElementsFeat dom env
+  where
+    alphaEqSym = alphaEqSymDefault
+
+instance Sharable ElementsFeat
+
+instance Monotonic ElementsFeat
+
+instance SizeProp (ElementsFeat :|| Type)
+  where
+    sizeProp (C' EMaterialize) (WrapFull len :* WrapFull arr :* Nil) = infoSize arr
+    sizeProp (C' EWrite)       _                                     = universal
+    sizeProp (C' ESkip)        _                                     = universal
+    sizeProp (C' EPar)         (WrapFull p1 :* WrapFull p2 :* Nil)   = universal -- TODO: p1 U p2
+    sizeProp (C' EparFor)        _                                   = universal
+
+instance ( (ElementsFeat :|| Type) :<: dom
+         , OptimizeSuper dom
+         )
+      => Optimize (ElementsFeat :|| Type) dom
+  where
+    constructFeatUnOpt opts x@(C' _) = constructFeatUnOptDefault opts x

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -111,6 +111,7 @@ import Feldspar.Core.Frontend.Complex          as Frontend
 import Feldspar.Core.Frontend.Condition        as Frontend
 import Feldspar.Core.Frontend.ConditionM       as Frontend
 import Feldspar.Core.Frontend.Conversion       as Frontend
+import Feldspar.Core.Frontend.Elements         as Frontend
 import Feldspar.Core.Frontend.Eq               as Frontend
 import Feldspar.Core.Frontend.Error            as Frontend
 import Feldspar.Core.Frontend.FFI              as Frontend

--- a/src/Feldspar/Core/Frontend/Elements.hs
+++ b/src/Feldspar/Core/Frontend/Elements.hs
@@ -1,0 +1,27 @@
+module Feldspar.Core.Frontend.Elements
+  ( materialize
+  , write
+  , par
+  , parFor
+  , skip
+  ) where
+
+import Feldspar.Core.Types
+import Feldspar.Core.Constructs
+import Feldspar.Core.Constructs.Elements
+
+materialize :: Type a => Data Length -> Data (Elements a) -> Data [a]
+materialize = sugarSymF EMaterialize
+
+write :: Type a => Data Index -> Data a -> Data (Elements a)
+write = sugarSymF EWrite
+
+par :: Type a => Data (Elements a) -> Data (Elements a) -> Data (Elements a)
+par = sugarSymF EPar
+
+parFor :: Type a => Data Length -> (Data Index -> Data (Elements a)) -> Data (Elements a)
+parFor = sugarSymF EparFor
+
+skip :: Type a => Data (Elements a)
+skip = sugarSymF ESkip
+


### PR DESCRIPTION
This adds the basic support for the Elements language that is designed for writing arrays in parallel. The language allows parallelism by construction and is a a perfect match for writing Push vectors to memory. There are four simple constructs in the grammar:

expr ::= ... | materialize l elements
elements ::= skip | write ix expr | elements `par` elements | parFor l (\ix -> elements)

This  patch adds the language support. The vector libraries in the tree are left as is so the patch should not break anything if it does contain bugs. I have tested the language with various programs using:

*) Push.hs in master.
*) PullPush.hs in the arrays branch.
*) MultiDim.hs in the arrays branch.

Feldspar-compiler-support coming in the next pull request. Idea by Koen Claessen, grammar communicated by Josef Svenningsson. 
