### PR TITLE
Inline functions to reduce contexts

### DIFF
--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -47,7 +47,6 @@ module Feldspar.Core.Representation
   , literal
   , ExprCtx(..)
   , toAExpr
-  , funInfo
   , exprSize
   , (:->)
   , EqBox(..)
@@ -119,11 +118,6 @@ instance Show (Info a) where
 -- | Adding default info to an Expr
 toAExpr :: (Show (Size a), Lattice (Size a), TypeF a) => Expr (Full a) -> AExpr a
 toAExpr e = Info top :& e
-
--- | Constructing an annotation for a Lambda
-funInfo :: (Show (Size a), Lattice (Size a), Show (Size e), Lattice (Size e))
-         => AExpr a -> AExpr e -> Info (a -> e)
-funInfo a e = Info (exprSize a, exprSize e)
 
 -- | Getting the size (value info) of an expression from its annotation
 exprSize :: AExpr a -> Size a
@@ -509,7 +503,7 @@ fviB (CBind _ e) = fvi e
 showRhs (CBind _ e) = show e
 
 mkLets :: ExprCtx a => ([CBind], AExpr a) -> AExpr a
-mkLets (CBind v rhs : bs, e) = aeInfo e :& Operator Let :@ rhs :@ (funInfo rhs e :& Lambda v (mkLets (bs,e)))
+mkLets (CBind v rhs : bs, e) = aeInfo e :& Operator Let :@ rhs :@ (Info (exprSize rhs, exprSize e) :& Lambda v (mkLets (bs,e)))
 mkLets ([], e) = e
 
 -- | Functions for bind environments

--- a/src/Feldspar/Core/SizeProp.hs
+++ b/src/Feldspar/Core/SizeProp.hs
@@ -50,223 +50,219 @@ look vm v = lookupBE "SizeProp.look" vm v
 extend :: TypeF a => BindEnv -> Var a -> Info a -> BindEnv
 extend vm v info = extendBE vm $ CBind v $ info :& Variable v
 
-sizeProp :: (Show (Size a), Lattice (Size a)) => AExpr a -> AExpr a
+sizeProp :: AExpr a -> AExpr a
 sizeProp = spA M.empty
 
-spA :: (Show (Size a), Lattice (Size a))
-    => BindEnv -> AExpr a -> AExpr a
-spA vm (_ :& e) = spApp vm e
-
-spApp :: (TypeF a, Show (Size a), Lattice (Size a)) => BindEnv -> Expr a -> AExpr a
+spA :: BindEnv -> AExpr a -> AExpr a
 -- | Variables and literals
-spApp vm (Variable v) = look vm v
-spApp vm (Literal l)  = literal l
+spA vm (_ :& Variable v) = look vm v
+spA vm (_ :& Literal l)  = literal l
 -- Top level lambda
-spApp vm (Lambda v e) = snd $ spLambda vm top (Info top :& Lambda v e)
+spA vm (_ :& Lambda v e) = snd $ spLambda vm top (Info top :& Lambda v e)
 -- | Applications and lambdas based on head operator
 -- | Array
-spApp vm (Operator        Parallel :@ a :@ b)      = spLoI  vm        Parallel (:>) a b
-spApp vm (Operator      Sequential :@ a :@ b :@ c) = Info (exprSize a1 :> s) :& Operator Sequential :@ a1 :@ b1 :@ c1
+spA vm (_ :& Operator        Parallel :@ a :@ b)      = spLoI  vm        Parallel (:>) a b
+spA vm (_ :& Operator      Sequential :@ a :@ b :@ c) = Info (exprSize a1 :> s) :& Operator Sequential :@ a1 :@ b1 :@ c1
   where a1 = spA vm a
         b1 = spA vm b
         ((s,_),c1) = spLambda2 vm (exprSize a1) top c
-spApp vm (Operator          Append :@ a :@ b)      = spApp2 vm          Append appF a b
+spA vm (_ :& Operator          Append :@ a :@ b)      = spApp2 vm          Append appF a b
   where appF (alen :> aelem) (blen :> belem) = (alen + blen :> aelem \/ belem)
-spApp vm (Operator           GetIx :@ a :@ b)      = spApp2 vm           GetIx (\ (_ :> i) _ -> i) a b
-spApp vm (Operator           SetIx :@ a :@ b :@ c) = spApp3 vm           SetIx (\ (l :> i) _ j -> l :> i \/ j) a b c
-spApp vm (Operator       GetLength :@ a)           = spApp1 vm       GetLength (\ (l :> _) -> l) a
-spApp vm (Operator       SetLength :@ a :@ b)      = spApp2 vm       SetLength (\ l (_ :> i) -> l :> i) a b
+spA vm (_ :& Operator           GetIx :@ a :@ b)      = spApp2 vm           GetIx (\ (_ :> i) _ -> i) a b
+spA vm (_ :& Operator           SetIx :@ a :@ b :@ c) = spApp3 vm           SetIx (\ (l :> i) _ j -> l :> i \/ j) a b c
+spA vm (_ :& Operator       GetLength :@ a)           = spApp1 vm       GetLength (\ (l :> _) -> l) a
+spA vm (_ :& Operator       SetLength :@ a :@ b)      = spApp2 vm       SetLength (\ l (_ :> i) -> l :> i) a b
 
 -- | Binding
-spApp vm (Operator             Let :@ a :@ b)      = i :& Operator Let :@ a1 :@ b1
+spA vm (_ :& Operator             Let :@ a :@ b)      = i :& Operator Let :@ a1 :@ b1
   where (i,a1,b1) = spBind vm a b
 
 -- | Bits
