### PR TITLE
Remove GHC 7.8 leftovers

### DIFF
--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -8,9 +7,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeSynonymInstances #-}
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 

--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/src/Feldspar/Range.hs
+++ b/src/Feldspar/Range.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ConstraintKinds #-}
@@ -66,16 +65,8 @@ instance (Show a, Bounded a, Eq a) => Show (Range a)
 type BoundedInt a = (BoundedSuper a, BoundedSuper (UnsignedRep a))
 
 -- | Super class to 'BoundedInt'
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 708
 class    (Ord a, Num a, Bounded a, Integral a, FiniteBits a) => BoundedSuper a
 instance (Ord a, Num a, Bounded a, Integral a, FiniteBits a) => BoundedSuper a
-#else
-class    (Ord a, Num a, Bounded a, Integral a, Bits a) => BoundedSuper a
-instance (Ord a, Num a, Bounded a, Integral a, Bits a) => BoundedSuper a
-
-finiteBitSize :: (Bits b) => b -> Int
-finiteBitSize = bitSize
-#endif
 
 -- | Type famliy to determine the bit representation of a type
 type family UnsignedRep a


### PR DESCRIPTION
We no longer support GHC 7.8 so remove
the ifdefs and CPP extensions for it.