### PR TITLE
Revert "Make Select Sharable."

### DIFF
--- a/src/Feldspar/Core/Constructs/Tuple.hs
+++ b/src/Feldspar/Core/Constructs/Tuple.hs
@@ -121,6 +121,8 @@ instance SizeProp (Tuple :|| Type)
           )
 
 instance Sharable Select
+  where
+    sharable _ = False
 
 instance Monotonic Select
 


### PR DESCRIPTION
This reverts commit a6dc945284c5deba20321f184e03ba2cbf2894e9.

Sharing selectors unfortunately increases copying in feldspar-compiler. 
