### PR TITLE
cabal: run tests in parallel

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -126,6 +126,8 @@ test-suite range
     tasty            >= 0.3,
     tasty-quickcheck >= 0.2
 
+  ghc-options: -threaded -with-rtsopts=-maxN4
+
 test-suite semantics
   type: exitcode-stdio-1.0
 
@@ -150,6 +152,8 @@ test-suite semantics
     tasty-th         >= 0.1,
     tasty-quickcheck >= 0.2
 
+  ghc-options: -threaded -with-rtsopts=-maxN4
+
 test-suite decoration
   type: exitcode-stdio-1.0
 
@@ -172,6 +176,8 @@ test-suite decoration
     tasty-golden          >= 2.3,
     utf8-string           >= 0.3.7
 
+  ghc-options: -threaded -with-rtsopts=-maxN4
+
 test-suite tutorial
   type: exitcode-stdio-1.0
 
@@ -193,3 +199,5 @@ test-suite tutorial
     feldspar-language,
     base,
     bytestring         >= 0.9 && < 0.11
+
+  ghc-options: -threaded -with-rtsopts=-maxN4


### PR DESCRIPTION
Limit to 4 cores to avoid performance problems
from GHC scalability issues on 16+ core machines.