-spApp vm (Operator            BAnd :@ a :@ b)      = spApp2 vm            BAnd rangeAnd a b
-spApp vm (Operator             BOr :@ a :@ b)      = spApp2 vm             BOr rangeOr  a b
-spApp vm (Operator            BXor :@ a :@ b)      = spApp2 vm            BXor rangeXor a b
-spApp vm (Operator      Complement :@ a)           = spApp1 vm      Complement rangeComplement a
-spApp vm (Operator             Bit :@ a)           = spApp1 vm             Bit topF1 a
-spApp vm (Operator          SetBit :@ a :@ b)      = spApp2 vm          SetBit topF2 a b
-spApp vm (Operator        ClearBit :@ a :@ b)      = spApp2 vm        ClearBit topF2 a b
-spApp vm (Operator   ComplementBit :@ a :@ b)      = spApp2 vm   ComplementBit topF2 a b
-spApp vm (Operator         TestBit :@ a :@ b)      = spApp2 vm         TestBit topF2 a b
-spApp vm (Operator         ShiftLU :@ a :@ b)      = spApp2 vm         ShiftLU rangeShiftLU a b
-spApp vm (Operator         ShiftRU :@ a :@ b)      = spApp2 vm         ShiftRU rangeShiftRU a b
-spApp vm (Operator          ShiftL :@ a :@ b)      = spApp2 vm          ShiftL topF2 a b
-spApp vm (Operator          ShiftR :@ a :@ b)      = spApp2 vm          ShiftR topF2 a b
-spApp vm (Operator        RotateLU :@ a :@ b)      = spApp2 vm        RotateLU topF2 a b
-spApp vm (Operator        RotateRU :@ a :@ b)      = spApp2 vm        RotateRU topF2 a b
-spApp vm (Operator         RotateL :@ a :@ b)      = spApp2 vm         RotateL topF2 a b
-spApp vm (Operator         RotateR :@ a :@ b)      = spApp2 vm         RotateR topF2 a b
-spApp vm (Operator     ReverseBits :@ a)           = spApp1 vm     ReverseBits topF1 a
-spApp vm (Operator         BitScan :@ a)           = spApp1 vm         BitScan topF1 a
-spApp vm (Operator        BitCount :@ a)           = spApp1 vm        BitCount topF1 a -- We could do better
+spA vm (_ :& Operator            BAnd :@ a :@ b)      = spApp2 vm            BAnd rangeAnd a b
+spA vm (_ :& Operator             BOr :@ a :@ b)      = spApp2 vm             BOr rangeOr  a b
+spA vm (_ :& Operator            BXor :@ a :@ b)      = spApp2 vm            BXor rangeXor a b
+spA vm (_ :& Operator      Complement :@ a)           = spApp1 vm      Complement rangeComplement a
+spA vm (_ :& Operator             Bit :@ a)           = spApp1 vm             Bit topF1 a
+spA vm (_ :& Operator          SetBit :@ a :@ b)      = spApp2 vm          SetBit topF2 a b
+spA vm (_ :& Operator        ClearBit :@ a :@ b)      = spApp2 vm        ClearBit topF2 a b
+spA vm (_ :& Operator   ComplementBit :@ a :@ b)      = spApp2 vm   ComplementBit topF2 a b
+spA vm (_ :& Operator         TestBit :@ a :@ b)      = spApp2 vm         TestBit topF2 a b
+spA vm (_ :& Operator         ShiftLU :@ a :@ b)      = spApp2 vm         ShiftLU rangeShiftLU a b
+spA vm (_ :& Operator         ShiftRU :@ a :@ b)      = spApp2 vm         ShiftRU rangeShiftRU a b
+spA vm (_ :& Operator          ShiftL :@ a :@ b)      = spApp2 vm          ShiftL topF2 a b
+spA vm (_ :& Operator          ShiftR :@ a :@ b)      = spApp2 vm          ShiftR topF2 a b
+spA vm (_ :& Operator        RotateLU :@ a :@ b)      = spApp2 vm        RotateLU topF2 a b
+spA vm (_ :& Operator        RotateRU :@ a :@ b)      = spApp2 vm        RotateRU topF2 a b
+spA vm (_ :& Operator         RotateL :@ a :@ b)      = spApp2 vm         RotateL topF2 a b
+spA vm (_ :& Operator         RotateR :@ a :@ b)      = spApp2 vm         RotateR topF2 a b
+spA vm (_ :& Operator     ReverseBits :@ a)           = spApp1 vm     ReverseBits topF1 a
+spA vm (_ :& Operator         BitScan :@ a)           = spApp1 vm         BitScan topF1 a
+spA vm (_ :& Operator        BitCount :@ a)           = spApp1 vm        BitCount topF1 a -- We could do better
 
 -- | Complex
-spApp vm (Operator       MkComplex :@ a :@ b)      = spApp2 vm       MkComplex topF2 a b
-spApp vm (Operator        RealPart :@ a)           = spApp1 vm        RealPart topF1 a
-spApp vm (Operator        ImagPart :@ a)           = spApp1 vm        ImagPart topF1 a
-spApp vm (Operator       Conjugate :@ a)           = spApp1 vm       Conjugate topF1 a
-spApp vm (Operator         MkPolar :@ a :@ b)      = spApp2 vm         MkPolar topF2 a b
-spApp vm (Operator       Magnitude :@ a)           = spApp1 vm       Magnitude topF1 a
-spApp vm (Operator           Phase :@ a)           = spApp1 vm           Phase topF1 a
-spApp vm (Operator             Cis :@ a)           = spApp1 vm             Cis topF1 a
+spA vm (_ :& Operator       MkComplex :@ a :@ b)      = spApp2 vm       MkComplex topF2 a b
+spA vm (_ :& Operator        RealPart :@ a)           = spApp1 vm        RealPart topF1 a
+spA vm (_ :& Operator        ImagPart :@ a)           = spApp1 vm        ImagPart topF1 a
+spA vm (_ :& Operator       Conjugate :@ a)           = spApp1 vm       Conjugate topF1 a
+spA vm (_ :& Operator         MkPolar :@ a :@ b)      = spApp2 vm         MkPolar topF2 a b
+spA vm (_ :& Operator       Magnitude :@ a)           = spApp1 vm       Magnitude topF1 a
+spA vm (_ :& Operator           Phase :@ a)           = spApp1 vm           Phase topF1 a
+spA vm (_ :& Operator             Cis :@ a)           = spApp1 vm             Cis topF1 a
 
 -- | Condition
