### PR TITLE
cabal: Remove base-orphans package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: c
 
 cache:

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -86,7 +86,6 @@ library
   build-depends:
     array,
     base                        >= 4      && < 5.9,
-    base-orphans,
     bytestring                  >= 0.10   && < 0.11,
     containers                  >= 0.4    && < 0.7,
     comonad                     >= 4.2    && < 6.0,

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -85,7 +85,7 @@ library
 
   build-depends:
     array,
-    base                        >= 4      && < 5.9,
+    base                        >= 4.9.1  && < 5.9,
     bytestring                  >= 0.10   && < 0.11,
     containers                  >= 0.4    && < 0.7,
     comonad                     >= 4.2    && < 6.0,


### PR DESCRIPTION
This is not required with GHC 7.10 and later.