### PR TITLE
Ensure that there are no lets outside outermost lambda for BA.

### DIFF
--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -105,7 +105,7 @@ untypeProgDecor (Decor info a) = untypeProgSym a info
 
 -- | External module interface.
 untype :: Untype dom dom => FeldOpts -> ASTF (Decor Info dom) a ->  UntypedFeld
-untype opts = createTasks opts . unAnnotate . optimize . sinkLets . untypeProg
+untype opts = createTasks opts . unAnnotate . optimize . sinkLets opts . untypeProg
 
 untypeProg :: Untype dom dom =>
     ASTF (Decor Info dom) a -> AUntypedFeld ValueInfo

--- a/src/Feldspar/Core/Middleend/LetSinking.hs
+++ b/src/Feldspar/Core/Middleend/LetSinking.hs
@@ -1,11 +1,13 @@
 module Feldspar.Core.Middleend.LetSinking ( sinkLets ) where
 
 import Feldspar.Core.UntypedRepresentation
+import Feldspar.Core.Interpretation (FeldOpts, Target(..), inTarget)
 
 -- | Sink lets that are stuck between two lambdas.
 -- Necessary invariant: lambdas can only appear in special places.
-sinkLets :: AUntypedFeld a -> AUntypedFeld a
-sinkLets = go
+--
+sinkLets :: FeldOpts -> AUntypedFeld a -> AUntypedFeld a
+sinkLets opts = collectAtTop opts . go
   where go e@(AIn _ Variable{}) = e
         go (AIn r (Lambda v e))
          | (bs1, AIn r' (Lambda v' body)) <- collectLetBinders e
@@ -17,3 +19,13 @@ sinkLets = go
         go (AIn r (App Let t [e1, AIn r' (Lambda x e2)]))
          = AIn r (App Let t [go e1, AIn r' (Lambda x $ go e2)])
         go (AIn r (App p t es)) = AIn r (App p t $ map go es)
+
+collectAtTop :: FeldOpts -> AUntypedFeld a -> AUntypedFeld a
+collectAtTop opts e
+  | BA `inTarget` opts
+  , (bs, e1) <- collectLetBinders e -- Get outermost let bindings
+  , not $ null bs
+  , (vs, body) <- collectBinders e1 -- Get all lambdas immediately within
+  , not $ null vs
+  = mkLam' vs $ mkLets (bs, body)
+  | otherwise = e


### PR DESCRIPTION
When compiling for target BA it is necessary that there are
no let-bindings outside the outermost lambda in the program.
Otherwise fromCore will generate a program with top level
entities that are not functions, something the BA back end
currently does not handle.