### PR TITLE
Improve layout of 'Let' when drawing ASTs.

### DIFF
--- a/tests/gold/monadicSharing.txt
+++ b/tests/gold/monadicSharing.txt
@@ -8,11 +8,12 @@ Lambda v0 : u32
              ├╴GetRef {Mu32 in VIWord32 [*,*]}
              │  └╴v1 : Ru32 in VIWord32 [*,*]
              └╴Lambda v2 : u32
-                └╴Let {Mu32 in VIWord32 [*,*]}
-                   ├╴Add {u32 in VIWord32 [*,*]}
-                   │  ├╴v2 : u32 in VIWord32 [*,*]
-                   │  └╴3 : u32
-                   └╴Lambda v3 : u32
+                └╴Let
+                   ├╴Var v3 : u32 = 
+                   │  └╴Add {u32 in VIWord32 [*,*]}
+                   │     ├╴v2 : u32 in VIWord32 [*,*]
+                   │     └╴3 : u32
+                   └╴In
                       └╴Bind {Mu32 in VIWord32 [*,*]}
                          ├╴NewRef {MRu32 in VIWord32 [*,*]}
                          │  └╴v3 : u32 in VIWord32 [*,*]

--- a/tests/gold/trickySharing.txt
+++ b/tests/gold/trickySharing.txt
@@ -1,22 +1,22 @@
 Lambda v0 : u32
- └╴Let {u32 in VIWord32 [*,*]}
-    ├╴Add {u32 in VIWord32 [*,*]}
-    │  ├╴Mul {u32 in VIWord32 [*,*]}
-    │  │  ├╴v0 : u32 in VIWord32 [*,*]
-    │  │  └╴3 : u32
-    │  └╴Mul {u32 in VIWord32 [*,*]}
-    │     ├╴v0 : u32 in VIWord32 [*,*]
-    │     └╴5 : u32
-    └╴Lambda v4 : u32
-       └╴Let {u32 in VIWord32 [*,*]}
+ └╴Let
+    ├╴Var v4 : u32 = 
+    │  └╴Add {u32 in VIWord32 [*,*]}
+    │     ├╴Mul {u32 in VIWord32 [*,*]}
+    │     │  ├╴v0 : u32 in VIWord32 [*,*]
+    │     │  └╴3 : u32
+    │     └╴Mul {u32 in VIWord32 [*,*]}
+    │        ├╴v0 : u32 in VIWord32 [*,*]
+    │        └╴5 : u32
+    ├╴Var v5 : u32 = 
+    │  └╴Add {u32 in VIWord32 [*,*]}
+    │     ├╴v4 : u32 in VIWord32 [*,*]
+    │     └╴Mul {u32 in VIWord32 [*,*]}
+    │        ├╴v0 : u32 in VIWord32 [*,*]
+    │        └╴7 : u32
+    └╴In
+       └╴Add {u32 in VIWord32 [*,*]}
           ├╴Add {u32 in VIWord32 [*,*]}
-          │  ├╴v4 : u32 in VIWord32 [*,*]
-          │  └╴Mul {u32 in VIWord32 [*,*]}
-          │     ├╴v0 : u32 in VIWord32 [*,*]
-          │     └╴7 : u32
-          └╴Lambda v5 : u32
-             └╴Add {u32 in VIWord32 [*,*]}
-                ├╴Add {u32 in VIWord32 [*,*]}
-                │  ├╴v5 : u32 in VIWord32 [*,*]
-                │  └╴v4 : u32 in VIWord32 [*,*]
-                └╴v5 : u32 in VIWord32 [*,*]
+          │  ├╴v5 : u32 in VIWord32 [*,*]
+          │  └╴v4 : u32 in VIWord32 [*,*]
+          └╴v5 : u32 in VIWord32 [*,*]


### PR DESCRIPTION
In the AST, let expressions are represented by the 'Let' operator
which takes the RHS and a lambda expression as arguments. Hence
'let x = rhs in e' is represented as 'Let rhs (\x.e)'. This form
is harder to read when inspecting intermediate code and it also
leads to excessive indentation when the body is another let
expression. Hence we instead format a let nest of the form
'Let e1 (\x1. Let e2 (\x2. ... Let en (\xn.e)...))' as
'Let
  x1 = e1
  x2 = e2
  ...
  xn = en
In
  e'
to make it more readable.