-spApp vm (Operator       Condition :@ a :@ b :@ c) = spApp3 vm       Condition (const (\/)) a b c
+spA vm (_ :& Operator       Condition :@ a :@ b :@ c) = spApp3 vm       Condition (const (\/)) a b c
 
 -- | Conversion
-spApp vm (Operator             F2I :@ a)           = spApp1 vm             F2I topF1 a
-spApp vm (Operator          op@I2N :@ a)           = spApp1 vm             I2N (spI2N op) a
-spApp vm (Operator          op@B2I :@ a)           = spApp1 vm             B2I (spB2I op) a
-spApp vm (Operator           Round :@ a)           = spApp1 vm           Round topF1 a
-spApp vm (Operator         Ceiling :@ a)           = spApp1 vm         Ceiling topF1 a
-spApp vm (Operator           Floor :@ a)           = spApp1 vm           Floor topF1 a
+spA vm (_ :& Operator             F2I :@ a)           = spApp1 vm             F2I topF1 a
+spA vm (_ :& Operator          op@I2N :@ a)           = spApp1 vm             I2N (spI2N op) a
+spA vm (_ :& Operator          op@B2I :@ a)           = spApp1 vm             B2I (spB2I op) a
+spA vm (_ :& Operator           Round :@ a)           = spApp1 vm           Round topF1 a
+spA vm (_ :& Operator         Ceiling :@ a)           = spApp1 vm         Ceiling topF1 a
+spA vm (_ :& Operator           Floor :@ a)           = spApp1 vm           Floor topF1 a
 
 -- | Elements
-spApp vm (Operator    EMaterialize :@ a :@ b)      = spApp2 vm    EMaterialize (\ _ s -> s) a b
-spApp vm (Operator          EWrite :@ a :@ b)      = spApp2 vm          EWrite (:>) a b
-spApp vm (Operator           ESkip)                = spApp0 vm           ESkip bot
-spApp vm (Operator            EPar :@ a :@ b)      = spApp2 vm            EPar (\/) a b
-spApp vm (Operator         EparFor :@ a :@ b)      = spLoI  vm         EparFor (\ _ s -> s) a b
+spA vm (_ :& Operator    EMaterialize :@ a :@ b)      = spApp2 vm    EMaterialize (\ _ s -> s) a b
+spA vm (_ :& Operator          EWrite :@ a :@ b)      = spApp2 vm          EWrite (:>) a b
+spA vm (_ :& Operator           ESkip)                = spApp0 vm           ESkip bot
+spA vm (_ :& Operator            EPar :@ a :@ b)      = spApp2 vm            EPar (\/) a b
+spA vm (_ :& Operator         EparFor :@ a :@ b)      = spLoI  vm         EparFor (\ _ s -> s) a b
 
 -- | Eq
-spApp vm (Operator           Equal :@ a :@ b)      = spApp2 vm           Equal topF2 a b
-spApp vm (Operator        NotEqual :@ a :@ b)      = spApp2 vm        NotEqual topF2 a b
+spA vm (_ :& Operator           Equal :@ a :@ b)      = spApp2 vm           Equal topF2 a b
+spA vm (_ :& Operator        NotEqual :@ a :@ b)      = spApp2 vm        NotEqual topF2 a b
 
 -- | Error
-spApp vm (Operator       Undefined)                = spApp0 vm       Undefined bot
-spApp vm (Operator      (Assert s) :@ a :@ b)      = spApp2 vm      (Assert s) (\ _ s -> s) a b
+spA vm (_ :& Operator       Undefined)                = spApp0 vm       Undefined bot
+spA vm (_ :& Operator      (Assert s) :@ a :@ b)      = spApp2 vm      (Assert s) (\ _ s -> s) a b
 
 -- | Floating
-spApp vm (Operator              Pi)                = spApp0 vm              Pi top
-spApp vm (Operator             Exp :@ a)           = spApp1 vm             Exp topF1 a
-spApp vm (Operator            Sqrt :@ a)           = spApp1 vm            Sqrt topF1 a
-spApp vm (Operator             Log :@ a)           = spApp1 vm             Log topF1 a
-spApp vm (Operator             Pow :@ a :@ b)      = spApp2 vm             Pow topF2 a b
-spApp vm (Operator         LogBase :@ a :@ b)      = spApp2 vm         LogBase topF2 a b
-spApp vm (Operator             Sin :@ a)           = spApp1 vm             Sin topF1 a
-spApp vm (Operator             Tan :@ a)           = spApp1 vm             Tan topF1 a
-spApp vm (Operator             Cos :@ a)           = spApp1 vm             Cos topF1 a
-spApp vm (Operator            Asin :@ a)           = spApp1 vm            Asin topF1 a
-spApp vm (Operator            Atan :@ a)           = spApp1 vm            Atan topF1 a
-spApp vm (Operator            Acos :@ a)           = spApp1 vm            Acos topF1 a
-spApp vm (Operator            Sinh :@ a)           = spApp1 vm            Sinh topF1 a
-spApp vm (Operator            Tanh :@ a)           = spApp1 vm            Tanh topF1 a
-spApp vm (Operator            Cosh :@ a)           = spApp1 vm            Cosh topF1 a
-spApp vm (Operator           Asinh :@ a)           = spApp1 vm           Asinh topF1 a
-spApp vm (Operator           Atanh :@ a)           = spApp1 vm           Atanh topF1 a
-spApp vm (Operator           Acosh :@ a)           = spApp1 vm           Acosh topF1 a
+spA vm (_ :& Operator              Pi)                = spApp0 vm              Pi top
+spA vm (_ :& Operator             Exp :@ a)           = spApp1 vm             Exp topF1 a
+spA vm (_ :& Operator            Sqrt :@ a)           = spApp1 vm            Sqrt topF1 a
+spA vm (_ :& Operator             Log :@ a)           = spApp1 vm             Log topF1 a
+spA vm (_ :& Operator             Pow :@ a :@ b)      = spApp2 vm             Pow topF2 a b
+spA vm (_ :& Operator         LogBase :@ a :@ b)      = spApp2 vm         LogBase topF2 a b
+spA vm (_ :& Operator             Sin :@ a)           = spApp1 vm             Sin topF1 a
+spA vm (_ :& Operator             Tan :@ a)           = spApp1 vm             Tan topF1 a
+spA vm (_ :& Operator             Cos :@ a)           = spApp1 vm             Cos topF1 a
+spA vm (_ :& Operator            Asin :@ a)           = spApp1 vm            Asin topF1 a
+spA vm (_ :& Operator            Atan :@ a)           = spApp1 vm            Atan topF1 a
+spA vm (_ :& Operator            Acos :@ a)           = spApp1 vm            Acos topF1 a
+spA vm (_ :& Operator            Sinh :@ a)           = spApp1 vm            Sinh topF1 a
+spA vm (_ :& Operator            Tanh :@ a)           = spApp1 vm            Tanh topF1 a
+spA vm (_ :& Operator            Cosh :@ a)           = spApp1 vm            Cosh topF1 a
+spA vm (_ :& Operator           Asinh :@ a)           = spApp1 vm           Asinh topF1 a
+spA vm (_ :& Operator           Atanh :@ a)           = spApp1 vm           Atanh topF1 a
+spA vm (_ :& Operator           Acosh :@ a)           = spApp1 vm           Acosh topF1 a
 
 -- | Fractional
