### PR TITLE
Remove deriving Typeable, NFC

### DIFF
--- a/src/Feldspar/Core/NestedTuples.hs
+++ b/src/Feldspar/Core/NestedTuples.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -55,8 +54,6 @@ data TNil
 data RTuple a where
   (:*) :: a -> RTuple b -> RTuple (a :* b)
   TNil :: RTuple TNil
-
-deriving instance Typeable RTuple -- Not necessary with newer versions of GHC
 
 -- | Eq and Show instances
 

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -5,8 +5,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -229,8 +227,6 @@ instance MonadType Mut
 -- | Monad for parallel constructs
 type Par = MonadPar.Par
 
-deriving instance Typeable Par
-
 -- | Immutable references
 type IV = MonadPar.IVar
 
@@ -248,8 +244,6 @@ instance MonadType Par
 
 newtype Elements a = Elements { unE :: [(Index, a)] }
 
-deriving instance Typeable Elements
-
 instance Show a => Show (Elements a)
   where
     show (Elements a) = "Elements " ++ show a
@@ -263,9 +257,6 @@ instance Eq a => Eq (Elements a)
 --------------------------------------------------------------------------------
 
 newtype FVal a = FVal {unFVal :: a}
-
-deriving instance Typeable IV
-deriving instance Typeable FVal
 
 instance Show (FVal a)
   where

--- a/src/Feldspar/Range.hs
+++ b/src/Feldspar/Range.hs
@@ -42,7 +42,6 @@ module Feldspar.Range where
 import qualified Data.Array.IO as IO
 import Data.Bits
 import Data.Int
-import Data.Typeable (Typeable)
 import Data.Word
 import Data.Default
 import Data.Hash
@@ -81,7 +80,7 @@ instance (Show a, Bounded a, Eq a) => Show (Range a)
 -- | Target-dependent unsigned integers
 newtype WordN = WordN Word32
   deriving
-    ( Eq, Ord, Num, Enum, IO.Ix, Real, Integral, Bits, Bounded, Typeable
+    ( Eq, Ord, Num, Enum, IO.Ix, Real, Integral, Bits, Bounded
     , Q.Arbitrary, Random, Storable, NFData, Default
     , FiniteBits, Hashable
     )
@@ -89,7 +88,7 @@ newtype WordN = WordN Word32
 -- | Target-dependent signed integers
 newtype IntN = IntN Int32
   deriving
-    ( Eq, Ord, Num, Enum, IO.Ix, Real, Integral, Bits, Bounded, Typeable
+    ( Eq, Ord, Num, Enum, IO.Ix, Real, Integral, Bits, Bounded
     , Q.Arbitrary, Random, Storable, NFData, Default
     , FiniteBits, Hashable
     )


### PR DESCRIPTION
This is automatic for all data types since GHC 7.10
according to the documentation so remove the derives.