### PR TITLE
Remove domain type parameter from ASTF.

### DIFF
--- a/src/Feldspar/BitVector.hs
+++ b/src/Feldspar/BitVector.hs
@@ -86,7 +86,6 @@ type instance CollSize  (BitVector w) = Data Length
 
 instance (Unit a) => Syntactic (BitVector a)
   where
-    type Domain (BitVector a)   = FeldDomain
     type Internal (BitVector a) = [a]
     desugar = desugar . freezeBitVector
     sugar   = unfreezeBitVector . sugar

--- a/src/Feldspar/Core/Constructs.hs
+++ b/src/Feldspar/Core/Constructs.hs
@@ -47,30 +47,22 @@ import Feldspar.Core.Types
 import Feldspar.Core.Interpretation
 
 --------------------------------------------------------------------------------
--- * Domain
---------------------------------------------------------------------------------
-
-data FeldDomain a = FeldDomain
-data FeldDom a = FeldDom
-
---------------------------------------------------------------------------------
 -- * Front end
 --------------------------------------------------------------------------------
 
-newtype Data a = Data { unData :: ASTF FeldDomain a }
+newtype Data a = Data { unData :: ASTF a }
 
 deriving instance Typeable Data
 
 instance Syntactic (Data a)
   where
-    type Domain (Data a)   = FeldDomain
     type Internal (Data a) = a
     desugar = unData
     sugar   = Data
 
-type SyntacticFeld a = (Syntactic a, Domain a ~ FeldDomain, TypeF (Internal a))
+type SyntacticFeld a = (Syntactic a, TypeF (Internal a))
 
--- | Specialization of the 'Syntactic' class for the Feldspar domain
+-- | Specialization of the 'Syntactic' class for first class values (eg not functions)
 class    (SyntacticFeld a, Type (Internal a)) => Syntax a
 instance (SyntacticFeld a, Type (Internal a)) => Syntax a
   -- It would be possible to let 'Syntax' be an alias instead of giving separate
@@ -83,7 +75,7 @@ instance (SyntacticFeld a, Type (Internal a)) => Syntax a
   -- The type error is not very readable now either, but at least it fits on the
   -- screen.
 
-reifyF :: SyntacticFeld a => a -> ASTF FeldDomain (Internal a)
+reifyF :: SyntacticFeld a => a -> ASTF (Internal a)
 reifyF = desugar
 
 instance Type a => Eq (Data a)

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -47,7 +47,6 @@ module Feldspar.Core.Frontend
     , Syntactic
     , Internal
 
-    , FeldDomain
     , Data
     , SyntacticFeld
     , Syntax
@@ -116,31 +115,27 @@ import Feldspar.Core.UntypedRepresentation (VarId, stringTree)
 import Feldspar.Core.Constructs
 import Feldspar.Core.Language                  as Frontend
 
-data Info = Info
-data Decor a (c :: * -> *) d = Decor
 reifyFeldM :: (SyntacticFeld a, MonadState VarId m)
     => FeldOpts
     -> BitWidth n
     -> a
-    -> m (ASTF (Decor Info FeldDom) (Internal a))
-reifyFeldM opts n prog = return $ ut $ reifyFeld opts n prog
+    -> m (ASTF (Internal a))
+reifyFeldM opts n prog = return $ reifyFeld opts n prog
 
 
 reifyFeld :: Syntactic a
           => FeldOpts
           -> BitWidth n
           -> a
-          -> ASTF (Domain a) (Internal a)
+          -> ASTF (Internal a)
 reifyFeld _ _ x = Syntactic.desugar x
 
 reifyFeldUnOpt :: Syntactic a
                 => FeldOpts
                 -> BitWidth n
                 -> a
-                -> ASTF (Domain a) (Internal a)
+                -> ASTF (Internal a)
 reifyFeldUnOpt = reifyFeld
-
-instance StringTree FeldDomain where
 
 showExpr :: SyntacticFeld a => a -> String
 showExpr = render . reifyFeld defaultFeldOpts N32

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -58,7 +58,6 @@ import qualified Feldspar.Core.UntypedRepresentation as U
 import Feldspar.Core.Reify (ASTF(..), unASTF)
 import Feldspar.Core.Types (TypeRep(..), typeRep, defaultSize, TypeF(..))
 import qualified Feldspar.Core.Types as T
-import Feldspar.Core.Constructs (FeldDomain)
 import Feldspar.Core.UntypedRepresentation as U
 import Feldspar.ValueInfo
 import qualified Feldspar.Core.Representation as R
