### PR TITLE
Add TypeF to AExpr

### DIFF
--- a/src/Feldspar/Core/AdjustBindings.hs
+++ b/src/Feldspar/Core/AdjustBindings.hs
@@ -39,7 +39,7 @@ module Feldspar.Core.AdjustBindings (adjustBindings) where
 import Feldspar.Core.Representation
 
 adjustBindings :: AExpr a -> AExpr a
-adjustBindings e = adjA e
+adjustBindings = adjA
 
 adjA :: AExpr a -> AExpr a
 adjA (i :& e) = i :& adj e

--- a/src/Feldspar/Core/AdjustBindings.hs
+++ b/src/Feldspar/Core/AdjustBindings.hs
@@ -38,10 +38,10 @@ module Feldspar.Core.AdjustBindings (adjustBindings) where
 
 import Feldspar.Core.Representation
 
-adjustBindings :: ExprCtx a => AExpr a -> AExpr a
+adjustBindings :: AExpr a -> AExpr a
 adjustBindings e = adjA e
 
-adjA :: ExprCtx a => AExpr a -> AExpr a
+adjA :: AExpr a -> AExpr a
 adjA (i :& e) = i :& adj e
 
 adj :: ExprCtx a => Expr a -> Expr a

--- a/src/Feldspar/Core/Eval.hs
+++ b/src/Feldspar/Core/Eval.hs
@@ -45,7 +45,7 @@ data Closure where
   Clo :: Typeable a => a -> Closure
 
 evalTop :: AExpr a -> a
-evalTop e = evalA M.empty e
+evalTop = evalA M.empty
 
 evalA :: CloEnv -> AExpr a -> a
 evalA bm (_ :& e) = evalE bm e

--- a/src/Feldspar/Core/Eval.hs
+++ b/src/Feldspar/Core/Eval.hs
@@ -44,14 +44,14 @@ import Data.Typeable
 data Closure where
   Clo :: Typeable a => a -> Closure
 
-evalTop :: TypeF a => AExpr a -> a
+evalTop :: AExpr a -> a
 evalTop e = evalA M.empty e
 
-evalA :: TypeF a => CloEnv -> AExpr a -> a
+evalA :: CloEnv -> AExpr a -> a
 evalA bm (_ :& e) = evalE bm e
 
 
-evalE :: TypeF a => CloEnv -> Expr a -> a
+evalE :: Typeable a => CloEnv -> Expr a -> a
 evalE bm (Literal l) = l
 evalE bm (Variable v) = lookupCE "Eval.evalE" bm v
 evalE bm (Operator op) = semSem $ semantics op
@@ -71,5 +71,3 @@ lookupCE msg bm (v :: Var a)
 
 extendCE :: Typeable a => CloEnv -> Var a -> a -> CloEnv
 extendCE bm v x = M.insert (varNum v) (Clo x) bm
-
-

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -115,7 +115,7 @@ asOpT _ = typeRepF
 toType :: TypeRep a -> Type
 toType tr = untypeType tr (defaultSize tr)
 
-toU :: TypeF a => R.AExpr a -> AUntypedFeld ValueInfo
+toU :: R.AExpr a -> AUntypedFeld ValueInfo
 toU (i :& e) = AIn (toAnno i) (toUr e)
 
 toUr :: TypeF a => R.Expr a -> UntypedFeldF (AUntypedFeld ValueInfo)
@@ -351,7 +351,7 @@ instance TypeF a => Pretty (ASTF a) where
   pretty = pretty . unASTF ()
 
 -- | Untype version to use with the new CSE
-untypeProgOpt :: TypeF a => FeldOpts -> AExpr a -> AUntypedFeld ValueInfo
+untypeProgOpt :: FeldOpts -> AExpr a -> AUntypedFeld ValueInfo
 untypeProgOpt opts = toU
 
 -- | Front-end driver

