### PR TITLE
Add the type of operators to the hash value

### DIFF
--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -136,7 +136,7 @@ showAExpr n (i :& (e :: Expr (Full a))) r = '{':inf ++ "} " ++ showExpr n e r
 -}
 data Expr a where
   Literal  :: (Hashable a, Type a)   => a -> Expr (Full a)
-  Operator ::                           Op a -> Expr a
+  Operator :: Typeable a             => Op a -> Expr a
   Variable ::                           Var a -> Expr (Full a)
   (:@)     :: Typeable a             => Expr (a -> b) -> AExpr a -> Expr b
   Lambda   :: TypeF a                => Var a -> AExpr b -> Expr (Full (a -> b))

--- a/tests/gold/example9.txt
+++ b/tests/gold/example9.txt
@@ -1,6 +1,6 @@
 Lambda v0 : 1xi32
  └╴Let
-    ├╴Var v2 : 1xi32 = 
+    ├╴Var v1 : 1xi32 = 
     │  └╴Add {1xi32 in VIInt32 [*,*]}
     │     ├╴v0 : 1xi32 in VIInt32 [*,*]
     │     └╴20 : 1xi32
@@ -11,7 +11,7 @@ Lambda v0 : 1xi32
           │  └╴5 : 1xi32
           ├╴Mul {1xi32 in VIInt32 [*,*]}
           │  ├╴3 : 1xi32
-          │  └╴v2 : 1xi32 in VIInt32 [*,*]
+          │  └╴v1 : 1xi32 in VIInt32 [*,*]
           └╴Mul {1xi32 in VIInt32 [*,*]}
              ├╴30 : 1xi32
-             └╴v2 : 1xi32 in VIInt32 [*,*]
+             └╴v1 : 1xi32 in VIInt32 [*,*]


### PR DESCRIPTION
This avoids hashing F2I and other conversion
operators to the same hash value. This is
a step towards reducing the need for TypeF.