### PR TITLE
Hash type into leaves in Reify

### DIFF
--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -286,16 +286,19 @@ catchBindings vs (m,e) = (m1, mkLets (bs,e))
 -}
 
 hashExpr :: AExpr a -> VarId
-hashExpr (_ :& (e :: Expr a)) = (hash2VarId $ hash (typeRepF :: T.TypeRep a)) `combineHash` hashExprR e
+hashExpr (_ :& e) = hashExprR e
 
 hashExprR :: Expr a -> VarId
-hashExprR (Variable v) = varNum v
-hashExprR (Literal c) = hash2VarId $ hash c
+hashExprR (Variable v) = (hashStr . show $ typeOf v) `combineHash` (varNum v)
+hashExprR (Literal c)
+  = (hashStr . show $ typeOf c) `combineHash` (hash2VarId $ hash c)
 hashExprR (Operator op) = hashOp op
 -- Hash value of rhs in let is equal to bound variable name which occurs in body
 hashExprR (Operator Let :@ _ :@ (_ :& Lambda _ e)) = hashExpr e
 hashExprR (f :@ e) = appHash `combineHash` hashExprR f `combineHash` hashExpr e
-hashExprR (Lambda v e) = absHash `combineHash` varNum v `combineHash` hashExpr e
+hashExprR (Lambda v e)
+  = absHash `combineHash` (hashStr . show $ typeOf v) `combineHash`
+    (varNum v) `combineHash` hashExpr e
 
 hashStr :: String -> VarId
 hashStr s = fromInteger $ foldr combineHash 5 $ map (toInteger . fromEnum) s

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -137,7 +137,7 @@ showAExpr n (i :& (e :: Expr (Full a))) r = '{':inf ++ "} " ++ showExpr n e r
 data Expr a where
   Literal  :: (Hashable a, Type a)   => a -> Expr (Full a)
   Operator :: Typeable a             => Op a -> Expr a
-  Variable ::                           Var a -> Expr (Full a)
+  Variable :: Typeable a             => Var a -> Expr (Full a)
   (:@)     :: Typeable a             => Expr (a -> b) -> AExpr a -> Expr b
   Lambda   :: TypeF a                => Var a -> AExpr b -> Expr (Full (a -> b))
 

--- a/tests/gold/example9.txt
+++ b/tests/gold/example9.txt
@@ -1,6 +1,6 @@
 Lambda v0 : 1xi32
  └╴Let
-    ├╴Var v1 : 1xi32 = 
+    ├╴Var v2 : 1xi32 = 
     │  └╴Add {1xi32 in VIInt32 [*,*]}
     │     ├╴v0 : 1xi32 in VIInt32 [*,*]
     │     └╴20 : 1xi32
@@ -11,7 +11,7 @@ Lambda v0 : 1xi32
           │  └╴5 : 1xi32
           ├╴Mul {1xi32 in VIInt32 [*,*]}
           │  ├╴3 : 1xi32
-          │  └╴v1 : 1xi32 in VIInt32 [*,*]
+          │  └╴v2 : 1xi32 in VIInt32 [*,*]
           └╴Mul {1xi32 in VIInt32 [*,*]}
              ├╴30 : 1xi32
-             └╴v1 : 1xi32 in VIInt32 [*,*]
+             └╴v2 : 1xi32 in VIInt32 [*,*]


### PR DESCRIPTION
This switches the reification machinery
to hashing the types of leaves using Typeable.
This eliminates the need for TypeF for those
parts of Feldspar.