### PR TITLE
Add size info to the typed abstract syntax.

### DIFF
--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -967,7 +967,7 @@ renameExp :: AUntypedFeld a -> AUntypedFeld a
 renameExp e = evalState (rename e) 0
 
 toAnno :: TypeF a => R.Info a -> ValueInfo
-toAnno = topInfo . toType . asInfo
+toAnno info = toValueInfo (asInfo info) (R.infoSize info)
 
 asInfo :: TypeF a => R.Info a -> TypeRep a
 asInfo _ = typeRepF

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -85,7 +85,7 @@ resugar = sugar . desugar
 --   in the expression part of the CExpr.
 data ASTF (d :: * -> *) a = ASTF (CExpr a) Int
 
-alphaEq :: Typeable a => ASTF d a -> ASTF d a -> Bool
+alphaEq :: T.Type a => ASTF d a -> ASTF d a -> Bool
 alphaEq (ASTF (ml,el) _) (ASTF (mr,er) _) = M.toList ml == M.toList mr && el == er
 
 -- | Convert an ASTF to an expression

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -1301,7 +1301,7 @@ typeRepByProxy :: Type a => Proxy a -> TypeRep a
 typeRepByProxy _ = typeRep
 
 -- | Extend the class Type to higher order types
-class Typeable a => TypeF a where
+class (Typeable a, Lattice (Size a)) => TypeF a where
   typeRepF :: TypeRep a
 
 instance {-# OVERLAPPING #-} (TypeF a, TypeF b) => TypeF (a -> b) where

--- a/tests/gold/monadicSharing.txt
+++ b/tests/gold/monadicSharing.txt
@@ -1,28 +1,28 @@
 Lambda v0 : u32
- └╴Run {u32 in VIWord32 [*,*]}
-    └╴Bind {Mu32 in VIWord32 [*,*]}
-       ├╴NewRef {MRu32 in VIWord32 [*,*]}
-       │  └╴v0 : u32 in VIWord32 [*,*]
+ └╴Run {u32 in VIWordN [*,*]}
+    └╴Bind {Mu32 in VIWordN [*,*]}
+       ├╴NewRef {MRu32 in VIWordN [*,*]}
+       │  └╴v0 : u32 in VIWordN [*,*]
        └╴Lambda v1 : Ru32
-          └╴Bind {Mu32 in VIWord32 [*,*]}
-             ├╴GetRef {Mu32 in VIWord32 [*,*]}
-             │  └╴v1 : Ru32 in VIWord32 [*,*]
+          └╴Bind {Mu32 in VIWordN [*,*]}
+             ├╴GetRef {Mu32 in VIWordN [*,*]}
+             │  └╴v1 : Ru32 in VIWordN [*,*]
              └╴Lambda v2 : u32
                 └╴Let
                    ├╴Var v3 : u32 = 
-                   │  └╴Add {u32 in VIWord32 [*,*]}
-                   │     ├╴v2 : u32 in VIWord32 [*,*]
+                   │  └╴Add {u32 in VIWordN [*,*]}
+                   │     ├╴v2 : u32 in VIWordN [*,*]
                    │     └╴3 : u32
                    └╴In
-                      └╴Bind {Mu32 in VIWord32 [*,*]}
-                         ├╴NewRef {MRu32 in VIWord32 [*,*]}
-                         │  └╴v3 : u32 in VIWord32 [*,*]
+                      └╴Bind {Mu32 in VIWordN [*,*]}
+                         ├╴NewRef {MRu32 in VIWordN [*,*]}
+                         │  └╴v3 : u32 in VIWordN [*,*]
                          └╴Lambda v4 : Ru32
-                            └╴Bind {Mu32 in VIWord32 [*,*]}
-                               ├╴GetRef {Mu32 in VIWord32 [*,*]}
-                               │  └╴v4 : Ru32 in VIWord32 [*,*]
+                            └╴Bind {Mu32 in VIWordN [*,*]}
+                               ├╴GetRef {Mu32 in VIWordN [*,*]}
+                               │  └╴v4 : Ru32 in VIWordN [*,*]
                                └╴Lambda v5 : u32
-                                  └╴Return {Mu32 in VIWord32 [*,*]}
-                                     └╴Add {u32 in VIWord32 [*,*]}
-                                        ├╴v5 : u32 in VIWord32 [*,*]
-                                        └╴v3 : u32 in VIWord32 [*,*]
+                                  └╴Return {Mu32 in VIWordN [*,*]}
+                                     └╴Add {u32 in VIWordN [*,*]}
+                                        ├╴v5 : u32 in VIWordN [*,*]
+                                        └╴v3 : u32 in VIWordN [*,*]

--- a/tests/gold/topLevelConsts.txt
+++ b/tests/gold/topLevelConsts.txt
@@ -2,17 +2,17 @@ Lambda v2 : u32
  └╴Lambda v6 : u32
     └╴Let
        ├╴Var v3 : u32 = 
-       │  └╴Add {u32 in VIWord32 [*,*]}
-       │     ├╴v2 : u32 in VIWord32 [*,*]
+       │  └╴Add {u32 in VIWordN [*,*]}
+       │     ├╴v2 : u32 in VIWordN [*,*]
        │     └╴5 : u32
        └╴In
-          └╴Condition {u32 in VIWord32 [*,*]}
+          └╴Condition {u32 in VIWordN [*,*]}
              ├╴LTH {bool in VIBool [0,1]}
-             │  ├╴v6 : u32 in VIWord32 [*,*]
+             │  ├╴v6 : u32 in VIWordN [*,*]
              │  └╴5 : u32
-             ├╴GetIx {u32 in VIWord32 [*,*]}
+             ├╴GetIx {u32 in VIWordN [*,*]}
              │  ├╴[2,3,4,5,6] : au32
-             │  └╴v3 : u32 in VIWord32 [*,*]
-             └╴GetIx {u32 in VIWord32 [*,*]}
+             │  └╴v3 : u32 in VIWordN [*,*]
+             └╴GetIx {u32 in VIWordN [*,*]}
                 ├╴[1,2,3,4,5] : au32
-                └╴v3 : u32 in VIWord32 [*,*]
+                └╴v3 : u32 in VIWordN [*,*]

--- a/tests/gold/trickySharing.txt
+++ b/tests/gold/trickySharing.txt
@@ -1,22 +1,22 @@
 Lambda v0 : u32
  └╴Let
     ├╴Var v4 : u32 = 
-    │  └╴Add {u32 in VIWord32 [*,*]}
-    │     ├╴Mul {u32 in VIWord32 [*,*]}
-    │     │  ├╴v0 : u32 in VIWord32 [*,*]
+    │  └╴Add {u32 in VIWordN [*,*]}
+    │     ├╴Mul {u32 in VIWordN [*,*]}
+    │     │  ├╴v0 : u32 in VIWordN [*,*]
     │     │  └╴3 : u32
-    │     └╴Mul {u32 in VIWord32 [*,*]}
-    │        ├╴v0 : u32 in VIWord32 [*,*]
+    │     └╴Mul {u32 in VIWordN [*,*]}
+    │        ├╴v0 : u32 in VIWordN [*,*]
     │        └╴5 : u32
     ├╴Var v5 : u32 = 
-    │  └╴Add {u32 in VIWord32 [*,*]}
-    │     ├╴v4 : u32 in VIWord32 [*,*]
-    │     └╴Mul {u32 in VIWord32 [*,*]}
-    │        ├╴v0 : u32 in VIWord32 [*,*]
+    │  └╴Add {u32 in VIWordN [*,*]}
+    │     ├╴v4 : u32 in VIWordN [*,*]
+    │     └╴Mul {u32 in VIWordN [*,*]}
+    │        ├╴v0 : u32 in VIWordN [*,*]
     │        └╴7 : u32
     └╴In
-       └╴Add {u32 in VIWord32 [*,*]}
-          ├╴Add {u32 in VIWord32 [*,*]}
-          │  ├╴v5 : u32 in VIWord32 [*,*]
-          │  └╴v4 : u32 in VIWord32 [*,*]
-          └╴v5 : u32 in VIWord32 [*,*]
+       └╴Add {u32 in VIWordN [*,*]}
+          ├╴Add {u32 in VIWordN [*,*]}
+          │  ├╴v5 : u32 in VIWordN [*,*]
+          │  └╴v4 : u32 in VIWordN [*,*]
+          └╴v5 : u32 in VIWordN [*,*]


### PR DESCRIPTION
This patch adds size (range) information to the typed variant
of the abstraxt syntax by redifining the Info type in Representation.
The size information is initialized to top when reifying the
program; size propagation will be the task of a separate pass.

The changes introduced in Representation leads to further
changes, mainly to strengthen contexts to enable the use
of operations from the Lattice and Eq classes on expressions
now also containing size information.

Equality is defined to require the size information to match. This
might lead to hash collisions in the CSE, but it is unlikely as the
size information is initialized to top for the corresponding type,
and the types are used when computing the hash values.