### PR TITLE
Use strict version of Data.Map

### DIFF
--- a/src/Feldspar/Core/Middleend/UniqueVars.hs
+++ b/src/Feldspar/Core/Middleend/UniqueVars.hs
@@ -31,7 +31,7 @@ module Feldspar.Core.Middleend.UniqueVars (uniqueVars) where
 import Feldspar.Core.UntypedRepresentation
 
 import qualified Data.Set as S
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import Control.Monad.State
 
 type U a = State (S.Set VarId) a

--- a/src/Feldspar/Core/SizeProp.hs
+++ b/src/Feldspar/Core/SizeProp.hs
@@ -41,7 +41,7 @@ import Feldspar.Range
 import Feldspar.Lattice (Lattice, top, bot, (\/), (/\))
 
 import Data.Typeable (Typeable)
-import qualified Data.Map as M (empty)
+import qualified Data.Map.Strict as M (empty)
 
 sizeProp :: AExpr a -> AExpr a
 sizeProp = spA M.empty

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -85,7 +85,7 @@ module Feldspar.Core.UntypedRepresentation (
   where
 
 import Control.Monad.State
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 import qualified Data.ByteString.Char8 as B
 import Data.List (nub, intercalate)
 import Data.Tree


### PR DESCRIPTION
These Maps carry variables that we will access
so use the strict version of the map.