@@ -69,7 +68,7 @@ import Feldspar.Core.SizeProp
 import Feldspar.Core.AdjustBindings
 
 -- | External module interface. Untype, optimize and unannotate.
-untype :: TypeF a => FeldOpts -> ASTF dom a -> UntypedFeld
+untype :: TypeF a => FeldOpts -> ASTF a -> UntypedFeld
 untype opts = cleanUp opts
             . pushLets
             . optimize
@@ -77,7 +76,7 @@ untype opts = cleanUp opts
             . justUntype opts
 
 -- | External module interface.
-untypeDecor :: TypeF a => FeldOpts -> ASTF dom a -> AUntypedFeld ValueInfo
+untypeDecor :: TypeF a => FeldOpts -> ASTF a -> AUntypedFeld ValueInfo
 untypeDecor opts = id
                  . pushLets
                  . optimize
@@ -85,12 +84,12 @@ untypeDecor opts = id
                  . justUntype opts
 
 -- | External module interface.
-untypeUnOpt :: TypeF a => FeldOpts -> ASTF dom a -> UntypedFeld
+untypeUnOpt :: TypeF a => FeldOpts -> ASTF a -> UntypedFeld
 untypeUnOpt opts = cleanUp opts
                  . justUntype opts
 
 -- | Only do the conversion to AUntypedFeld ValueInfo
-justUntype :: TypeF a => FeldOpts -> ASTF dom a -> AUntypedFeld ValueInfo
+justUntype :: TypeF a => FeldOpts -> ASTF a -> AUntypedFeld ValueInfo
 justUntype opts = renameExp . toU . sizeProp . adjustBindings . unASTF opts
 
 -- | Prepare the code for fromCore
@@ -353,18 +352,15 @@ instance PrettyInfo a => Pretty (AUntypedFeld a) where
 instance TypeF a => Pretty (AExpr a) where
   pretty = show
 
-instance TypeF a => Pretty (ASTF dom a) where
+instance TypeF a => Pretty (ASTF a) where
   pretty = pretty . unASTF ()
 
 -- | Untype version to use with the new CSE
 untypeProgOpt :: TypeF a => FeldOpts -> AExpr a -> AUntypedFeld ValueInfo
 untypeProgOpt opts = toU
 
--- | Domain synonym to use with new CSE
-type FEDom = FeldDomain
-
 -- | Front-end driver
-frontend :: TypeF a => PassCtrl FrontendPass -> FeldOpts -> ASTF FEDom a -> ([String], Maybe UntypedFeld)
+frontend :: TypeF a => PassCtrl FrontendPass -> FeldOpts -> ASTF a -> ([String], Maybe UntypedFeld)
 frontend ctrl opts = evalPasses 0
                    $ pc FPCreateTasks      (createTasks opts)
                    . pt FPUnAnnotate       unAnnotate

--- a/src/Feldspar/Core/Render.hs
+++ b/src/Feldspar/Core/Render.hs
@@ -55,7 +55,7 @@ import Feldspar.Core.Middleend.FromTyped (untypeUnOpt, untypeDecor)
 import Feldspar.Core.Interpretation (defaultFeldOpts)
 import Feldspar.ValueInfo (ValueInfo)
 
