### PR TITLE
Add local let floating.

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -59,6 +59,7 @@ library
     Feldspar.Core.Middleend.FromTyped
     Feldspar.Core.Middleend.FromTypeUtil
     Feldspar.Core.Middleend.LetSinking
+    Feldspar.Core.Middleend.LocalLetFloating
     Feldspar.Core.Middleend.OptimizeUntyped
     Feldspar.Core.Middleend.PassManager
     Feldspar.Core.Middleend.PushLets

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -25,6 +25,7 @@ import Feldspar.Core.Middleend.LetSinking
 import Feldspar.Core.Middleend.OptimizeUntyped
 import Feldspar.Core.Middleend.PushLets
 import Feldspar.Core.Middleend.Expand
+import Feldspar.Core.Middleend.LocalLetFloating
 import Feldspar.Core.Middleend.UniqueVars
 import Feldspar.Core.Middleend.PassManager
 import qualified Feldspar.Core.UntypedRepresentation as U
@@ -935,6 +936,7 @@ import Data.Typeable (Typeable)
 -- | External module interface. Untype, optimize and unannotate.
 untype :: TypeF a => FeldOpts -> ASTF dom a -> UntypedFeld
 untype opts = cleanUp opts
+            . localLetFloating opts
             . expand
             . pushLets
             . optimize
@@ -944,6 +946,7 @@ untype opts = cleanUp opts
 -- | External module interface.
 untypeDecor :: TypeF a => FeldOpts -> ASTF dom a -> AUntypedFeld ValueInfo
 untypeDecor opts = id
+                 . localLetFloating opts
                  . expand
                  . pushLets
                  . optimize
@@ -1183,6 +1186,7 @@ data FrontendPass
      | FPOptimize
      | FPPushLets
      | FPExpand
+     | FPLocalLetFloating
      | FPUnique
      | FPUnAnnotate
      | FPCreateTasks
@@ -1245,6 +1249,7 @@ frontend ctrl opts = evalPasses 0
                    $ pc FPCreateTasks      (createTasks opts)
                    . pt FPUnAnnotate       unAnnotate
                    . pc FPUnique           uniqueVars
+                   . pc FPLocalLetFloating (localLetFloating opts)
                    . pc FPExpand           expand
                    . pc FPPushLets         pushLets
                    . pc FPOptimize         optimize

--- a/src/Feldspar/Core/Middleend/LocalLetFloating.hs
+++ b/src/Feldspar/Core/Middleend/LocalLetFloating.hs
@@ -1,0 +1,23 @@
+module Feldspar.Core.Middleend.LocalLetFloating (localLetFloating) where
+
+import Feldspar.Core.UntypedRepresentation
+import Feldspar.Core.Interpretation (FeldOpts)
+
+-- | Float let bindings as far up as possible but not out of lambdas
+--   or the branches of conditionals.
+localLetFloating :: FeldOpts -> AUntypedFeld a -> AUntypedFeld a
+localLetFloating opts = mkLets . go
+  where go (AIn r (App Let t [eRhs, AIn r' (Lambda v eBody)]))
+           = let (bsB,eBody1) = go eBody
+                 (bsR,eRhs1) = go eRhs
+                 bsOut = bsR ++ [(v, eRhs1)] ++ bsB
+              in (bsOut, eBody1)
+        go (AIn r (App Condition t [ec, et, ee]))
+           = let (bs,ec1) = go ec
+                 es = [ec1, mkLets $ go et, mkLets $ go ee]
+              in (bs, AIn r $ App Condition t es)
+        go (AIn r (App f t es))
+           = let (bss,es1) = unzip $ map go es
+              in (concat bss, AIn r $ App f t es1)
+        go (AIn r (Lambda v e)) = ([], AIn r $ Lambda v $ mkLets $ go e)
+        go e = ([],e)


### PR DESCRIPTION
Float let bindings outwards as much as possible without floating
out of a lambda or one of the branches of a conditional. The result
is an equivalent expression that is often more readable.