### PR TITLE
Avoid deprecated pragma

### DIFF
--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -7,7 +8,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE OverlappingInstances #-}
+#endif
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
@@ -317,7 +320,7 @@ class Equal a
   where
     (====) :: a -> a -> Property
 
-instance (P.Eq a, Show a) => Equal a
+instance {-# OVERLAPPABLE #-} (P.Eq a, Show a) => Equal a
   where
     x ==== y = x === y
 

--- a/src/Feldspar/Core/Interpretation/Typed.hs
+++ b/src/Feldspar/Core/Interpretation/Typed.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE OverlappingInstances #-}
+#endif
 
 -- | Witness 'Type' constraints
 
@@ -29,7 +32,7 @@ class Typed dom
 instance Typed (sub :|| Type)
   where typeDictSym (C' _) = Just Dict
 
-instance Typed sub => Typed (sub :|| pred)
+instance {-# OVERLAPPABLE #-} Typed sub => Typed (sub :|| pred)
   where typeDictSym (C' s) = typeDictSym s
 
 instance Typed sub => Typed (sub :| pred)
@@ -46,7 +49,7 @@ instance (Typed sub) => Typed (Decor info sub)
   where typeDictSym (Decor _ s) = typeDictSym s
 
 instance Typed Empty
-instance Typed dom
+instance  {-# OVERLAPPABLE #-} Typed dom
 
 -- | Extract a possible 'Type' constraint witness from an 'AST'
 typeDict :: Typed dom => ASTF dom a -> Maybe (Dict (Type a))


### PR DESCRIPTION
The -XOverlappingInstances language extension (a.k.a pragma LANGUAGE OverlappingInstances) is deprecated in favour of fine-grained per instance pragmas.