-stringTreeASTF :: TypeF a => ASTF d a -> Tree String
+stringTreeASTF :: TypeF a => ASTF a -> Tree String
 stringTreeASTF = U.stringTree . untypeUnOpt defaultFeldOpts
 
 {-
@@ -69,24 +69,24 @@ class StringTree (a :: * -> *) where
 -- Copied from Langage.Syntactic.Interpretation.Render
 
 -- | Show a syntax tree using ASCII art
-showAST :: (StringTree dom, TypeF a) => ASTF dom a -> String
+showAST :: TypeF a => ASTF a -> String
 showAST = showTree . stringTreeASTF
 {-# INLINABLE showAST #-}
 
 -- | Print a syntax tree using ASCII art
-drawAST :: (StringTree dom, TypeF a) => ASTF dom a -> IO ()
+drawAST :: TypeF a => ASTF a -> IO ()
 drawAST = putStrLn . showAST
 {-# INLINABLE drawAST #-}
 
-writeHtmlAST :: (StringTree sym, TypeF a) => FilePath -> ASTF sym a -> IO ()
+writeHtmlAST :: TypeF a => FilePath -> ASTF a -> IO ()
 writeHtmlAST file = writeHtmlTree Nothing file
                   . fmap (\n -> NodeInfo InitiallyExpanded n "")
                   . stringTreeASTF
 {-# INLINABLE writeHtmlAST #-}
 
-showDecorWith :: (StringTree d, TypeF a) => (ValueInfo -> String) -> ASTF d a -> String
+showDecorWith :: TypeF a => (ValueInfo -> String) -> ASTF a -> String
 showDecorWith f = showTree . stringTreeExp g . untypeDecor defaultFeldOpts
   where g x = " in " ++ f x
 
-drawDecorWith :: (StringTree d, TypeF a) => (ValueInfo -> String) -> ASTF d a -> IO ()
+drawDecorWith :: TypeF a => (ValueInfo -> String) -> ASTF a -> IO ()
 drawDecorWith f = putStrLn . showDecorWith f

--- a/src/Feldspar/FixedPoint.hs
+++ b/src/Feldspar/FixedPoint.hs
@@ -138,7 +138,6 @@ fixfromRational inp = Fix e m
       e = negate $ value fracPartWith
 
 instance (Type a) => Syntactic (Fix a) where
-  type Domain (Fix a)   = FeldDomain
   type Internal (Fix a) = (IntN, a)
   desugar = desugar . freezeFix
   sugar   = unfreezeFix . sugar

--- a/src/Feldspar/Option.hs
+++ b/src/Feldspar/Option.hs
@@ -51,7 +51,6 @@ data Option a = Option { isSome :: Data Bool, fromSome :: a }
 
 instance Syntax a => Syntactic (Option a)
   where
-    type Domain (Option a)   = FeldDomain
     type Internal (Option a) = (Bool, Internal a)
     desugar = desugar . desugarOption . fmap resugar
     sugar   = fmap resugar . sugarOption . sugar

--- a/src/Feldspar/Repa.hs
+++ b/src/Feldspar/Repa.hs
@@ -150,7 +150,6 @@ type DVector sh a = Vector sh (Data a)
 
 instance (Shape sh, Syntax a) => Syntactic (Vector sh a)
   where
-    type Domain (Vector sh a)   = FeldDomain
     type Internal (Vector sh a) = ([Length],[Internal a])
     desugar = desugar . freezeVector . map resugar
     sugar   = map resugar . thawVector . sugar

--- a/src/Feldspar/SimpleVector/Internal.hs
+++ b/src/Feldspar/SimpleVector/Internal.hs
@@ -78,7 +78,6 @@ type Vector2 a = Vector (Vector (Data a))
 
 instance (Syntax a, Hashable (Internal a)) => Syntactic (Vector a)
   where
-    type Domain (Vector a)   = FeldDomain
     type Internal (Vector a) = [Internal a]
     desugar = desugar . freezeVector . map resugar
     sugar   = map resugar . thawVector . sugar

--- a/src/Feldspar/SimpleVector/Push.hs
+++ b/src/Feldspar/SimpleVector/Push.hs
@@ -49,7 +49,6 @@ type PushVector1 a = PushVector (Data a)
 
 instance Syntax a => Syntactic (PushVector a)
   where
-    type Domain (PushVector a)   = FeldDomain
     type Internal (PushVector a) = [Internal a]
     desugar = desugar . freezePush
     sugar   = thawPush . sugar

--- a/src/Feldspar/Vector.hs
+++ b/src/Feldspar/Vector.hs
@@ -180,7 +180,6 @@ type family InternalShape sh a where
 
 instance (Syntax a, Shapely sh) => Syntactic (Pull sh a)
   where
-    type Domain (Pull sh a) = FeldDomain
     type Internal (Pull sh a) = InternalShape sh a
 
     desugar v@(Pull _ sh) = case sh of
@@ -1261,7 +1260,6 @@ thawPush1 = toPush . thawPull1
 
 instance (Syntax a, Shapely sh) => Syntactic (Push sh a)
   where
-    type Domain (Push sh a) = FeldDomain
     type Internal (Push sh a) = InternalShape sh a
 
     desugar v@(Push _ sh) = case sh of
@@ -1354,7 +1352,6 @@ instance Storable (Push sh) where
   store vec@(Push f sh) = Manifest (save $ fromPush (fmap F.desugar vec)) sh
 
 instance (Syntax a, Shapely sh) => Syntactic (Manifest sh a) where
-  type Domain   (Manifest sh a) = FeldDomain
   type Internal (Manifest sh a) = InternalShape sh a
   desugar v@(Manifest _ sh) = case sh of
       Z           -> desugar $ fromZero v


### PR DESCRIPTION
The old ASTF type is parameterized on a domain, but the new CSE does
not need that parameterization. It was however left as a phantom type
parameter, which is what we now remove. This allows us to remove also
remove the corresponding parameterization from the Syntactic class.