### PR TITLE
Use higher level information for Info

### DIFF
--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -207,11 +207,11 @@ class SugarF a where
 
 instance (Syntactic b, SugarF c) => SugarF (b -> c) where
   type SugarT (b -> c) = Internal b -> SugarT c
-  sugarF f = \ e -> sugarF $ f @@ e
+  sugarF f = sugarF . (@@) f
 
 instance (Syntactic b, TypeF (Internal b)) => SugarF (FFF b) where
   type SugarT (FFF b) = Internal b
-  sugarF (~(m, e),i) = FFF $ sugar $ ASTF (flattenCSE (m, Info top :& e)) i
+  sugarF = FFF . sugar . full
 
 -------------------------------------------------
 -- Converting Haskell values to Feldspar
@@ -228,7 +228,7 @@ type CSEExpr e = (CSEMap, e)
 type CExpr a = CSEExpr (AExpr a)
 
 -- | Convert a CSE map, an Expr and an Int to an ASTF
-full :: T.Type b => (CSEExpr (Expr b), Int) -> ASTF b
+full :: TypeF b => (CSEExpr (Expr b), Int) -> ASTF b
 full (~(m, e), i) = ASTF (flattenCSE (m, Info top :& e)) i
 
 flattenCSE :: CExpr a -> CExpr a

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -107,12 +107,12 @@ type a :-> b = a -> b
 
 -- | The type of information, for instance range information. Currently only size info.
 data Info a where
-  Info :: (Show (Size a), Lattice (Size a)) => {infoSize :: Size a} -> Info a
+  Info :: {infoSize :: Size a} -> Info a
 
-instance Eq (Info a) where
+instance Eq (Size a) => Eq (Info a) where
   Info x == Info y = x == y
 
-instance Show (Info a) where
+instance Show (Size a) => Show (Info a) where
   show (Info x) = show x
 
 -- | Annotated expression, that is, an expression together with extra information,
@@ -470,10 +470,10 @@ data CBind where
   CBind :: Var a -> AExpr a -> CBind
 
 instance Eq CBind where
-  CBind (v1@(Var n1 _) :: Var a) e1 == CBind (v2@(Var n2 _) :: Var b) e2
+  CBind (v1@Var{} :: Var a) e1 == CBind (v2@Var{} :: Var b) e2
       = case eqT :: Maybe (a :~: b) of
           Nothing -> False
-          Just Refl -> n1 == n2 && e1 == e2
+          Just Refl -> v1 == v2 && e1 == e2
 
 instance Show CBind where
   show (CBind v e) = show v ++ " = " ++ show e


### PR DESCRIPTION
The pattern matching in SizeProp now includes enough
context for us to not need the context on "Info a"
so remove the context. Also wiggle some other contexts
to align definitions.