### PR TITLE
Implement toTarget for Complex a

### DIFF
--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -803,7 +803,7 @@ instance (Type a, RealFloat a) => Type (Complex a)
   where
     typeRep             = ComplexType typeRep
     sizeOf _            = AnySize
-    toTarget _ (_ :+ _) = error "TODO" -- toTarget n r :+ toTarget n i
+    toTarget n (r :+ i) = toTarget n r :+ toTarget n i
 
 instance Type a => Type [a]
   where


### PR DESCRIPTION
The implementation came commented out with
the initial import in 2012. Re-enable the
commented out implementation.