### PR TITLE
Require result of sugarSymN to be in Type

### DIFF
--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -1397,21 +1397,17 @@ instance ( Syntactic a
 -------------------------------------------------
 
 -- | Convenience wrappers for sugarSym
-sugarSym0 :: (Syntactic a, TypeF (Internal a)) => Op (Internal a) -> a
+sugarSym0 :: Syntax a => Op (Internal a) -> a
 sugarSym0 op         = unFull $ sugarSym op
-sugarSym1
-  :: (TypeF (Internal a), TypeF (Internal b), Syntactic a, Syntactic b)
-  => Op (Internal a -> Internal b) -> a -> b
+sugarSym1 :: (TypeF (Internal a), Syntactic a, Syntax b)
+          => Op (Internal a -> Internal b) -> a -> b
 sugarSym1 op a       = unFull $ sugarSym op a
-sugarSym2
-  :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
-      Syntactic a, Syntactic b, Syntactic c) =>
-     Op (Internal a -> Internal b -> Internal c) -> a -> b -> c
+sugarSym2 :: (TypeF (Internal a), TypeF (Internal b),
+              Syntactic a, Syntactic b, Syntax c)
+          => Op (Internal a -> Internal b -> Internal c) -> a -> b -> c
 sugarSym2 op a b     = unFull $ sugarSym op a b
-sugarSym3
-  :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
-      TypeF (Internal d), Syntactic a, Syntactic b, Syntactic c,
-      Syntactic d) =>
-     Op (Internal a -> Internal b -> Internal c -> Internal d)
-     -> a -> b -> c -> d
+sugarSym3 :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
+              Syntactic a, Syntactic b, Syntactic c, Syntax d)
+          => Op (Internal a -> Internal b -> Internal c -> Internal d)
+             -> a -> b -> c -> d
 sugarSym3 op a b c   = unFull $ sugarSym op a b c

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -225,7 +225,7 @@ type CExpr a = CSEExpr (AExpr a)
 full :: T.Type b => (CSEExpr (Expr b), Int) -> ASTF b
 full (~(m, e), i) = ASTF (flattenCSE (m, Info top :& e)) i
 
-flattenCSE :: CExpr a -> CExpr a
+flattenCSE :: T.Type a => CExpr a -> CExpr a
 flattenCSE (m,e) | not $ sharable e = (m, e)
 flattenCSE (m,e@(i :& _))
   = mergeMapCExpr (M.singleton (varNum v) (CBind v e)) (m, i :& Variable v)

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -203,7 +203,7 @@ instance (Syntactic b, SugarF c) => SugarF (b -> c) where
   sugarF f@(cf,i) = sugarF . go . desugar
     where go (ASTF ce j) = (applyCSE cf ce, max i j)
 
-instance (Syntactic b, TypeF (Internal b)) => SugarF (FFF b) where
+instance Syntax b => SugarF (FFF b) where
   type SugarT (FFF b) = Internal b
   sugarF = FFF . sugar . full
 
@@ -222,7 +222,7 @@ type CSEExpr e = (CSEMap, e)
 type CExpr a = CSEExpr (AExpr a)
 
 -- | Convert a CSE map, an Expr and an Int to an ASTF
-full :: TypeF b => (CSEExpr (Expr b), Int) -> ASTF b
+full :: T.Type b => (CSEExpr (Expr b), Int) -> ASTF b
 full (~(m, e), i) = ASTF (flattenCSE (m, Info top :& e)) i
 
 flattenCSE :: CExpr a -> CExpr a

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -138,7 +138,7 @@ data Expr a where
   Operator :: Typeable a             => Op a -> Expr a
   Variable :: Typeable a             => Var a -> Expr (Full a)
   (:@)     :: Typeable a             => Expr (a -> b) -> AExpr a -> Expr b
-  Lambda   :: TypeF a                => Var a -> AExpr b -> Expr (Full (a -> b))
+  Lambda   :: Type a                 => Var a -> AExpr b -> Expr (Full (a -> b))
 
 instance Show (Expr a) where
   show e = showExpr 0 e ""
@@ -462,7 +462,7 @@ viSet v = S.singleton $ varNum v
 
 
 data CBind where
-  CBind :: Typeable a => Var a -> AExpr a -> CBind
+  CBind :: Type a => Var a -> AExpr a -> CBind
 
 instance Eq CBind where
   CBind (v1@Var{} :: Var a) e1 == CBind (v2@Var{} :: Var b) e2


### PR DESCRIPTION
This enforces the result to be a first-order type.