### PR TITLE
Revert "Derive Lift instances"

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -95,7 +95,6 @@ library
     QuickCheck                  >= 2.7    && < 3,
     patch-combinators           >= 0.2    && < 0.3,
     prelude-edsl                             < 0.4,
-    template-haskell,
     tuple                       >= 0.2    && < 0.5,
     monad-par                   >= 0.3.4.5,
     deepseq,

--- a/src/Feldspar/Core/Interpretation.hs
+++ b/src/Feldspar/Core/Interpretation.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveLift #-}
-
 --
 -- Copyright (c) 2009-2011, ERICSSON AB
 -- All rights reserved.
@@ -33,16 +31,14 @@
 
 module Feldspar.Core.Interpretation where
 
-import Language.Haskell.TH.Syntax (Lift(..))
-
 -- | Possible compilation targets in a broad sense.
 data Target = RegionInf | Wool | CSE | SICS | BA
-  deriving (Eq, Lift)
+  deriving Eq
 
 -- | A record with options for explicit passing in rewrite rules.
 data FeldOpts = FeldOpts
     { targets    :: [Target]
-    } deriving Lift
+    }
 
 -- | Default options.
 defaultFeldOpts :: FeldOpts

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -92,7 +91,6 @@ import Data.List (nub, intercalate)
 import Data.Tree
 import Data.Int
 import Data.Word
-import Language.Haskell.TH.Syntax (Lift(..))
 
 import Feldspar.Core.Representation (VarId(..))
 
@@ -158,10 +156,10 @@ dropAnnotation (AIn _ e) = e
 
 data Size = S8 | S16 | S32 | S40 | S64
           | S128 -- Used by SICS.
-    deriving (Eq,Show,Enum,Ord,Lift)
+    deriving (Eq,Show,Enum,Ord)
 
 data Signedness = Signed | Unsigned
-    deriving (Eq,Show,Enum,Lift)
+    deriving (Eq,Show,Enum)
 
 data Fork = None | Future | Par | Loop
     deriving (Eq,Show)


### PR DESCRIPTION
Reverts Feldspar/feldspar-language#310

This breaks feldspar-compiler, revert for now.