### PR TITLE
Export constructors for IntN and WordN.

### DIFF
--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -42,7 +42,7 @@
 
 module Feldspar.Core.Types
        ( module Feldspar.Core.Types
-       , IntN, WordN
+       , IntN(..), WordN(..)
        , tuple, Tuple(), RTuple(..), sel, Skip(..), First(..), (:*), TNil -- From NestedTuples
        ) where
 


### PR DESCRIPTION
Some modules in feldspar-compiler need the constructors for these
types.