--- a/src/Feldspar/Core/Middleend/PassManager.hs
+++ b/src/Feldspar/Core/Middleend/PassManager.hs
@@ -69,7 +69,7 @@ prOrStop pos prs stop pass (Prog (Just p) ss s)
   where preamble = "\n========== " ++ pos ++ " " ++ show pass ++ " ==========\n\n"
 prOrStop _ _ _ _ prog = prog
 
-runPassC :: (Eq b ) => [b] -> b -> (a -> a) -> Prog a c -> Prog a c
+runPassC :: Eq b => [b] -> b -> (a -> a) -> Prog a c -> Prog a c
 runPassC skips pass f (Prog (Just p) ss s)
   = Prog (Just $ if pass `elem` skips then p else f p) ss s
 runPassC _ _ _ prog = prog

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -84,7 +84,7 @@ resugar = sugar . desugar
 --   in the expression part of the CExpr.
 data ASTF a = ASTF (CExpr a) Int
 
-alphaEq :: T.Type a => ASTF a -> ASTF a -> Bool
+alphaEq :: ASTF a -> ASTF a -> Bool
 alphaEq (ASTF (ml,el) _) (ASTF (mr,er) _) = error "alphaEq not supported (binding time violation)"
 
 -- | Convert an ASTF to an expression
@@ -95,10 +95,10 @@ unASTF _ (ASTF ce _) = fromCExp ce
 evalBind :: TypeF a => ASTF a -> a
 evalBind = evalTop . unASTF ()
 
-render :: TypeF a => ASTF a -> String
+render :: ASTF a -> String
 render (ASTF (m,e) _) = unwords $ show e : "where" : map (show . snd) (M.toList m)
 
-instance TypeF a => Show (ASTF a) where
+instance Show (ASTF a) where
   show = render
 
 class Syntactic a where
@@ -213,10 +213,10 @@ catchBindings vs (m,e) = (m1, mkLets (bs,e))
 {- | Functions for constructing hash values.
 -}
 
-hashExpr :: TypeF a => AExpr a -> VarId
+hashExpr :: AExpr a -> VarId
 hashExpr (_ :& e) = (hash2VarId $ hash $ exprType e) `combineHash` hashExprR e
 
-hashExprR :: TypeF a => Expr a -> VarId
+hashExprR :: Expr a -> VarId
 hashExprR (Variable v) = varNum v
 hashExprR (Literal c) = hash2VarId $ hash c
 hashExprR (Operator op) = hashOp op

--- a/src/Feldspar/Core/SizeProp.hs
+++ b/src/Feldspar/Core/SizeProp.hs
@@ -50,14 +50,14 @@ look vm v = lookupBE "SizeProp.look" vm v
 extend :: TypeF a => BindEnv -> Var a -> Info a -> BindEnv
 extend vm v info = extendBE vm $ CBind v $ info :& Variable v
 
-sizeProp :: (Show (Size a), Lattice (Size a), Typeable a) => AExpr a -> AExpr a
+sizeProp :: (Show (Size a), Lattice (Size a)) => AExpr a -> AExpr a
 sizeProp = spA M.empty
 
-spA :: (Show (Size a), Lattice (Size a), Typeable a)
+spA :: (Show (Size a), Lattice (Size a))
     => BindEnv -> AExpr a -> AExpr a
 spA vm (_ :& e) = spApp vm e
 
-spApp :: (Show (Size a), Lattice (Size a), Typeable a) => BindEnv -> Expr a -> AExpr a
+spApp :: (TypeF a, Show (Size a), Lattice (Size a)) => BindEnv -> Expr a -> AExpr a
 -- | Variables and literals
 spApp vm (Variable v) = look vm v
 spApp vm (Literal l)  = literal l
@@ -493,7 +493,7 @@ finalInfo :: (Show (Size a), Lattice (Size a)) => AExpr a -> Size a -> Info a
 finalInfo e s = Info $ exprSize e \/ s
 
 -- | Indexed loops without state (Parallel, EparFor, ...)
-spLoI :: (Show (Size u), Lattice (Size u))
+spLoI :: (TypeF u, Show (Size u), Lattice (Size u))
       => BindEnv -> Op (Length -> (Index -> b) -> u)
       -> (Size Index -> Size b -> Size u)
       -> AExpr Length -> AExpr (Index -> b)
