### PR TITLE
Use lifted list constructors for Tuple

### DIFF
--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -1398,21 +1398,17 @@ instance ( Syntactic a
 -------------------------------------------------
 
 -- | Convenience wrappers for sugarSym
-sugarSym0 :: (Syntactic a, TypeF (Internal a)) => Op (Internal a) -> a
+sugarSym0 :: Syntax a => Op (Internal a) -> a
 sugarSym0 op         = unFull $ sugarSym op
-sugarSym1
-  :: (TypeF (Internal a), TypeF (Internal b), Syntactic a, Syntactic b)
-  => Op (Internal a -> Internal b) -> a -> b
+sugarSym1 :: (TypeF (Internal a), Syntactic a, Syntax b)
+          => Op (Internal a -> Internal b) -> a -> b
 sugarSym1 op a       = unFull $ sugarSym op a
-sugarSym2
-  :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
-      Syntactic a, Syntactic b, Syntactic c) =>
-     Op (Internal a -> Internal b -> Internal c) -> a -> b -> c
+sugarSym2 :: (TypeF (Internal a), TypeF (Internal b),
+              Syntactic a, Syntactic b, Syntax c)
+          => Op (Internal a -> Internal b -> Internal c) -> a -> b -> c
 sugarSym2 op a b     = unFull $ sugarSym op a b
-sugarSym3
-  :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
-      TypeF (Internal d), Syntactic a, Syntactic b, Syntactic c,
-      Syntactic d) =>
-     Op (Internal a -> Internal b -> Internal c -> Internal d)
-     -> a -> b -> c -> d
+sugarSym3 :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
+              Syntactic a, Syntactic b, Syntactic c, Syntax d)
+          => Op (Internal a -> Internal b -> Internal c -> Internal d)
+             -> a -> b -> c -> d
 sugarSym3 op a b c   = unFull $ sugarSym op a b c

--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -783,7 +784,7 @@ thawArray arr = do
 --------------------------------------------------
 
 class SyntacticTup a where
-    type InternalTup a
+    type InternalTup a :: [*]
     desugarTup :: Tuple a -> ASTF (Tuple (InternalTup a))
     sugarTup   :: ASTF (Tuple (InternalTup a)) -> Tuple a
 
@@ -792,13 +793,13 @@ class SyntacticTup a where
 -- The test case 'noshare' in the 'decoration' suite checks that tails are not shared.
 
 instance (Syntax a, Type (Tuple (InternalTup b)), SyntacticTup b, Typeable (InternalTup b))
