### PR TITLE
Fine-tune movement of bindings and inling decisions.

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -54,6 +54,7 @@ library
     Feldspar.Core.Tuple
     Feldspar.Core.Types
     Feldspar.Core.UntypedRepresentation
+    Feldspar.Core.Middleend.Constructors
     Feldspar.Core.Middleend.CreateTasks
     Feldspar.Core.Middleend.Expand
     Feldspar.Core.Middleend.FromTyped

--- a/src/Feldspar/Core/Middleend/Constructors.hs
+++ b/src/Feldspar/Core/Middleend/Constructors.hs
@@ -1,0 +1,79 @@
+module Feldspar.Core.Middleend.Constructors
+  ( Bag(..)
+  , BindBag
+  , AExpB
+  , RExpB
+  , variable
+  , literal
+  , lambda
+  , app
+  , aIn
+  , mkBinds
+  , toExpr
+  , fromExpr
+  , fromRExpr
+  , unAnnotateB
+  )
+  where
+
+import Feldspar.Core.UntypedRepresentation
+
+-- | Intelligent constructors for placing bindings
+
+data Bag a = Bags [Bag a]
+           | Item a
+           deriving (Eq, Ord, Show)
+
+type BindBag a = Bag [(Var, AUntypedFeld a)]
+
+foldBag :: (a -> b -> b) -> b -> Bag a -> b
+foldBag f u (Bags bs) = foldr (\ b r -> foldBag f r b) u bs
+foldBag f u (Item x) = f x u
+
+appendBag :: Bag a -> Bag a -> Bag a
+appendBag (Bags []) b         = b
+appendBag b         (Bags []) = b
+appendBag l         (Bags rs) = Bags $ l : rs
+
+concatBags :: [Bag a] -> Bag a
+concatBags = foldr appendBag (Bags [])
+
+type AExpB a = (BindBag a, AUntypedFeld a)
+type RExpB a = (BindBag a, RRExp a)
+
+type RRExp a = UntypedFeldF (ATerm a UntypedFeldF)
+
+toExpr :: AExpB a -> AUntypedFeld a
+toExpr (b,e) = foldBag (curry mkLets) e b
+
+fromExpr :: AUntypedFeld a -> AExpB a
+fromExpr e = (Bags [], e)
+
+unAnnotateB :: AExpB a -> RExpB a
+unAnnotateB (b, (AIn _ e)) = (b, e)
+
+fromRExpr :: RRExp a -> RExpB a
+fromRExpr e = (Bags [], e)
+
+variable :: Var -> RExpB a
+variable v = (Bags [], Variable v)
+
+literal :: Lit -> RExpB a
+literal l = (Bags [], Literal l)
+
+lambda :: Var -> AExpB a -> RExpB a
+lambda v eb = (Bags [], Lambda v $ toExpr eb)
+
+app :: Op -> Type -> [AExpB a] -> RExpB a
+app Condition t [(b,ec), et, ee] = (b, App Condition t [ec, toExpr et, toExpr ee])
+app op t es = (concatBags bs, App op t es1)
+  where (bs,es1) = unzip es
+
+aIn :: a -> RExpB a -> AExpB a
+aIn r (b,e) = (b, AIn r e)
+
+mkBinds :: ([(Var, AExpB a)], AExpB a) -> AExpB a
+mkBinds (bs,(b,e)) = (foldr appendBag (appendBag (Item $ zip vs es1) b) bs1, e)
+  where (vs,bes) = unzip bs
+        (bs1,es1) = unzip bes
+

--- a/src/Feldspar/Core/Middleend/OptimizeUntyped.hs
+++ b/src/Feldspar/Core/Middleend/OptimizeUntyped.hs
@@ -142,7 +142,9 @@ simpApp env r op t es = go op t es
          | Just n <- lookup op selectTable
          , App Tup _ es <- examine env eTup
          , n < length es
-         = es !! n
+         , eComp <- es !! n
+         , not $ sharable eComp
+         = eComp
 
         -- Select from a tuple literal
         go op _ [eTup]

--- a/src/Feldspar/Core/Middleend/PushLets.hs
+++ b/src/Feldspar/Core/Middleend/PushLets.hs
@@ -29,46 +29,60 @@
 module Feldspar.Core.Middleend.PushLets (pushLets) where
 
 import Feldspar.Core.UntypedRepresentation
+import Feldspar.Core.Middleend.Constructors
 
 pushLets :: AUntypedFeld a -> AUntypedFeld a
