### PR TITLE
Remove UnTup and stop exposing car/cdr

### DIFF
--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -788,10 +788,10 @@ class SyntacticTup a where
     desugarTup :: RTuple a -> ASTF (RTuple (InternalTup a))
     sugarTup   :: ASTF (RTuple (InternalTup a)) -> RTuple a
 
-instance (Type (Internal a), Type (RTuple (InternalTup b)), Syntactic a, SyntacticTup b, Typeable (InternalTup b))
+instance (Syntax a, Type (RTuple (InternalTup b)), SyntacticTup b, Typeable (InternalTup b))
          => SyntacticTup (a :* b) where
     type InternalTup (a :* b) = Internal a :* InternalTup b
-    desugarTup (x :* xs) = sugarSym2 Cons x xs
+    desugarTup (x :* xs) = sugarSym2 Cons x (desugarTup xs)
     sugarTup e = sugar (sugarSym1 Car e) :* sugarTup (sugarSym1 Cdr e)
 
 instance SyntacticTup TNil where
@@ -799,27 +799,10 @@ instance SyntacticTup TNil where
     desugarTup TNil = sugarSym0 Nil
     sugarTup _ = TNil
 
-instance SyntacticTup a => Syntactic (RTuple a) where
-    type Internal (RTuple a) = RTuple (InternalTup a)
-    desugar = desugarTup
-    sugar = sugarTup
-
-car :: (Syntax a, SyntacticTup b, Type (RTuple (InternalTup b)), Typeable (InternalTup b))
-    => RTuple (a :* b) -> a
-car = sugarSym1 Car
-
-cdr :: (Syntax a, SyntacticTup b, Type (RTuple (InternalTup b)), Typeable (InternalTup b))
-    => RTuple (a :* b) -> RTuple b
-cdr = sugarSym1 Cdr
-
-instance (P.Eq (Tuple (InternalTup a)),
-          Type (RTuple (InternalTup a)),
-          Type (InternalTup a),
-          SyntacticTup a)
-      => Syntactic (Tuple a) where
-    type Internal (Tuple a) = Tuple (InternalTup a)
-    desugar (Tuple x) = sugarSym1 Tup x
-    sugar e = Tuple $ sugar $ sugarSym1 UnTup e
+instance SyntacticTup a => Syntactic (Tuple a) where
+    type Internal (Tuple a) = RTuple (InternalTup a)
+    desugar = desugarTup . unTup
+    sugar = Tuple . sugarTup
 
 --------------------------------------------------
 -- NoInline.hs

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -121,8 +121,6 @@ toU (((R.Info i) :: R.Info a) :& e)
            R.Operator R.Tup ->
              case toU a of
               AIn _ e' -> e'
-           R.Operator R.UnTup ->
-             let e' = toU a in App (Drop 0) (typeof e') [e']
            _ -> case go e [] of
                  (op, es) ->
                    App op (untypeType tr i) es

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -325,7 +325,6 @@ data Op a where
     Car   :: Type a => Op (RTuple (a :* b) :-> Full a)
     Cdr   ::           Op (RTuple (a :* b) :-> Full (RTuple b))
     Tup   ::           Op (RTuple a :-> Full (Tuple a))
-    UnTup ::           Op (Tuple a :-> Full (RTuple a))
 
     -- | NoInline
     NoInline :: Type a => Op (a :-> Full a)
@@ -542,7 +541,6 @@ shOp ModRef    = False
 shOp Cons      = False
 shOp Nil       = False
 shOp Cdr       = False
-shOp UnTup     = False
 -- Everything else
 shOp _ = True
 

--- a/src/Feldspar/Core/Semantics.hs
+++ b/src/Feldspar/Core/Semantics.hs
@@ -213,7 +213,6 @@ semantics Nil   = Sem "nil"   TNil
 semantics Car   = Sem "car"   (\ (x :* _) -> x)
 semantics Cdr   = Sem "cdr"   (\ (_ :* y) -> y)
 semantics Tup   = Sem "tup"   Tuple
-semantics UnTup = Sem "untup" unTup
 -- Feldspar.Core.Constructs.NoInline
 semantics NoInline  = Sem "NoInline" id
 -- Feldspar.Core.Constructs.Num

--- a/src/Feldspar/Core/SizeProp.hs
+++ b/src/Feldspar/Core/SizeProp.hs
@@ -368,9 +368,6 @@ spA vm (_ :& Operator             Cdr :@ a)
 spA vm (_ :& Operator             Tup :@ a)
   | a1@(Info ai1 :& _) <- spA vm a
   = Info ai1 :& Operator Tup :@ a1
-spA vm (_ :& Operator           UnTup :@ a)
-  | a1@(Info ai1 :& _) <- spA vm a
-  = Info ai1 :& Operator UnTup :@ a1
 
 -- | NoInline
 spA vm (_ :& Operator        NoInline :@ a)


### PR DESCRIPTION
This removes the UnTup constructor and makes
"sel" the only way to select components
on nested tuples.