-spApp vm (Operator         DivFrac :@ a :@ b)      = spApp2 vm         DivFrac topF2 a b
+spA vm (_ :& Operator         DivFrac :@ a :@ b)      = spApp2 vm         DivFrac topF2 a b
 
 -- | Future
-spApp vm (Operator        MkFuture :@ a)           = spApp1 vm        MkFuture id a
-spApp vm (Operator           Await :@ a)           = spApp1 vm           Await id a
+spA vm (_ :& Operator        MkFuture :@ a)           = spApp1 vm        MkFuture id a
+spA vm (_ :& Operator           Await :@ a)           = spApp1 vm           Await id a
 
 -- | Integral
-spApp vm (Operator            Quot :@ a :@ b)      = spApp2 vm            Quot rangeQuot a b
-spApp vm (Operator             Rem :@ a :@ b)      = spApp2 vm             Rem rangeRem a b
-spApp vm (Operator             Div :@ a :@ b)      = spApp2 vm             Div rangeDiv a b
-spApp vm (Operator             Mod :@ a :@ b)      = spApp2 vm             Mod rangeMod a b
-spApp vm (Operator            IExp :@ a :@ b)      = spApp2 vm            IExp rangeExp a b
+spA vm (_ :& Operator            Quot :@ a :@ b)      = spApp2 vm            Quot rangeQuot a b
+spA vm (_ :& Operator             Rem :@ a :@ b)      = spApp2 vm             Rem rangeRem a b
+spA vm (_ :& Operator             Div :@ a :@ b)      = spApp2 vm             Div rangeDiv a b
+spA vm (_ :& Operator             Mod :@ a :@ b)      = spApp2 vm             Mod rangeMod a b
+spA vm (_ :& Operator            IExp :@ a :@ b)      = spApp2 vm            IExp rangeExp a b
 
 -- | Logic
-spApp vm (Operator             And :@ a :@ b)      = spApp2 vm             And topF2 a b
-spApp vm (Operator              Or :@ a :@ b)      = spApp2 vm              Or topF2 a b
-spApp vm (Operator             Not :@ a)           = spApp1 vm             Not topF1 a
+spA vm (_ :& Operator             And :@ a :@ b)      = spApp2 vm             And topF2 a b
+spA vm (_ :& Operator              Or :@ a :@ b)      = spApp2 vm              Or topF2 a b
+spA vm (_ :& Operator             Not :@ a)           = spApp1 vm             Not topF1 a
 
 -- | Loop
-spApp vm (Operator ForLoop :@ a :@ b :@ c) = finalInfo b1 s :& Operator ForLoop :@ a1 :@ b1 :@ c1
+spA vm (_ :& Operator ForLoop :@ a :@ b :@ c) = Info (exprSize  b1 \/ s) :& Operator ForLoop :@ a1 :@ b1 :@ c1
   where a1 = spA vm a
         b1 = spA vm b
         (s,c1) = spLambda2 vm (exprSize a1) top c
 
-spApp vm (Operator  WhileLoop :@ a :@ b :@ c) = finalInfo a1 s :& Operator WhileLoop :@ a1 :@ b1 :@ c1
+spA vm (_ :& Operator  WhileLoop :@ a :@ b :@ c) = Info (exprSize a1 \/ s) :& Operator WhileLoop :@ a1 :@ b1 :@ c1
   where a1 = spA vm a
         (_,b1) = spLambda vm top b
         (s,c1) = spLambda vm top c
 
 -- | Mutable
-spApp vm (Operator             Run :@ a)           = spApp1 vm             Run id a
+spA vm (_ :& Operator             Run :@ a)           = spApp1 vm             Run id a
 
 -- | MutableArray
