### PR TITLE
Simplified Stream implementation

### DIFF
--- a/src/Feldspar/Stream.hs
+++ b/src/Feldspar/Stream.hs
@@ -71,6 +71,8 @@ import Feldspar.Vector.Shape (Shape(..),DIM1)
 -- | Infinite streams.
 data Stream a where
   Stream :: M (M a) -> Stream a
+    -- The outer monadic layer is for initialization and the inner layer
+    -- for extracting elements.
 
 type instance Elem      (Stream a) = a
 type instance CollIndex (Stream a) = Data Index


### PR DESCRIPTION
I removed the existential state type in `Stream`. Now streams are represented by a single value `M (M a)` where the outer monad layer is used to initialize and return the method `M a` that produces the next element.

@josefs, what do you think about this change. I see no big reason to prefer this implementation other than that the code is a bit simpler. At first, I thought that removing the existential would make it possible to do more things, but this turned out not to be the case.

Note that the generated code is exactly the same as before.

Since the `Stream` constructor is not exported, this change should not break any code.