@@ -527,18 +527,19 @@ spLambda2 vm s t (_ :& Lambda v (_ :& Lambda w e)) = (exprSize e1, f1)
 spLambda2 _  _ _ _ = error "SizeProp.spLambda2: not a lambda abstraction."
 
 -- | Nullary applications
-spApp0 :: (Show (Size u), Lattice (Size u)) => BindEnv -> Op u -> Size u -> AExpr u
+spApp0 :: (TypeF u, Show (Size u), Lattice (Size u))
+       => BindEnv -> Op u -> Size u -> AExpr u
 spApp0 vm op s = Info s :& Operator op
 
 -- | Unary applications
-spApp1 :: (TypeF a, Show (Size u), Lattice (Size u))
+spApp1 :: (TypeF a, TypeF u, Show (Size u), Lattice (Size u))
        => BindEnv -> Op (a -> u) -> (Size a -> Size u) -> AExpr a -> AExpr u
 spApp1 vm op f a = Info (f ai) :& Operator op :@ a1
   where a1 = spA vm a
         ai = infoSize $ aeInfo a1
 
 -- | Binary applications
-spApp2 :: (TypeF a, TypeF b, Show (Size u), Lattice (Size u))
+spApp2 :: (TypeF a, TypeF b, TypeF u, Show (Size u), Lattice (Size u))
        => BindEnv -> Op (a -> b -> u) -> (Size a -> Size b -> Size u)
        -> AExpr a -> AExpr b -> AExpr u
 spApp2 vm op f a b = Info (f ai bi) :& Operator op :@ a1 :@ b1
@@ -548,11 +549,10 @@ spApp2 vm op f a b = Info (f ai bi) :& Operator op :@ a1 :@ b1
         bi = infoSize $ aeInfo b1
 
 -- | Ternary applications
-spApp3 :: (TypeF a, TypeF b, TypeF c, Show (Size u), Lattice (Size u))
+spApp3 :: (TypeF a, TypeF b, TypeF c, TypeF u, Show (Size u), Lattice (Size u))
        => BindEnv -> Op (a -> b -> c -> u)
        -> (Size a -> Size b -> Size c -> Size u)
-       -> AExpr a -> AExpr b -> AExpr c
-       -> AExpr u
+       -> AExpr a -> AExpr b -> AExpr c -> AExpr u
 spApp3 vm op f a b c = Info (f ai bi ci) :& Operator op :@ a1 :@ b1 :@ c1
   where a1 = spA vm a
         ai = infoSize $ aeInfo a1

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 --
@@ -140,7 +139,7 @@ unAnnotate (AIn _ e) = In $ go e
 
 -- | Add annotations using an annotation function
 annotate :: (UntypedFeldF (AUntypedFeld a) -> a) -> UntypedFeld -> AUntypedFeld a
-annotate anno e = goA e
+annotate anno = goA
   where go (Lambda v e)         = Lambda v $ goA e
         go (LetFun (s,k,e1) e2) = LetFun (s, k, goA e1) $ goA e2
         go (App f t es)         = App f t $ map goA es
@@ -653,10 +652,10 @@ prettyExp prA e = render (pr 0 0 e)
           | indent x <= indent y &&
             all ((==) (indent y) . indent) xs &&
             l <= 60
-          = [(indent x, l, intercalate " " $ map val $ x:y:xs)]
+          = [(indent x, l, unwords $ map val $ x:y:xs)]
             where l = sum (map len $ x:y:xs) + length xs + 1
         join xs = xs
-        render ls = foldr (\ (i,_,cs) str -> replicate i ' ' ++ cs ++ "\n" ++ str) "" ls
+        render = foldr (\ (i,_,cs) str -> replicate i ' ' ++ cs ++ "\n" ++ str) ""
         line i cs = [(i, length cs, cs)]
         indent (i,_,_) = i
         len (_,l,_) = l


### PR DESCRIPTION
Require contexts when building the AST
rather than when inspecting the AST.