### PR TITLE
Add SIMD vector (:#) to Type

### DIFF
--- a/src/Feldspar/Core/Middleend/FromTypeUtil.hs
+++ b/src/Feldspar/Core/Middleend/FromTypeUtil.hs
@@ -34,7 +34,8 @@ import Data.Complex
 
 import Feldspar.Core.Types
 import Feldspar.Core.UntypedRepresentation hiding ( Lambda, UntypedFeldF(..)
-                                                  , Size, Type(..), Signedness
+                                                  , Size, ScalarType(..)
+                                                  , Type(..), Signedness
                                                   , Op(..)
                                                   )
 import qualified Feldspar.Core.UntypedRepresentation as Ut
@@ -43,11 +44,11 @@ import Feldspar.Range
 
 untypeType :: TypeRep a -> Size a -> Ut.Type
 untypeType UnitType _               = Ut.TupType []
-untypeType BoolType _               = Ut.BoolType
-untypeType (IntType s n) _          = Ut.IntType (convSign s) (convSize n)
-untypeType FloatType _              = Ut.FloatType
-untypeType DoubleType _             = Ut.DoubleType
-untypeType (ComplexType t) _        = Ut.ComplexType (untypeType t (defaultSize t))
+untypeType BoolType _               = 1 Ut.:# Ut.BoolType
+untypeType (IntType s n) _          = 1 Ut.:# (Ut.IntType (convSign s) (convSize n))
+untypeType FloatType _              = 1 Ut.:# Ut.FloatType
+untypeType DoubleType _             = 1 Ut.:# Ut.DoubleType
+untypeType (ComplexType t) _        = 1 Ut.:# (Ut.ComplexType (untypeType t (defaultSize t)))
 untypeType (Tup2Type a b) (sa,sb)
   = Ut.TupType [untypeType a sa, untypeType b sb]
 untypeType (Tup3Type a b c) (sa,sb,sc)

--- a/tests/gold/example9.txt
+++ b/tests/gold/example9.txt
@@ -1,17 +1,17 @@
-Lambda v0 : i32
+Lambda v0 : 1xi32
  └╴Let
-    ├╴Var v2 : i32 = 
-    │  └╴Add {i32 in VIInt32 [*,*]}
-    │     ├╴v0 : i32 in VIInt32 [*,*]
-    │     └╴20 : i32
+    ├╴Var v2 : 1xi32 = 
+    │  └╴Add {1xi32 in VIInt32 [*,*]}
+    │     ├╴v0 : 1xi32 in VIInt32 [*,*]
+    │     └╴20 : 1xi32
     └╴In
-       └╴Condition {i32 in VIInt32 [*,*]}
-          ├╴LTH {bool in VIBool [0,1]}
-          │  ├╴v0 : i32 in VIInt32 [*,*]
-          │  └╴5 : i32
-          ├╴Mul {i32 in VIInt32 [*,*]}
-          │  ├╴3 : i32
-          │  └╴v2 : i32 in VIInt32 [*,*]
-          └╴Mul {i32 in VIInt32 [*,*]}
-             ├╴30 : i32
-             └╴v2 : i32 in VIInt32 [*,*]
+       └╴Condition {1xi32 in VIInt32 [*,*]}
+          ├╴LTH {1xbool in VIBool [0,1]}
+          │  ├╴v0 : 1xi32 in VIInt32 [*,*]
+          │  └╴5 : 1xi32
+          ├╴Mul {1xi32 in VIInt32 [*,*]}
+          │  ├╴3 : 1xi32
+          │  └╴v2 : 1xi32 in VIInt32 [*,*]
+          └╴Mul {1xi32 in VIInt32 [*,*]}
+             ├╴30 : 1xi32
+             └╴v2 : 1xi32 in VIInt32 [*,*]

--- a/tests/gold/monadicSharing.txt
+++ b/tests/gold/monadicSharing.txt
@@ -1,28 +1,28 @@
-Lambda v0 : u32
- └╴Run {u32 in VIWordN [*,*]}
-    └╴Bind {Mu32 in VIWordN [*,*]}
-       ├╴NewRef {MRu32 in VIWordN [*,*]}
-       │  └╴v0 : u32 in VIWordN [*,*]
-       └╴Lambda v1 : Ru32
-          └╴Bind {Mu32 in VIWordN [*,*]}
-             ├╴GetRef {Mu32 in VIWordN [*,*]}
-             │  └╴v1 : Ru32 in VIWordN [*,*]
-             └╴Lambda v2 : u32
+Lambda v0 : 1xu32
+ └╴Run {1xu32 in VIWordN [*,*]}
+    └╴Bind {M1xu32 in VIWordN [*,*]}
+       ├╴NewRef {MR1xu32 in VIWordN [*,*]}
+       │  └╴v0 : 1xu32 in VIWordN [*,*]
+       └╴Lambda v1 : R1xu32
+          └╴Bind {M1xu32 in VIWordN [*,*]}
+             ├╴GetRef {M1xu32 in VIWordN [*,*]}
+             │  └╴v1 : R1xu32 in VIWordN [*,*]
+             └╴Lambda v2 : 1xu32
                 └╴Let
-                   ├╴Var v3 : u32 = 
-                   │  └╴Add {u32 in VIWordN [*,*]}
-                   │     ├╴v2 : u32 in VIWordN [*,*]
-                   │     └╴3 : u32
+                   ├╴Var v3 : 1xu32 = 
+                   │  └╴Add {1xu32 in VIWordN [*,*]}
+                   │     ├╴v2 : 1xu32 in VIWordN [*,*]
+                   │     └╴3 : 1xu32
                    └╴In
-                      └╴Bind {Mu32 in VIWordN [*,*]}
-                         ├╴NewRef {MRu32 in VIWordN [*,*]}
-                         │  └╴v3 : u32 in VIWordN [*,*]
-                         └╴Lambda v4 : Ru32
-                            └╴Bind {Mu32 in VIWordN [*,*]}
-                               ├╴GetRef {Mu32 in VIWordN [*,*]}
-                               │  └╴v4 : Ru32 in VIWordN [*,*]
-                               └╴Lambda v5 : u32
-                                  └╴Return {Mu32 in VIWordN [*,*]}
-                                     └╴Add {u32 in VIWordN [*,*]}
-                                        ├╴v5 : u32 in VIWordN [*,*]
-                                        └╴v3 : u32 in VIWordN [*,*]
+                      └╴Bind {M1xu32 in VIWordN [*,*]}
+                         ├╴NewRef {MR1xu32 in VIWordN [*,*]}
+                         │  └╴v3 : 1xu32 in VIWordN [*,*]
+                         └╴Lambda v4 : R1xu32
+                            └╴Bind {M1xu32 in VIWordN [*,*]}
+                               ├╴GetRef {M1xu32 in VIWordN [*,*]}
+                               │  └╴v4 : R1xu32 in VIWordN [*,*]
+                               └╴Lambda v5 : 1xu32
+                                  └╴Return {M1xu32 in VIWordN [*,*]}
+                                     └╴Add {1xu32 in VIWordN [*,*]}
+                                        ├╴v5 : 1xu32 in VIWordN [*,*]
+                                        └╴v3 : 1xu32 in VIWordN [*,*]

--- a/tests/gold/topLevelConsts.txt
+++ b/tests/gold/topLevelConsts.txt
@@ -1,18 +1,18 @@
-Lambda v1 : u32
- └╴Lambda v2 : u32
+Lambda v1 : 1xu32
+ └╴Lambda v2 : 1xu32
     └╴Let
-       ├╴Var v4 : u32 = 
-       │  └╴Add {u32 in VIWordN [*,*]}
-       │     ├╴v1 : u32 in VIWordN [*,*]
-       │     └╴5 : u32
+       ├╴Var v4 : 1xu32 = 
+       │  └╴Add {1xu32 in VIWordN [*,*]}
+       │     ├╴v1 : 1xu32 in VIWordN [*,*]
+       │     └╴5 : 1xu32
        └╴In
-          └╴Condition {u32 in VIWordN [1,6]}
-             ├╴LTH {bool in VIBool [0,1]}
-             │  ├╴v2 : u32 in VIWordN [*,*]
-             │  └╴5 : u32
-             ├╴GetIx {u32 in VIWordN [2,6]}
-             │  ├╴[2,3,4,5,6] : au32
-             │  └╴v4 : u32 in VIWordN [*,*]
-             └╴GetIx {u32 in VIWordN [1,5]}
-                ├╴[1,2,3,4,5] : au32
-                └╴v4 : u32 in VIWordN [*,*]
+          └╴Condition {1xu32 in VIWordN [1,6]}
+             ├╴LTH {1xbool in VIBool [0,1]}
+             │  ├╴v2 : 1xu32 in VIWordN [*,*]
+             │  └╴5 : 1xu32
+             ├╴GetIx {1xu32 in VIWordN [2,6]}
+             │  ├╴[2,3,4,5,6] : a1xu32
+             │  └╴v4 : 1xu32 in VIWordN [*,*]
+             └╴GetIx {1xu32 in VIWordN [1,5]}
+                ├╴[1,2,3,4,5] : a1xu32
+                └╴v4 : 1xu32 in VIWordN [*,*]

--- a/tests/gold/trickySharing.txt
+++ b/tests/gold/trickySharing.txt
@@ -1,22 +1,22 @@
-Lambda v0 : u32
+Lambda v0 : 1xu32
  └╴Let
-    ├╴Var v4 : u32 = 
-    │  └╴Add {u32 in VIWordN [*,*]}
-    │     ├╴Mul {u32 in VIWordN [*,*]}
-    │     │  ├╴v0 : u32 in VIWordN [*,*]
-    │     │  └╴3 : u32
-    │     └╴Mul {u32 in VIWordN [*,*]}
-    │        ├╴v0 : u32 in VIWordN [*,*]
-    │        └╴5 : u32
-    ├╴Var v5 : u32 = 
-    │  └╴Add {u32 in VIWordN [*,*]}
-    │     ├╴v4 : u32 in VIWordN [*,*]
-    │     └╴Mul {u32 in VIWordN [*,*]}
-    │        ├╴v0 : u32 in VIWordN [*,*]
-    │        └╴7 : u32
+    ├╴Var v4 : 1xu32 = 
+    │  └╴Add {1xu32 in VIWordN [*,*]}
+    │     ├╴Mul {1xu32 in VIWordN [*,*]}
+    │     │  ├╴v0 : 1xu32 in VIWordN [*,*]
+    │     │  └╴3 : 1xu32
+    │     └╴Mul {1xu32 in VIWordN [*,*]}
+    │        ├╴v0 : 1xu32 in VIWordN [*,*]
+    │        └╴5 : 1xu32
+    ├╴Var v5 : 1xu32 = 
+    │  └╴Add {1xu32 in VIWordN [*,*]}
+    │     ├╴v4 : 1xu32 in VIWordN [*,*]
+    │     └╴Mul {1xu32 in VIWordN [*,*]}
+    │        ├╴v0 : 1xu32 in VIWordN [*,*]
+    │        └╴7 : 1xu32
     └╴In
-       └╴Add {u32 in VIWordN [*,*]}
-          ├╴Add {u32 in VIWordN [*,*]}
-          │  ├╴v5 : u32 in VIWordN [*,*]
-          │  └╴v4 : u32 in VIWordN [*,*]
-          └╴v5 : u32 in VIWordN [*,*]
+       └╴Add {1xu32 in VIWordN [*,*]}
+          ├╴Add {1xu32 in VIWordN [*,*]}
+          │  ├╴v5 : 1xu32 in VIWordN [*,*]
+          │  └╴v4 : 1xu32 in VIWordN [*,*]
+          └╴v5 : 1xu32 in VIWordN [*,*]


### PR DESCRIPTION
This is just the plumbing, there
is still no user interface.

This mirrors the type structure
in feldspar-compiler.