### PR TITLE
Add a string to Var type

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -144,6 +144,7 @@ library
     array,
     base                        >= 4      && < 5.9,
     base-orphans,
+    bytestring                  >= 0.10   && < 0.11,
     containers                  >= 0.4    && < 0.6,
     comonad                     >= 4.2    && < 5.0,
     mtl                         >= 2.0    && < 2.3,

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -11,6 +11,7 @@ module Feldspar.Core.Middleend.FromTyped
   )
   where
 
+import qualified Data.ByteString.Char8 as B
 import Data.Complex
 import Data.Typeable (Typeable)
 
@@ -165,14 +166,14 @@ instance ( Untype dom dom
 instance Untype (Core.Variable :|| Type) dom
   where
     untypeProgSym (C' (Core.Variable v)) info Nil
-        = AIn r' (Ut.Variable (Ut.Var v t'))
+        = AIn r' (Ut.Variable (Ut.Var v t' B.empty))
            where t' = untypeType (infoType info) (infoSize info)
                  r' = toValueInfo (infoType info) (infoSize info)
 
 instance (Untype dom dom,Project (CLambda Type) dom) => Untype (CLambda Type) dom
   where
     untypeProgSym (SubConstr2 (Lambda v)) info (body :* Nil)
-     = AIn r' (Ut.Lambda (Ut.Var v t') body')
+     = AIn r' (Ut.Lambda (Ut.Var v t' B.empty) body')
         where t' = untypeType (argType $ infoType info) (fst $ infoSize info)
               -- The value info of a function is that of its return value.
               body'@(AIn r' _) = untypeProg body

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -45,6 +45,7 @@ module Feldspar.Core.UntypedRepresentation (
   )
   where
 
+import qualified Data.ByteString.Char8 as B
 import Data.List (nub, intercalate)
 import Data.Tree
 import Data.Int
@@ -130,6 +131,7 @@ data Type =
 
 data Var = Var { varNum :: VarId
                , varType :: Type
+               , varName :: B.ByteString
                }
 
 -- Variables are equal if they have the same varNum.
@@ -140,7 +142,9 @@ instance Ord Var where
   compare v1 v2 = compare (varNum v1) (varNum v2)
 
 instance Show Var where
-  show (Var n _t) = "v" ++ show n
+  show (Var n _t name) = (if name == B.empty
+                            then "v"
+                            else B.unpack name) ++ show n
 
 data Lit =
      LBool Bool


### PR DESCRIPTION
This will allow variable names created
by transformations to be derived from
the variable name that prompted the creation.