-spApp vm (Operator          NewArr :@ a :@ b)      = spApp2 vm          NewArr (\ s _ -> s :> top) a b
-spApp vm (Operator         NewArr_ :@ a)           = spApp1 vm         NewArr_ (\ s -> s :> top) a
-spApp vm (Operator          GetArr :@ a :@ b)      = spApp2 vm          GetArr topF2 a b
-spApp vm (Operator          SetArr :@ a :@ b :@ c) = spApp3 vm          SetArr topF3 a b c
-spApp vm (Operator       ArrLength :@ a)           = spApp1 vm       ArrLength (\ (l :> _) -> l) a
+spA vm (_ :& Operator          NewArr :@ a :@ b)      = spApp2 vm          NewArr (\ s _ -> s :> top) a b
+spA vm (_ :& Operator         NewArr_ :@ a)           = spApp1 vm         NewArr_ (\ s -> s :> top) a
+spA vm (_ :& Operator          GetArr :@ a :@ b)      = spApp2 vm          GetArr topF2 a b
+spA vm (_ :& Operator          SetArr :@ a :@ b :@ c) = spApp3 vm          SetArr topF3 a b c
+spA vm (_ :& Operator       ArrLength :@ a)           = spApp1 vm       ArrLength (\ (l :> _) -> l) a
 
 -- | MutableToPure
-spApp vm (Operator RunMutableArray :@ a)           = spApp1 vm RunMutableArray id a
-spApp vm (Operator       WithArray :@ a :@ f)      = i :& Operator WithArray :@ a1 :@ f1
+spA vm (_ :& Operator RunMutableArray :@ a)           = spApp1 vm RunMutableArray id a
+spA vm (_ :& Operator       WithArray :@ a :@ f)      = i :& Operator WithArray :@ a1 :@ f1
   where (i,a1,f1) = spBind vm a f
 
 -- | MutableReference
-spApp vm (Operator          NewRef :@ a)           = spApp1 vm          NewRef topF1 a
-spApp vm (Operator          GetRef :@ a)           = spApp1 vm          GetRef topF1 a
-spApp vm (Operator          SetRef :@ a :@ b)      = spApp2 vm          SetRef topF2 a b
-spApp vm (Operator          ModRef :@ a :@ b)      = spApp2 vm          ModRef topF2 a b
+spA vm (_ :& Operator          NewRef :@ a)           = spApp1 vm          NewRef topF1 a
+spA vm (_ :& Operator          GetRef :@ a)           = spApp1 vm          GetRef topF1 a
+spA vm (_ :& Operator          SetRef :@ a :@ b)      = spApp2 vm          SetRef topF2 a b
+spA vm (_ :& Operator          ModRef :@ a :@ b)      = spApp2 vm          ModRef topF2 a b
 
 -- | Nested tuples
-spApp vm (Operator            Cons :@ a :@ b)      = spApp2 vm            Cons (,) a b
-spApp vm (Operator             Nil)                = spApp0 vm             Nil top
-spApp vm (Operator             Car :@ a)           = spApp1 vm             Car fst a
-spApp vm (Operator             Cdr :@ a)           = spApp1 vm             Cdr snd a
-spApp vm (Operator             Tup :@ a)           = spApp1 vm             Tup id  a
-spApp vm (Operator           UnTup :@ a)           = spApp1 vm           UnTup id  a
+spA vm (_ :& Operator            Cons :@ a :@ b)      = spApp2 vm            Cons (,) a b
+spA vm (_ :& Operator             Nil)                = spApp0 vm             Nil top
+spA vm (_ :& Operator             Car :@ a)           = spApp1 vm             Car fst a
+spA vm (_ :& Operator             Cdr :@ a)           = spApp1 vm             Cdr snd a
+spA vm (_ :& Operator             Tup :@ a)           = spApp1 vm             Tup id  a
+spA vm (_ :& Operator           UnTup :@ a)           = spApp1 vm           UnTup id  a
 
 -- | NoInline
-spApp vm (Operator        NoInline :@ a)           = spApp1 vm        NoInline topF1 a -- Could we not have 'id'?
+spA vm (_ :& Operator        NoInline :@ a)           = spApp1 vm        NoInline topF1 a -- Could we not have 'id'?
 
 -- | Num
-spApp vm (Operator             Abs :@ a)           = spApp1 vm             Abs abs a
-spApp vm (Operator            Sign :@ a)           = spApp1 vm            Sign signum a
-spApp vm (Operator             Add :@ a :@ b)      = spApp2 vm             Add (+) a b
-spApp vm (Operator             Sub :@ a :@ b)      = spApp2 vm             Sub (-) a b
-spApp vm (Operator             Mul :@ a :@ b)      = spApp2 vm             Mul (*) a b
+spA vm (_ :& Operator             Abs :@ a)           = spApp1 vm             Abs abs a
+spA vm (_ :& Operator            Sign :@ a)           = spApp1 vm            Sign signum a
+spA vm (_ :& Operator             Add :@ a :@ b)      = spApp2 vm             Add (+) a b
+spA vm (_ :& Operator             Sub :@ a :@ b)      = spApp2 vm             Sub (-) a b
+spA vm (_ :& Operator             Mul :@ a :@ b)      = spApp2 vm             Mul (*) a b
 
 -- | Ord
-spApp vm (Operator             LTH :@ a :@ b)      = spApp2 vm             LTH topF2 a b
-spApp vm (Operator             GTH :@ a :@ b)      = spApp2 vm             GTH topF2 a b
-spApp vm (Operator             LTE :@ a :@ b)      = spApp2 vm             LTE topF2 a b
-spApp vm (Operator             GTE :@ a :@ b)      = spApp2 vm             GTE topF2 a b
-spApp vm (Operator             Min :@ a :@ b)      = spApp2 vm             Min min a b
-spApp vm (Operator             Max :@ a :@ b)      = spApp2 vm             Max max a b
+spA vm (_ :& Operator             LTH :@ a :@ b)      = spApp2 vm             LTH topF2 a b
+spA vm (_ :& Operator             GTH :@ a :@ b)      = spApp2 vm             GTH topF2 a b
+spA vm (_ :& Operator             LTE :@ a :@ b)      = spApp2 vm             LTE topF2 a b
+spA vm (_ :& Operator             GTE :@ a :@ b)      = spApp2 vm             GTE topF2 a b
+spA vm (_ :& Operator             Min :@ a :@ b)      = spApp2 vm             Min min a b
+spA vm (_ :& Operator             Max :@ a :@ b)      = spApp2 vm             Max max a b
 
 -- | Par