-pushLets = go
-  where go (AIn r (App Let t [rhs, AIn r1 (Lambda v body)])) = push v (go rhs) r1 (go body)
-        go (AIn r (App op t es)) = AIn r $ App op t $ map go es
-        go (AIn r (Lambda v e)) = AIn r $ Lambda v $ go e
-        go e = e
+pushLets = toExpr . go
+  where go (AIn r (App Let t [rhs, AIn r1 (Lambda v body)]))
+           | legalToInline rhs = push v (go rhs) r1 (toExpr $ go body)
+           | otherwise = mkBinds ([(v, go rhs)], go body)
+        go (AIn r (App op t es)) = aIn r $ app op t $ map go es
+        go (AIn r (Lambda v e)) = aIn r $ lambda v $ go e
+        go e = fromExpr e
 
 data OCount = OC {low, high :: Int}
   deriving (Eq, Show)
 
-push :: Var -> AUntypedFeld a -> a -> AUntypedFeld a -> AUntypedFeld a
-push v rhs@(AIn _ eRhs) r = snd . goA False False
-  where goA lo pa (AIn r1 e) = (norm lo n1, AIn r1 $ if ph && not lo then eB else e1)
-           where (n1,e1) = go lo (pa || ph) e
-                 ph = not pa && high n1 > 1
-                 eB = App Let (typeof $ AIn r1 e) [rhs, AIn r $ Lambda v $ AIn r1 e1]
+data DSCount = DS {dynamic :: OCount, static :: Int}
+  deriving (Eq, Show)
 
-        go lo pa e@(Variable u) = if u /= v then (OC 0 0, e)
-                                            else (OC 1 1, if pa then e else eRhs)
-        go lo pa e@(Literal _) = (OC 0 0, e)
-        go lo pa (App Condition t [ec, et, ee]) = (n, App Condition t [ec1, et1, ee1])
+push :: Var -> AExpB a -> a -> AUntypedFeld a -> AExpB a
+push v rhs r = snd . goA False False
+  where goA lo pa (AIn r1 e) = (norm n1, aIn r1 $ if ph then eB else e1)
+           where (n1,e1) = go lo (pa || ph) e
+                 d1 = dynamic n1
+                 ph = not pa && (high d1 > 1 || low d1 > 0 && static n1 > 1)
+                 eB = unAnnotateB $ mkBinds ([(v, rhs)], aIn r1 e1)
+
+        go lo pa e@(Variable u) = if u /= v then (zeroDS, fromRExpr e)
+                                            else (oneDS, if pa then fromRExpr e else unAnnotateB rhs)
+        go lo pa e@(Literal _) = (zeroDS, fromRExpr e)
+        go lo pa (App Condition t [ec, et, ee]) = (n, app Condition t [ec1, et1, ee1])
            where (nc,ec1) = goA False pa ec
                  (nt,et1) = goA False pa et
                  (ne,ee1) = goA False pa ee
-                 n = both nc (oneOf nt ne)
-        go lo pa (App op t es) = (n, App op t es1)
+                 n = liftDS both nc (liftDS oneOf nt ne)
+        go lo pa (App op t es) = (n, app op t es1)
            where (ns,es1) = unzip $ map (goA lo1 pa) es
-                 n = foldr both (OC 0 0) ns
+                 n = foldr (liftDS both) zeroDS ns
                  lo1 = elem op [Parallel, Sequential, EparFor, ForLoop, WhileLoop, For, While]
-        go lo pa e@(Lambda u _) | u == v = (OC 0 0, e)
-        go lo pa (Lambda u e) = (n, Lambda u e1)
+        go lo pa e@(Lambda u _) | u == v = (zeroDS, fromRExpr e)
+        go lo pa (Lambda u e) = (lamDS lo n1, lambda u $ e1)
            where (n1,e1) = goA False pa e
-                 n = if lo then -- oneOf n1 $ OC 0 0
-                                both n1 n1 -- A loop body may be run several times
-                           else n1
+
+lamDS :: Bool -> DSCount -> DSCount
+lamDS lo (DS d s) = if lo then DS (both d d) (s+s) else DS d s -- A loop body may be run several times
+
+zeroDS, oneDS :: DSCount
+zeroDS = DS (OC 0 0) 0
+oneDS = DS (OC 1 1) 1
+
+liftDS :: (OCount -> OCount -> OCount) -> DSCount -> DSCount -> DSCount
+liftDS df l r = DS (dynamic l `df` dynamic r) (static l + static r)
 
 both, oneOf :: OCount -> OCount -> OCount
 both (OC ll hl) (OC lr hr) = OC (ll+lr) (hl+hr)
 oneOf (OC ll hl) (OC lr hr) = OC (min ll lr) (max hl hr)
 