-         => SyntacticTup (a :* b) where
-    type InternalTup (a :* b) = Internal a :* InternalTup b
+         => SyntacticTup (a ': b) where
+    type InternalTup (a ': b) = Internal a ': InternalTup b
     desugarTup (x :* xs) = sugarSym2 Cons x (desugarTup xs)
     sugarTup e = sugar (sugarSym1 Car e) :* sugarTup (sugarSym1 Cdr e)
 
-instance SyntacticTup TNil where
-    type InternalTup TNil = TNil
+instance SyntacticTup '[] where
+    type InternalTup '[] = '[]
     desugarTup TNil = sugarSym0 Nil
     sugarTup _ = TNil
 

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -338,10 +339,10 @@ instance HashTup a => Hashable (Tuple a) where
 class HashTup a where
   hashTup :: Tuple a -> Hash
 
-instance HashTup TNil where
+instance HashTup '[] where
   hashTup _ = hashInt 1
 
-instance (Hashable h, HashTup t) => HashTup (h :* t) where
+instance (Hashable h, HashTup t) => HashTup (h ': t) where
   hashTup (x :* xs) = hashInt 2 # x # xs
 
 infixl 5 #

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -204,7 +204,7 @@ instance (Syntactic b, SugarF c) => SugarF (b -> c) where
   sugarF f@(cf,i) = sugarF . go . desugar
     where go (ASTF ce j) = (applyCSE cf ce, max i j)
 
-instance (Syntactic b, TypeF (Internal b)) => SugarF (FFF b) where
+instance Syntax b => SugarF (FFF b) where
   type SugarT (FFF b) = Internal b
   sugarF = FFF . sugar . full
 
@@ -223,7 +223,7 @@ type CSEExpr e = (CSEMap, e)
 type CExpr a = CSEExpr (AExpr a)
 
 -- | Convert a CSE map, an Expr and an Int to an ASTF
-full :: TypeF b => (CSEExpr (Expr b), Int) -> ASTF b
+full :: T.Type b => (CSEExpr (Expr b), Int) -> ASTF b
 full (~(m, e), i) = ASTF (flattenCSE (m, Info top :& e)) i
 
 flattenCSE :: CExpr a -> CExpr a

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
 --
@@ -62,7 +63,8 @@ module Feldspar.Core.Representation
   ) where
 
 import Feldspar.Core.Types (Type(..), TypeF(..), TypeRep(..), Length, Index, IntN,
-                            Size(..), Elements, FVal, Mut, AnySize, MArr, Par, IV, Tuple(..), (:*), TNil)
+                            Size(..), Elements, FVal, Mut, AnySize, MArr, Par,
+                            IV, Tuple(..))
 import Feldspar.Range (Range, BoundedInt)
 
 import qualified Data.ByteString.Char8 as B
@@ -319,10 +321,10 @@ data Op a where
     ModRef :: Type a => Op (IORef a :-> (a -> a) :-> Full (Mut ()))
 
     -- | Nested tuples
-    Cons  :: Type a => Op (a :-> Tuple b :-> Full (Tuple (a :* b)))
-    Nil   ::           Op (Full (Tuple TNil))
-    Car   :: Type a => Op (Tuple (a :* b) :-> Full a)
-    Cdr   ::           Op (Tuple (a :* b) :-> Full (Tuple b))
+    Cons  :: Type a => Op (a :-> Tuple b :-> Full (Tuple (a ': b)))
+    Nil   ::           Op (Full (Tuple '[]))
+    Car   :: Type a => Op (Tuple (a ': b) :-> Full a)
+    Cdr   ::           Op (Tuple (a ': b) :-> Full (Tuple b))
     Tup   ::           Op (Tuple a :-> Full (Tuple a))
 
     -- | NoInline

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -40,7 +41,7 @@
 module Feldspar.Core.Types
        ( module Feldspar.Core.Types
        , IntN(..), WordN(..)
-       , Tuple(..), (:*), TNil -- From NestedTuples
+       , Tuple(..) -- From NestedTuples
        ) where
 
 
@@ -270,8 +271,8 @@ data TypeRep a
     MArrType      :: TypeRep a -> TypeRep (MArr a)
     ParType       :: TypeRep a -> TypeRep (Par a)
     ElementsType  :: TypeRep a -> TypeRep (Elements a)
-    ConsType      :: TypeRep a -> TypeRep (Tuple b) -> TypeRep (Tuple (a :* b))
-    NilType       :: TypeRep (Tuple TNil)
+    ConsType      :: TypeRep a -> TypeRep (Tuple b) -> TypeRep (Tuple (a ': b))
+    NilType       :: TypeRep (Tuple '[])
     IVarType      :: TypeRep a -> TypeRep (IV a)
     FValType      :: TypeRep a -> TypeRep (FVal a)
       -- TODO `MArrType` Should have a target-specialized version. Or perhaps
@@ -742,12 +743,12 @@ instance Type a => Type (Elements a)
 
     sizeOf _ = universal
 
-instance (Type a, Typeable b, Type (Tuple b)) => Type (Tuple (a :* b))
+instance (Type a, Typeable b, Type (Tuple b)) => Type (Tuple (a ': b))
   where
     typeRep = ConsType typeRep typeRep
     sizeOf (x :* xs) = (sizeOf x, sizeOf xs)
 
-instance Type (Tuple TNil)
+instance Type (Tuple '[])
   where
     typeRep = NilType
     sizeOf _ = universal
@@ -843,8 +844,8 @@ type family Size a where
   Size (MArr a)        = Range Length :> Size a
   Size (Par a)         = Size a
   Size (Elements a)    = Range Length :> Size a
-  Size (Tuple (a :* b)) = (Size a, Size (Tuple b))
-  Size (Tuple TNil)   = Size ()
+  Size (Tuple (a ': b)) = (Size a, Size (Tuple b))
+  Size (Tuple '[])     = Size ()
   Size (IV a)          = Size a
   Size (FVal a)        = Size a
 

--- a/tests/DecorationTests.hs
+++ b/tests/DecorationTests.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeOperators #-}
+
 module Main where
 
 -- To generate the golden files use a script similiar to this one
@@ -45,13 +47,13 @@ trickySharing x = (a+b+c) + (a+b) + (a+b+c)
     c = x*7
 
 -- We want no sharing between the two tuples in the result although they have a common tail
-noshareT :: (Tuple (Data Length :* Data Length :* TNil)
-           , Tuple (Data Length :* Data Length :* TNil))
+noshareT :: (Tuple '[Data Length, Data Length]
+           , Tuple '[Data Length, Data Length])
 noshareT = let two = 2 in (build $ tuple 1 two, build $ tuple 3 two)
 
 -- We want sharing between the two tuples in the result since they are identical
-shareT :: (Tuple (Data Length :* Data Length :* TNil)
-         , Tuple (Data Length :* Data Length :* TNil))
+shareT :: (Tuple '[Data Length, Data Length]
+         , Tuple '[Data Length, Data Length])
 shareT = (build $ tuple 1 2, build $ tuple 1 2)
 
 selectT :: Data Length
@@ -80,4 +82,3 @@ tests = testGroup "DecorationTests"
     ]
 
 main = defaultMain $ testGroup "Tests" [tests]
-


### PR DESCRIPTION
This reduces namespace pollution and gives
the more convenient list syntax with
a tick (') for specifying the type of tuples.