-spApp vm (Operator          ParRun :@ a)           = spApp1 vm          ParRun id a
-spApp vm (Operator          ParNew)                = spApp0 vm          ParNew top
-spApp vm (Operator          ParGet :@ a)           = spApp1 vm          ParGet topF1 a
-spApp vm (Operator          ParPut :@ a :@ b)      = spApp2 vm          ParPut topF2 a b
-spApp vm (Operator         ParFork :@ a)           = spApp1 vm         ParFork topF1 a
-spApp vm (Operator        ParYield)                = spApp0 vm        ParYield top
+spA vm (_ :& Operator          ParRun :@ a)           = spApp1 vm          ParRun id a
+spA vm (_ :& Operator          ParNew)                = spApp0 vm          ParNew top
+spA vm (_ :& Operator          ParGet :@ a)           = spApp1 vm          ParGet topF1 a
+spA vm (_ :& Operator          ParPut :@ a :@ b)      = spApp2 vm          ParPut topF2 a b
+spA vm (_ :& Operator         ParFork :@ a)           = spApp1 vm         ParFork topF1 a
+spA vm (_ :& Operator        ParYield)                = spApp0 vm        ParYield top
 
 -- | RealFloat
-spApp vm (Operator           Atan2 :@ a :@ b)      = spApp2 vm           Atan2 topF2 a b
+spA vm (_ :& Operator           Atan2 :@ a :@ b)      = spApp2 vm           Atan2 topF2 a b
 
 -- | Save
-spApp vm (Operator            Save :@ a)           = spApp1 vm            Save id a
+spA vm (_ :& Operator            Save :@ a)           = spApp1 vm            Save id a
 
 -- PropSize
-spApp vm (Operator    (PropSize f) :@ a :@ b)      = spApp2 vm    (PropSize f) (\ s t -> unEqBox f s /\ t) a b
+spA vm (_ :& Operator    (PropSize f) :@ a :@ b)      = spApp2 vm    (PropSize f) (\ s t -> unEqBox f s /\ t) a b
 
 -- | Switch
-spApp vm (Operator          Switch :@ a)           = spApp1 vm          Switch id a
+spA vm (_ :& Operator          Switch :@ a)           = spApp1 vm          Switch id a
 
 -- | Tuple
-spApp vm (Operator Tup0) = Info bot :& Operator Tup0
+spA vm (_ :& Operator Tup0) = Info bot :& Operator Tup0
 
-spApp vm (Operator Tup2 :@ a :@ b)
+spA vm (_ :& Operator Tup2 :@ a :@ b)
   = Info (s a1, s b1)
     :& Operator Tup2 :@ a1 :@ b1
   where a1 = spA vm a
         b1 = spA vm b
         s e = exprSize e
 
-spApp vm (Operator Tup3 :@ a :@ b :@ c)
+spA vm (_ :& Operator Tup3 :@ a :@ b :@ c)
   = Info (s a1, s b1, s c1)
     :& Operator Tup3 :@ a1 :@ b1 :@ c1
   where a1 = spA vm a
@@ -274,7 +270,7 @@ spApp vm (Operator Tup3 :@ a :@ b :@ c)
         c1 = spA vm c
         s e = exprSize e
 
-spApp vm (Operator Tup4 :@ a :@ b :@ c :@ d)
+spA vm (_ :& Operator Tup4 :@ a :@ b :@ c :@ d)
   = Info (s a1, s b1, s c1, s d1)
     :& Operator Tup4 :@ a1 :@ b1 :@ c1 :@ d1
   where a1 = spA vm a
@@ -283,7 +279,7 @@ spApp vm (Operator Tup4 :@ a :@ b :@ c :@ d)
         d1 = spA vm d
         s e = exprSize e
 
-spApp vm (Operator Tup5 :@ a :@ b :@ c :@ d :@ e)
+spA vm (_ :& Operator Tup5 :@ a :@ b :@ c :@ d :@ e)
   = Info (s a1, s b1, s c1, s d1, s e1)
     :& Operator Tup5 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1
   where a1 = spA vm a
@@ -293,7 +289,7 @@ spApp vm (Operator Tup5 :@ a :@ b :@ c :@ d :@ e)
         e1 = spA vm e
         s e = exprSize e
 
-spApp vm (Operator Tup6 :@ a :@ b :@ c :@ d :@ e :@ f)
+spA vm (_ :& Operator Tup6 :@ a :@ b :@ c :@ d :@ e :@ f)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1)
     :& Operator Tup6 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1
   where a1 = spA vm a
@@ -304,7 +300,7 @@ spApp vm (Operator Tup6 :@ a :@ b :@ c :@ d :@ e :@ f)
         f1 = spA vm f
         s e = exprSize e
 
-spApp vm (Operator Tup7 :@ a :@ b :@ c :@ d :@ e :@ f :@ g)
+spA vm (_ :& Operator Tup7 :@ a :@ b :@ c :@ d :@ e :@ f :@ g)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1)
     :& Operator Tup7 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1
   where a1 = spA vm a
@@ -316,7 +312,7 @@ spApp vm (Operator Tup7 :@ a :@ b :@ c :@ d :@ e :@ f :@ g)
         g1 = spA vm g
         s e = exprSize e
 
-spApp vm (Operator Tup8 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h)
+spA vm (_ :& Operator Tup8 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1)
     :& Operator Tup8 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1
   where a1 = spA vm a
@@ -329,7 +325,7 @@ spApp vm (Operator Tup8 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h)
         h1 = spA vm h
         s e = exprSize e
 
-spApp vm (Operator Tup9 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i)
+spA vm (_ :& Operator Tup9 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1)
     :& Operator Tup9 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1
   where a1 = spA vm a
@@ -343,7 +339,7 @@ spApp vm (Operator Tup9 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i)
         i1 = spA vm i
         s e = exprSize e
 