-norm :: Bool -> OCount -> OCount
-norm lo (OC l h) = if lo then OC l h else OC (min 1 l) (min 1 h)
+norm :: DSCount -> DSCount
+norm ds@(DS (OC l h) s) = DS (OC (min 1 l) (min 1 h)) s

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -49,6 +49,7 @@ module Feldspar.Core.UntypedRepresentation (
   , sharable
   , legalToShare
   , goodToShare
+  , legalToInline
   , Rename(..)
   , rename
   , newVar
@@ -747,6 +748,10 @@ goodToShare (AIn _ (Literal l))
   | LTup (_:_)     <- l = True
 goodToShare (AIn _ (App _ _ _)) = True
 goodToShare _                   = False
+
+legalToInline :: AUntypedFeld a -> Bool
+legalToInline (AIn _ (App op _ _)) = op `notElem` [MkFuture, ParFork, NoInline]
+legalToInline _                    = True
 
 type Rename a = State VarId a
 

--- a/tests/gold/example9.txt
+++ b/tests/gold/example9.txt
@@ -1,15 +1,17 @@
 Lambda v0 : i32
- └╴Condition {i32 in VIInt32 [*,*]}
-    ├╴LTH {bool in VIBool [0,1]}
-    │  ├╴v0 : i32 in VIInt32 [*,*]
-    │  └╴5 : i32
-    ├╴Mul {i32 in VIInt32 [*,*]}
-    │  ├╴3 : i32
+ └╴Let
+    ├╴Var v2 : i32 = 
     │  └╴Add {i32 in VIInt32 [*,*]}
     │     ├╴v0 : i32 in VIInt32 [*,*]
     │     └╴20 : i32
-    └╴Mul {i32 in VIInt32 [*,*]}
-       ├╴30 : i32
-       └╴Add {i32 in VIInt32 [*,*]}
-          ├╴v0 : i32 in VIInt32 [*,*]
-          └╴20 : i32
+    └╴In
+       └╴Condition {i32 in VIInt32 [*,*]}
+          ├╴LTH {bool in VIBool [0,1]}
+          │  ├╴v0 : i32 in VIInt32 [*,*]
+          │  └╴5 : i32
+          ├╴Mul {i32 in VIInt32 [*,*]}
+          │  ├╴3 : i32
+          │  └╴v2 : i32 in VIInt32 [*,*]
+          └╴Mul {i32 in VIInt32 [*,*]}
+             ├╴30 : i32
+             └╴v2 : i32 in VIInt32 [*,*]

--- a/tests/gold/topLevelConsts.txt
+++ b/tests/gold/topLevelConsts.txt
@@ -1,16 +1,18 @@
 Lambda v2 : u32
  └╴Lambda v6 : u32
-    └╴Condition {u32 in VIWord32 [*,*]}
-       ├╴LTH {bool in VIBool [0,1]}
-       │  ├╴v6 : u32 in VIWord32 [*,*]
-       │  └╴5 : u32
-       ├╴GetIx {u32 in VIWord32 [*,*]}
-       │  ├╴[2,3,4,5,6] : au32
+    └╴Let
+       ├╴Var v3 : u32 = 
        │  └╴Add {u32 in VIWord32 [*,*]}
        │     ├╴v2 : u32 in VIWord32 [*,*]
        │     └╴5 : u32
-       └╴GetIx {u32 in VIWord32 [*,*]}
-          ├╴[1,2,3,4,5] : au32
-          └╴Add {u32 in VIWord32 [*,*]}
-             ├╴v2 : u32 in VIWord32 [*,*]
-             └╴5 : u32
+       └╴In
+          └╴Condition {u32 in VIWord32 [*,*]}
+             ├╴LTH {bool in VIBool [0,1]}
+             │  ├╴v6 : u32 in VIWord32 [*,*]
+             │  └╴5 : u32
+             ├╴GetIx {u32 in VIWord32 [*,*]}
+             │  ├╴[2,3,4,5,6] : au32
+             │  └╴v3 : u32 in VIWord32 [*,*]
+             └╴GetIx {u32 in VIWord32 [*,*]}
+                ├╴[1,2,3,4,5] : au32
+                └╴v3 : u32 in VIWord32 [*,*]


### PR DESCRIPTION
This commit fine-tunes the movement of bindings by the PushLet
pass so that
- a binding is left as soon as it is known to be needed (strict),
- unless there is only one static occurrence of the variable and
  that occurrence is not inside a loop body.
It also does not move bindings whose rhs is a task (Future,
ParFork) or should not be inlined (NoInline).

In OptimizeUntyped, reductions of selectors is inhibited if the
corresponding tuple components are sharable (that is, nonatomic).