### PR TITLE
Remove TypeF from SyntacticFeld

### DIFF
--- a/src/Feldspar/Core/Constructs.hs
+++ b/src/Feldspar/Core/Constructs.hs
@@ -56,7 +56,7 @@ instance Syntactic (Data a)
     desugar = unData
     sugar   = Data
 
-type SyntacticFeld a = (Syntactic a, TypeF (Internal a))
+type SyntacticFeld a = Syntactic a
 
 -- | Specialization of the 'Syntactic' class for first class values (eg not functions)
 class    (SyntacticFeld a, Type (Internal a)) => Syntax a

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -98,7 +98,7 @@ import Data.Hash
 
 import qualified Feldspar.Core.Reify as Syntactic
 import qualified Feldspar.Core.Render as Syntactic
-import Feldspar.Core.Reify hiding (showAST, drawAST, writeHtmlAST, desugar, sugar, resugar)
+import Feldspar.Core.Reify hiding (desugar, sugar, resugar)
 import Feldspar.Core.Eval (evalBind)
 import Feldspar.Core.Render (StringTree, render)
 


### PR DESCRIPTION
This is no longer needed since the TypeF context
has been pushed into the GADTs that need it.