### PR TITLE
Make Word32 the UnsignedRep of Int32

### DIFF
--- a/src/Feldspar/Range.hs
+++ b/src/Feldspar/Range.hs
@@ -113,7 +113,7 @@ type family UnsignedRep a where
   UnsignedRep Word8  = Word8
   UnsignedRep Int16  = Word16
   UnsignedRep Word16 = Word16
-  UnsignedRep Int32  = Int32
+  UnsignedRep Int32  = Word32
   UnsignedRep Word32 = Word32
   UnsignedRep Int64  = Word64
   UnsignedRep Word64 = Word64


### PR DESCRIPTION
The range tests hang when testing prop_or on Int32
so make Word32 the unsigned representation of Int32.
This aligns the definition of Int32 with the other
signed types in UnsignedRep.