### PR TITLE
Add nested tuples

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -40,6 +40,7 @@ library
     Feldspar.Core.AdjustBindings
     Feldspar.Core.Eval
     Feldspar.Core.Language
+    Feldspar.Core.NestedTuples
     Feldspar.Core.Reify
     Feldspar.Core.Render
     Feldspar.Core.Representation

--- a/src/Feldspar/Core/NestedTuples.hs
+++ b/src/Feldspar/Core/NestedTuples.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+module Feldspar.Core.NestedTuples where
+
+import Data.Typeable
+
+-- | Data and type constructor for nested tuples
+infixr 5 :*
+
+-- | Types for nonempty and empty nested tuples
+data a :* b
+data TNil
+
+-- | Raw tuples which can only be used in restricted ways
+data RTuple a where
+  (:*) :: a -> RTuple b -> RTuple (a :* b)
+  TNil :: RTuple TNil
+
+deriving instance Typeable RTuple -- Not necessary with newer versions of GHC
+
+-- | Eq and Show instances
+
+instance (Eq a, Eq (RTuple b)) => Eq (RTuple (a :* b)) where
+  (a1 :* b1) == (a2 :* b2) = a1 == a2 && b1 == b2
+
+instance Eq (RTuple TNil) where
+  TNil == TNil = True
+
+instance (Show a, Show (RTuple b)) => Show (RTuple (a :* b)) where
+  show (x :* xs) = show x ++ " :* " ++ show xs
+
+instance Show (RTuple TNil) where
+  show TNil = "TNil"
+
+-- | Wrap a raw tuple to make it a first class object
+
+newtype Tuple a = Tuple {unTup :: RTuple a}
+
+deriving instance Eq (Tuple TNil)
+deriving instance (Eq a, Eq (RTuple b)) => Eq (Tuple (a :* b))
+
+instance Show (RTuple a) => Show (Tuple a) where
+  show t = "<" ++ show (unTup t) ++ ">"
+
+tuple :: RTuple a -> Tuple a
+tuple t = Tuple t
+
+-- | Selecting components of a tuple
+
+-- | Designating a tuple component
+newtype Skip a = Skip {unSkip :: a}
+data First = First
+
+-- | Type recursive selection based on designator
+class Select s t where
+  type SelResult s t
+  selR :: s -> RTuple t -> SelResult s t
+
+instance Select a t => Select (Skip a) (b :* t) where
+  type SelResult (Skip a) (b :* t) = SelResult a t
+  selR s (_ :* y) = selR (unSkip s) y
+
+instance Select First (b :* t) where
+  type SelResult First (b :* t) = b
+  selR _ (x :* _) = x
+
+-- | Exposed select interface which extracts the raw tuple
+sel :: Select s t => s -> Tuple t -> SelResult s t
+sel s (Tuple t) = selR s t

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -289,6 +289,9 @@ instance Hashable (T.TypeRep a) where
   hash (T.MArrType t)     = hashInt 26 # t
   hash (T.ParType t)      = hashInt 27 # t
   hash (T.ElementsType t) = hashInt 28 # t
+  hash (T.ConsType a b)   = hashInt 31 # a # b
+  hash  T.NilType         = hashInt 32
+  hash (T.TupleType t)    = hashInt 33 # t
   hash (T.IVarType t)     = hashInt 29 # t
   hash (T.FValType t)     = hashInt 30 # t
 

--- a/src/Feldspar/Core/Semantics.hs
+++ b/src/Feldspar/Core/Semantics.hs
@@ -50,6 +50,7 @@ import Data.Typeable
 import Feldspar.Core.Interpretation
 import Feldspar.Core.Representation
 import Feldspar.Core.Tuple
+import Feldspar.Core.NestedTuples
 import Feldspar.Core.Types
 import Feldspar.Lattice
 import Feldspar.Range
@@ -211,6 +212,13 @@ semantics ModRef = Sem "modRef" (\r f -> readIORef r >>= writeIORef r . f)
 -- Feldspar.Core.Constructs.MutableToPure
 semantics RunMutableArray = Sem "runMutableArray" runMutableArrayEval
 semantics WithArray       = Sem "withArray"       withArrayEval
+-- Nested tuples
+semantics Cons  = Sem "cons"  (\ x y -> x :* y)
+semantics Nil   = Sem "nil"   TNil
+semantics Car   = Sem "car"   (\ (x :* _) -> x)
+semantics Cdr   = Sem "cdr"   (\ (_ :* y) -> y)
+semantics Tup   = Sem "tup"   Tuple
+semantics UnTup = Sem "untup" unTup
 -- Feldspar.Core.Constructs.NoInline
 semantics NoInline  = Sem "NoInline" id
 -- Feldspar.Core.Constructs.Num

--- a/src/Feldspar/Core/SizeProp.hs
+++ b/src/Feldspar/Core/SizeProp.hs
@@ -213,6 +213,14 @@ spApp vm (Operator          GetRef :@ a)           = spApp1 vm          GetRef t
 spApp vm (Operator          SetRef :@ a :@ b)      = spApp2 vm          SetRef topF2 a b
 spApp vm (Operator          ModRef :@ a :@ b)      = spApp2 vm          ModRef topF2 a b
 
+-- | Nested tuples
+spApp vm (Operator            Cons :@ a :@ b)      = spApp2 vm            Cons (,) a b
+spApp vm (Operator             Nil)                = spApp0 vm             Nil top
+spApp vm (Operator             Car :@ a)           = spApp1 vm             Car fst a
+spApp vm (Operator             Cdr :@ a)           = spApp1 vm             Cdr snd a
+spApp vm (Operator             Tup :@ a)           = spApp1 vm             Tup id  a
+spApp vm (Operator           UnTup :@ a)           = spApp1 vm           UnTup id  a
+
 -- | NoInline
 spApp vm (Operator        NoInline :@ a)           = spApp1 vm        NoInline topF1 a -- Could we not have 'id'?
 

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -501,6 +501,8 @@ data Op =
    | Sel13
    | Sel14
    | Sel15
+   | SelN Int
+   | DropN Int
    -- Common nodes
    | Call Fork String
    deriving (Eq, Show)


### PR DESCRIPTION
This commit adds nested tuples to Feldspar. This allows Feldspar programs
to use tuples of arbitrary length, though not through the use of Haskell
tuple syntax. It is also possible to write for instance length independent
zip functions. Nested tuples are translated to the existing untyped tuples
which are already arbitrary length.

The existing support for tuples of length up to 15 is left as-is, so
using tuple syntax (,,,) yields the old tuples.