### PR TITLE
Weaken context for sugarSymN

### DIFF
--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -1399,14 +1399,14 @@ instance ( Syntactic a
 -- | Convenience wrappers for sugarSym
 sugarSym0 :: Syntax a => Op (Internal a) -> a
 sugarSym0 op         = unFull $ sugarSym op
-sugarSym1 :: (TypeF (Internal a), Syntactic a, Syntax b)
+sugarSym1 :: (Typeable (Internal a), Syntactic a, Syntax b)
           => Op (Internal a -> Internal b) -> a -> b
 sugarSym1 op a       = unFull $ sugarSym op a
-sugarSym2 :: (TypeF (Internal a), TypeF (Internal b),
+sugarSym2 :: (Typeable (Internal a), Typeable (Internal b),
               Syntactic a, Syntactic b, Syntax c)
           => Op (Internal a -> Internal b -> Internal c) -> a -> b -> c
 sugarSym2 op a b     = unFull $ sugarSym op a b
-sugarSym3 :: (TypeF (Internal a), TypeF (Internal b), TypeF (Internal c),
+sugarSym3 :: (Typeable (Internal a), Typeable (Internal b), Typeable (Internal c),
               Syntactic a, Syntactic b, Syntactic c, Syntax d)
           => Op (Internal a -> Internal b -> Internal c -> Internal d)
              -> a -> b -> c -> d


### PR DESCRIPTION
The sugarSymN functions only need Typeable
for their arguments after the latest round
of changes to tuples.