### PR TITLE
Recurrence

### DIFF
--- a/src/Feldspar/Stream.hs
+++ b/src/Feldspar/Stream.hs
@@ -476,8 +476,10 @@ slidingAvg n str = recurrenceI (replicate1 n 0) str
 fir :: Pull1 Float ->
        Stream (Data Float) -> Stream (Data Float)
 fir b inp =
-    recurrenceI (replicate1 (length b) 0) inp
-                (scalarProd b)
+    recurrenceIO (replicate1 (length b) 0) inp (replicate1 1 0)
+                 (\i _ -> scalarProd b i)
+  -- Temporarily using recurrenceIO instead of recurrenceI, because the latter uses an empty output
+  -- buffer, which triggers https://github.com/Feldspar/feldspar-language/issues/24
 
 -- | An iir filter on streams
 iir :: Data Float -> Pull1 Float -> Pull1 Float ->

--- a/src/Feldspar/Stream.hs
+++ b/src/Feldspar/Stream.hs
@@ -473,8 +473,8 @@ slidingAvg n str = recurrenceI (replicate1 n 0) str
                    (\input -> (fromZero $ sum input) `quot` n)
 
 -- | A fir filter on streams
-fir :: Pull1 Float ->
-       Stream (Data Float) -> Stream (Data Float)
+fir :: Numeric a => Pull1 a ->
+       Stream (Data a) -> Stream (Data a)
 fir b inp =
     recurrenceIO (replicate1 (length b) 0) inp (replicate1 1 0)
                  (\i _ -> scalarProd b i)
@@ -482,8 +482,8 @@ fir b inp =
   -- buffer, which triggers https://github.com/Feldspar/feldspar-language/issues/24
 
 -- | An iir filter on streams
-iir :: Data Float -> Pull1 Float -> Pull1 Float ->
-       Stream (Data Float) -> Stream (Data Float)
+iir :: Fraction a => Data a -> Pull1 a -> Pull1 a ->
+       Stream (Data a) -> Stream (Data a)
 iir a0 a b inp =
     recurrenceIO (replicate1 (length b) 0) inp
                  (replicate1 (length a) 0)

--- a/src/Feldspar/Stream.hs
+++ b/src/Feldspar/Stream.hs
@@ -424,11 +424,10 @@ recurrenceIO ii (Stream init) io mkExpr = Stream $ do
                           (indexed1 lenI (\i -> getIx ib ((lenI + ix - i) `rem` lenI)))
                           (indexed1 lenO (\i -> getIx ob ((lenO + ix - i - 1) `rem` lenO)))
                             ))
-      ifM (lenO /= 0)
+      whenM (lenO /= 0)
         (do o <- getArr obuf (ix `rem` lenO)
-            setArr obuf (ix `rem` lenO) b
-            return o)
-        (return b)
+            setArr obuf (ix `rem` lenO) b)
+      return b
   where
     lenI = length ii
     lenO = length io
@@ -460,11 +459,10 @@ recurrenceIIO i1 (Stream init1) i2 (Stream init2) io mkExpr = Stream $ do
                                    (indexed1 len2 (\i -> getIx ib2 ((len2 + ix - i) `rem` len2)))
                                    (indexed1 lenO (\i -> getIx ob  ((lenO + ix - i - 1) `rem` lenO)))
                                 )))
-      ifM (lenO /= 0)
+      whenM (lenO /= 0)
           (do o <- getArr obuf (ix `rem` lenO)
-              setArr obuf (ix `rem` lenO) out
-              return o)
-          (return out)
+              setArr obuf (ix `rem` lenO) out)
+      return out
   where
     len1 = length i1
     len2 = length i2

--- a/tests/Feldspar/Stream/Test.hs
+++ b/tests/Feldspar/Stream/Test.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Feldspar.Stream.Test where
+
+
+
+import qualified Prelude as P
+import qualified Data.List as List
+
+import Feldspar
+import Feldspar.Stream
+import Feldspar.Vector
+
+import Test.Tasty
+import Test.Tasty.TH
+import Test.Tasty.QuickCheck
+
+import Test.QuickCheck
+
+
+
+scProd :: Num a => [a] -> [a] -> a
+scProd a b = P.sum $ P.zipWith (*) a b
+
+
+
+-- Reference implementation of FIR filter
+firRef :: Num a => [a] -> [a] -> [a]
+firRef coeffs inp = [scProd coeffs is | is <- P.map P.reverse $ P.tail $ List.inits inp]
+
+firFeld :: [Int32] -> [Int32] -> [Int32]
+firFeld coeffs = eval (freezePull1 . streamAsVector (fir (toPull $ value1 coeffs)) . thawPull1)
+
+prop_fir (NonEmpty coeffs) = firRef coeffs ==== firFeld coeffs
+
+
+
+-- Reference implementation of IIR filter
+iirRef :: Num a => [a] -> [a] -> [a] -> [a]
+iirRef as bs inp = outp
+  where
+    inps  = P.map P.reverse $ P.tail $ List.inits inp
+    outps = P.map P.reverse $ P.tail $ List.inits (0:outp)
+
+    outp = [scProd bs is - scProd as os | (is,os) <- P.zip inps outps]
+
+-- | Same as 'iir' in "Feldspar.Stream", but without the fractional constraint, to avoid rounding
+-- errors when testing
+iirInt :: Numeric a => Pull1 a -> Pull1 a -> Stream (Data a) -> Stream (Data a)
+iirInt a b inp =
+    recurrenceIO (replicate1 (length b) 0) inp
+                 (replicate1 (length a) 0)
+                 (\i o -> (scalarProd b i - scalarProd a o))
+
+iirFeld :: [Int32] -> [Int32] -> [Int32] -> [Int32]
+iirFeld as bs = eval (freezePull1 . iirVec . thawPull1)
+  where
+    iirVec = streamAsVector (iirInt (toPull $ value1 as) (toPull $ value1 bs))
+
+prop_iir (NonEmpty as) (NonEmpty bs) = iirRef as bs ==== iirFeld as bs
+
+
+
+tests = $(testGroupGenerator)
+

--- a/tests/SemanticsTest.hs
+++ b/tests/SemanticsTest.hs
@@ -11,6 +11,7 @@ import Examples.Simple.Basics
 import qualified Feldspar.Core.Test
 import qualified Feldspar.Mutable.Test
 import qualified Feldspar.Vector.Test
+import qualified Feldspar.Stream.Test
 
 prop_example5 = eval example5 ==== (+)
 prop_example9 = eval example9 ==== \a -> if a<5 then 3*(a+20) else 30*(a+20)
@@ -21,5 +22,6 @@ main = defaultMain $ testGroup "Tests"
     [ tests
     , Feldspar.Mutable.Test.tests
     , Feldspar.Vector.Test.tests
+    , Feldspar.Stream.Test.tests
     ]
 


### PR DESCRIPTION
ed79b5a fixes the output of the recurrence combinators.

@josefs, I'm not sure if the old behavior was intentional, but the provided test for `iir` shows that it now behaves consistently with a Haskell reference.

Also, following up on my comment in 640d57d, the tests in this PR speak for the correctness of that commit.