-spApp vm (Operator Tup10 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j)
+spA vm (_ :& Operator Tup10 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1, s j1)
     :& Operator Tup10 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1 :@ j1
   where a1 = spA vm a
@@ -358,7 +354,7 @@ spApp vm (Operator Tup10 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j)
         j1 = spA vm j
         s e = exprSize e
 
-spApp vm (Operator Tup11 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k)
+spA vm (_ :& Operator Tup11 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1, s j1, s k1)
     :& Operator Tup11 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1 :@ j1 :@ k1
   where a1 = spA vm a
@@ -374,7 +370,7 @@ spApp vm (Operator Tup11 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k)
         k1 = spA vm k
         s e = exprSize e
 
-spApp vm (Operator Tup12 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l)
+spA vm (_ :& Operator Tup12 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1, s j1, s k1, s l1)
     :& Operator Tup12 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1 :@ j1 :@ k1 :@ l1
   where a1 = spA vm a
@@ -391,7 +387,7 @@ spApp vm (Operator Tup12 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k 
         l1 = spA vm l
         s e = exprSize e
 
-spApp vm (Operator Tup13 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l :@ m)
+spA vm (_ :& Operator Tup13 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l :@ m)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1, s j1, s k1, s l1, s m1)
     :& Operator Tup13 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1 :@ j1 :@ k1 :@ l1 :@ m1
   where a1 = spA vm a
@@ -409,7 +405,7 @@ spApp vm (Operator Tup13 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k 
         m1 = spA vm m
         s e = exprSize e
 
-spApp vm (Operator Tup14 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l :@ m :@ n)
+spA vm (_ :& Operator Tup14 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l :@ m :@ n)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1, s j1, s k1, s l1, s m1, s n1)
     :& Operator Tup14 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1 :@ j1 :@ k1 :@ l1 :@ m1 :@ n1
   where a1 = spA vm a
