### PR TITLE
travis: bump ghc version for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ cache:
 
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-1.22,ghc-7.10.3,happy-1.19.5,alex-3.1.7]}}
     - env: CABALVER=1.24 GHCVER=8.0.2
       addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-1.24,ghc-8.0.2,happy-1.19.5,alex-3.1.7]}}
-    - env: CABALVER=head GHCVER=head
-      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7]}}
+    - env: CABALVER=2.2 GHCVER=8.4.4
+      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7]}}
 
   allow_failures:
     - env: CABALVER=head GHCVER=head

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -93,7 +93,7 @@ library
     base-orphans,
     bytestring                  >= 0.10   && < 0.11,
     containers                  >= 0.4    && < 0.6,
-    comonad                     >= 4.2    && < 5.0,
+    comonad                     >= 4.2    && < 6.0,
     mtl                         >= 2.0    && < 2.3,
     QuickCheck                  >= 2.7    && < 3,
     patch-combinators           >= 0.2    && < 0.3,


### PR DESCRIPTION
Test with a more recent compiler rather than
an old compiler we no longer use.