### PR TITLE
Add TypeF constraint to SyntacticFeld.

### DIFF
--- a/src/Feldspar/Core/Constructs.hs
+++ b/src/Feldspar/Core/Constructs.hs
@@ -203,12 +203,7 @@ instance Syntactic (Data a)
     desugar = unData
     sugar   = Data
 
-#ifndef INCREMENTAL_CSE
-type SyntacticFeld a = (Syntactic a, Domain a ~ FeldDomain)
-#else
 type SyntacticFeld a = (Syntactic a, Domain a ~ FeldDomain, TypeF (Internal a))
-#endif
-
 
 -- | Specialization of the 'Syntactic' class for the Feldspar domain
 class    (SyntacticFeld a, Type (Internal a)) => Syntax a


### PR DESCRIPTION
The incremental CSE needs the TypeF constraint in manny places,
hence it is included in SyntacticFeld when compiling with
INCREMENTAL_CSE. We will now also need the TypeF constraint in
FromCore (in feldspar-compiler), so we change SyntacticFeld
to always require TypeF.