@@ -428,7 +424,7 @@ spApp vm (Operator Tup14 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k 
         n1 = spA vm n
         s e = exprSize e
 
-spApp vm (Operator Tup15 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l :@ m :@ n :@ o)
+spA vm (_ :& Operator Tup15 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k :@ l :@ m :@ n :@ o)
   = Info (s a1, s b1, s c1, s d1, s e1, s f1, s g1, s h1, s i1, s j1, s k1, s l1, s m1, s n1, s o1)
     :& Operator Tup15 :@ a1 :@ b1 :@ c1 :@ d1 :@ e1 :@ f1 :@ g1 :@ h1 :@ i1 :@ j1 :@ k1 :@ l1 :@ m1 :@ n1 :@ o1
   where a1 = spA vm a
@@ -448,35 +444,35 @@ spApp vm (Operator Tup15 :@ a :@ b :@ c :@ d :@ e :@ f :@ g :@ h :@ i :@ j :@ k 
         o1 = spA vm o
         s e = exprSize e
 
-spApp vm (Operator            Sel1 :@ a)           = spApp1 vm            Sel1 sel1 a
-spApp vm (Operator            Sel2 :@ a)           = spApp1 vm            Sel2 sel2 a
-spApp vm (Operator            Sel3 :@ a)           = spApp1 vm            Sel3 sel3 a
-spApp vm (Operator            Sel4 :@ a)           = spApp1 vm            Sel4 sel4 a
-spApp vm (Operator            Sel5 :@ a)           = spApp1 vm            Sel5 sel5 a
-spApp vm (Operator            Sel6 :@ a)           = spApp1 vm            Sel6 sel6 a
-spApp vm (Operator            Sel7 :@ a)           = spApp1 vm            Sel7 sel7 a
-spApp vm (Operator            Sel8 :@ a)           = spApp1 vm            Sel8 sel8 a
-spApp vm (Operator            Sel9 :@ a)           = spApp1 vm            Sel9 sel9 a
-spApp vm (Operator           Sel10 :@ a)           = spApp1 vm           Sel10 sel10 a
-spApp vm (Operator           Sel11 :@ a)           = spApp1 vm           Sel11 sel11 a
-spApp vm (Operator           Sel12 :@ a)           = spApp1 vm           Sel12 sel12 a
-spApp vm (Operator           Sel13 :@ a)           = spApp1 vm           Sel13 sel13 a
-spApp vm (Operator           Sel14 :@ a)           = spApp1 vm           Sel14 sel14 a
-spApp vm (Operator           Sel15 :@ a)           = spApp1 vm           Sel15 sel15 a
+spA vm (_ :& Operator            Sel1 :@ a)           = spApp1 vm            Sel1 sel1 a
+spA vm (_ :& Operator            Sel2 :@ a)           = spApp1 vm            Sel2 sel2 a
+spA vm (_ :& Operator            Sel3 :@ a)           = spApp1 vm            Sel3 sel3 a
+spA vm (_ :& Operator            Sel4 :@ a)           = spApp1 vm            Sel4 sel4 a
+spA vm (_ :& Operator            Sel5 :@ a)           = spApp1 vm            Sel5 sel5 a
+spA vm (_ :& Operator            Sel6 :@ a)           = spApp1 vm            Sel6 sel6 a
+spA vm (_ :& Operator            Sel7 :@ a)           = spApp1 vm            Sel7 sel7 a
+spA vm (_ :& Operator            Sel8 :@ a)           = spApp1 vm            Sel8 sel8 a
+spA vm (_ :& Operator            Sel9 :@ a)           = spApp1 vm            Sel9 sel9 a
+spA vm (_ :& Operator           Sel10 :@ a)           = spApp1 vm           Sel10 sel10 a
+spA vm (_ :& Operator           Sel11 :@ a)           = spApp1 vm           Sel11 sel11 a
+spA vm (_ :& Operator           Sel12 :@ a)           = spApp1 vm           Sel12 sel12 a
+spA vm (_ :& Operator           Sel13 :@ a)           = spApp1 vm           Sel13 sel13 a
+spA vm (_ :& Operator           Sel14 :@ a)           = spApp1 vm           Sel14 sel14 a
+spA vm (_ :& Operator           Sel15 :@ a)           = spApp1 vm           Sel15 sel15 a
 
 -- | ConditionM
-spApp vm (Operator      ConditionM :@ a :@ b :@ c) = spApp3 vm      ConditionM (const (\/)) a b c
+spA vm (_ :& Operator      ConditionM :@ a :@ b :@ c) = spApp3 vm      ConditionM (const (\/)) a b c
 
 -- | LoopM
-spApp vm (Operator           While :@ a :@ b)      = spApp2 vm           While topF2 a b
-spApp vm (Operator             For :@ a :@ b)      = spApp2 vm             For topF2 a b
+spA vm (_ :& Operator           While :@ a :@ b)      = spApp2 vm           While topF2 a b
+spA vm (_ :& Operator             For :@ a :@ b)      = spApp2 vm             For topF2 a b
 
 -- | Mutable
-spApp vm (Operator          Return :@ a)           = spApp1 vm          Return id a
-spApp vm (Operator            Bind :@ a :@ f)      = i :& Operator Bind :@ a1 :@ f1
+spA vm (_ :& Operator          Return :@ a)           = spApp1 vm          Return id a
+spA vm (_ :& Operator            Bind :@ a :@ f)      = i :& Operator Bind :@ a1 :@ f1
   where (i,a1,f1) = spBind vm a f
-spApp vm (Operator            Then :@ a :@ b)      = spApp2 vm            Then (flip const) a b
-spApp vm (Operator            When :@ a :@ b)      = spApp2 vm            When (\ _ _ -> top) a b
+spA vm (_ :& Operator            Then :@ a :@ b)      = spApp2 vm            Then (flip const) a b
+spA vm (_ :& Operator            When :@ a :@ b)      = spApp2 vm            When (\ _ _ -> top) a b
 
 -- | Help functions
 
@@ -489,24 +485,19 @@ topF2 _ _ = top
 topF3 :: Lattice u => a -> b -> c -> u
 topF3 _ _ _ = top
 
-finalInfo :: (Show (Size a), Lattice (Size a)) => AExpr a -> Size a -> Info a
-finalInfo e s = Info $ exprSize e \/ s
-
 -- | Indexed loops without state (Parallel, EparFor, ...)
-spLoI :: (TypeF u, Show (Size u), Lattice (Size u))
+spLoI :: TypeF u
       => BindEnv -> Op (Length -> (Index -> b) -> u)
       -> (Size Index -> Size b -> Size u)
       -> AExpr Length -> AExpr (Index -> b)
       -> AExpr u
-spLoI vm op f a (_ :& Lambda v e) = Info (f i $ exprSize e1) :& Operator op :@ a1 :@ (funInfo a1 e1 :& Lambda v e1)
+spLoI vm op f a (_ :& Lambda v e) = Info (f i $ exprSize e1) :& Operator op :@ a1 :@ (Info (exprSize a1, exprSize e1) :& Lambda v e1)
   where a1 = spA vm a
         i  = exprSize a1
         e1 = spA (extend vm v $ Info i) e
 
 -- | Helper for binds
-spBind :: (Typeable a, Show (Size a), Lattice (Size a),
-           Show (Size b), Lattice (Size b),
-           Show (Size c), Lattice (Size c), Size a ~ Size b)
+spBind :: (Typeable a, Show (Size c), Lattice (Size c), Size a ~ Size b)
         => BindEnv -> AExpr a -> AExpr (b -> c) -> (Info c, AExpr a, AExpr (b -> c))
 spBind vm a f = (Info bs, a1, f1)
   where a1  = spA vm a
@@ -527,19 +518,18 @@ spLambda2 vm s t (_ :& Lambda v (_ :& Lambda w e)) = (exprSize e1, f1)
 spLambda2 _  _ _ _ = error "SizeProp.spLambda2: not a lambda abstraction."
 
 -- | Nullary applications
-spApp0 :: (TypeF u, Show (Size u), Lattice (Size u))
-       => BindEnv -> Op u -> Size u -> AExpr u
+spApp0 :: TypeF u => BindEnv -> Op u -> Size u -> AExpr u
 spApp0 vm op s = Info s :& Operator op
 
 -- | Unary applications
-spApp1 :: (TypeF a, TypeF u, Show (Size u), Lattice (Size u))
+spApp1 :: (TypeF a, TypeF u)
        => BindEnv -> Op (a -> u) -> (Size a -> Size u) -> AExpr a -> AExpr u
 spApp1 vm op f a = Info (f ai) :& Operator op :@ a1
   where a1 = spA vm a
         ai = infoSize $ aeInfo a1
 
 -- | Binary applications
-spApp2 :: (TypeF a, TypeF b, TypeF u, Show (Size u), Lattice (Size u))
+spApp2 :: (TypeF a, TypeF b, TypeF u)
        => BindEnv -> Op (a -> b -> u) -> (Size a -> Size b -> Size u)
        -> AExpr a -> AExpr b -> AExpr u
 spApp2 vm op f a b = Info (f ai bi) :& Operator op :@ a1 :@ b1
@@ -549,7 +539,7 @@ spApp2 vm op f a b = Info (f ai bi) :& Operator op :@ a1 :@ b1
         bi = infoSize $ aeInfo b1
 
 -- | Ternary applications
-spApp3 :: (TypeF a, TypeF b, TypeF c, TypeF u, Show (Size u), Lattice (Size u))
+spApp3 :: (TypeF a, TypeF b, TypeF c, TypeF u)
        => BindEnv -> Op (a -> b -> c -> u)
        -> (Size a -> Size b -> Size c -> Size u)
        -> AExpr a -> AExpr b -> AExpr c -> AExpr u


### PR DESCRIPTION
Inlining a few functions makes it obvious
to the type checker that some contexts
are present.