### PR TITLE
Fix deprecated -fcontext-stack message

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -129,7 +129,7 @@ library
 
   hs-source-dirs: src examples
 
-  ghc-options: -fcontext-stack=100
+  ghc-options: -freduction-depth=100
 
 test-suite range
   type: exitcode-stdio-1.0


### PR DESCRIPTION
Use -freduction-depth instead like the message
says.