### PR TITLE
Show size info when pretty printing the typed representation.

### DIFF
--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -338,7 +338,7 @@ instance PrettyInfo a => Pretty (AUntypedFeld a) where
   pretty = prettyExp f
      where f t x = " | " ++ prettyInfo t x
 
-instance Pretty (AExpr a) where
+instance TypeF a => Pretty (AExpr a) where
   pretty = show
 
 instance TypeF a => Pretty (ASTF dom a) where

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -1301,7 +1301,7 @@ typeRepByProxy :: Type a => Proxy a -> TypeRep a
 typeRepByProxy _ = typeRep
 
 -- | Extend the class Type to higher order types
-class (Typeable a, Lattice (Size a)) => TypeF a where
+class (Typeable a, Show (Size a), Lattice (Size a)) => TypeF a where
   typeRepF :: TypeRep a
 
 instance {-# OVERLAPPING #-} (TypeF a, TypeF b) => TypeF (a -> b) where


### PR DESCRIPTION
The main change is in the Representation module, in the function
showAExpr. This required 'Show (Size a)' for polymorphic types
in the AST, which necessitated the rest of the changes, in
particular adding 'Show (Size a)' to the supercalss context of
the TypeF class.