### PR TITLE
Import the sources of feldspar-compiler

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,11 +1,11 @@
 --
 -- Copyright (c) 2009-2011, ERICSSON AB
 -- All rights reserved.
--- 
+--
 -- Redistribution and use in source and binary forms, with or without
 -- modification, are permitted provided that the following conditions are met:
--- 
---     * Redistributions of source code must retain the above copyright notice, 
+--
+--     * Redistributions of source code must retain the above copyright notice,
 --       this list of conditions and the following disclaimer.
 --     * Redistributions in binary form must reproduce the above copyright
 --       notice, this list of conditions and the following disclaimer in the
@@ -13,10 +13,10 @@
 --     * Neither the name of the ERICSSON AB nor the names of its contributors
 --       may be used to endorse or promote products derived from this software
 --       without specific prior written permission.
--- 
+--
 -- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 -- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
--- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 -- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
 -- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 -- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
@@ -27,5 +27,59 @@
 --
 
 import Distribution.Simple
+import Distribution.Simple.Setup
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Program.Db
+import Distribution.Simple.Program.GHC
+import Distribution.Simple.Program.Builtin
+import Distribution.Simple.Program.Types
+import Distribution.Verbosity (verbose)
+import Distribution.PackageDescription
 
-main = defaultMain
+import System.Process ( readProcessWithExitCode )
+import System.FilePath ( replaceExtension )
+import Control.Monad ( unless )
+
+main = defaultMainWithHooks simpleUserHooks{ buildHook = buildH }
+
+-- | Custom build hook that builds C-sources for benchmarks with x-cc-name set.
+buildH :: PackageDescription -> LocalBuildInfo -> UserHooks -> BuildFlags -> IO ()
+buildH pd lbi user_hooks flags = do
+    benchmarks' <- mapM (checkIfAndCompile lbi) $ benchmarks pd
+    -- Build the remaining things the regular way.
+    buildHook simpleUserHooks pd{ benchmarks = benchmarks' } lbi user_hooks flags
+    return ()
+
+-- | Checks if x-cc-name is set, and compiles c-sources with that compiler name.
+checkIfAndCompile :: LocalBuildInfo -> Benchmark -> IO Benchmark
+checkIfAndCompile lbi bench = do
+    let bench_bi  = benchmarkBuildInfo bench
+    case lookup "x-cc-name" $ customFieldsBI bench_bi of
+        Nothing -> return bench
+        Just cc_name  -> do
+            let c_srcs    = cSources bench_bi
+                cc_opts   = ccOptions bench_bi
+                inc_dirs  = includeDirs bench_bi
+            -- Compile C/C++ sources
+            putStrLn "Invoking icc compiler"
+            mapM_ (compile lbi bench cc_name cc_opts inc_dirs) c_srcs
+            -- Remove C source code from the hooked build (don't change libs)
+            return $ bench{ benchmarkBuildInfo = bench_bi{ cSources = [] } }
+
+-- | Compiles a C file with the given options.
+compile :: LocalBuildInfo -> Benchmark -> String -> [String] -> [String] -> FilePath -> IO ()
+compile lbi bench cc_name opts inc_dirs srcfile = do
+    let args = [ "-optc -std=c99"
+               , "-optc -Wall"
+               , "-w"
+               , "-c"
+               , "-pgmc " ++ cc_name
+               ] ++ map ("-optc " ++) opts
+        objfile = replaceExtension srcfile "o"
+        fullargs = args ++ ["-o", objfile, srcfile]
+    (ghcProg,_) <- requireProgram verbose ghcProgram (withPrograms lbi)
+    let ghc = programPath ghcProg
+    print $ unwords $ ["Calling:",ghc] ++ fullargs
+    (_, stdout, stderr) <- readProcessWithExitCode ghc fullargs ""
+    let output = stdout ++ stderr
+    unless (null output) $ putStrLn output

--- a/clib/feldspar_array.h
+++ b/clib/feldspar_array.h
@@ -1,0 +1,104 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef FELDSPAR_ARRAY_H
+#define FELDSPAR_ARRAY_H
+
+#include <stdint.h>
+#include <string.h>
+#include <assert.h>
+#include <stdlib.h>
+//#define LOG
+#include "log.h"
+
+/* This library contains operations on flat arrays, arrays that do not contain
+   (pointers to) other arrays. For non-flat arrays, these array operations are
+   implemented by code generated from the program by the ArrayOps module.
+   The size argument is always the size in bytes of each element.
+*/
+
+/* TODO qualify the names to avoid clashes with Haskell names */
+
+struct array {
+    void*    buffer;   /* pointer to the buffer of elements */
+    int32_t  length;   /* number of elements in the array */
+};
+
+/// Allocate and initialize a struct array if we did not have one already
+static inline struct array *allocArray(struct array* src) {
+  log_1("allocArray %p\n", src);
+  if (src == NULL) {
+    src = malloc(sizeof(struct array));
+    src->buffer = NULL;
+    src->length = 0;
+  }
+  return src;
+}
+
+/// Resizing an existing array.
+static inline void* resizeArray(void* arr, int32_t size, int32_t len) {
+  log_3("resize %p with size %d and len %d\n", arr, size, len);
+  return realloc(arr, len*size);
+}
+
+/// Array (re)initialization for flat arrays.
+static inline void* initArray(void* arr, int32_t arrLen, int32_t size, int32_t newLen) {
+  log_4("initArray %p with arrlen %d size %d newLen %d\n", arr, arrLen, size, newLen);
+  if (newLen != arrLen)
+    arr = resizeArray(arr, size, newLen);
+  return arr;
+}
+
+/// Free a flat array or an array where all the arrays it contains have been free'd already.
+// TODO: Think about arrays escaping from their scope.
+static inline void freeArray(void* arr) {
+  log_1("freeArray %p\n", arr);
+  free(arr);
+}
+
+/// Deep array copy to a given position for flat arrays.
+static inline void* copyArrayPos(void* dst, int32_t dstLen, int32_t size, void* src, int32_t srcLen, int32_t pos) {
+  if (srcLen > 0)
+    memcpy(dst + pos * size, src, srcLen * size);
+  return dst;
+}
+
+/// Deep array copy for flat arrays.
+static inline void* copyArray(void* dst, int32_t dstLen, int32_t size, void* src, int32_t srcLen) {
+  return copyArrayPos(dst, dstLen, size, src, srcLen, 0);
+}
+
+/// Combined init and copy for flat arrays.
+static inline void* initCopyArray(void* dst, int32_t dstLen, int32_t size, void* src, int32_t srcLen) {
+  assert((src || !srcLen) && "source array not initialized");
+  assert((src != dst || srcLen == dstLen) && "same source as destination but with different lengths");
+
+  dst = initArray(dst, dstLen, size, srcLen);
+  return copyArrayPos(dst, dstLen, size, src, srcLen, 0);
+}
+#endif

--- a/clib/feldspar_c99.c
+++ b/clib/feldspar_c99.c
@@ -1,0 +1,1416 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "feldspar_c99.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <complex.h>
+
+#if defined(WIN32)
+  #include <windows.h>
+#else
+  #include <sys/time.h>
+  #include <time.h>
+#endif /* WIN32 */
+
+int feldspar_c99_hook(void) {
+  return 0;
+}
+
+/*--------------------------------------------------------------------------*
+ *                 pow(), abs(), signum(), logBase()                        *
+ *--------------------------------------------------------------------------*/
+
+int8_t pow_fun_int8_t(int8_t a, int8_t b) {
+    int8_t r = 1;
+    int i;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %" PRId8 " `pow` %" PRId8, a, b);
+        exit(1);
+    }
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+int16_t pow_fun_int16_t(int16_t a, int16_t b) {
+    int16_t r = 1;
+    int i;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %" PRId16 " `pow` %" PRId16, a, b);
+        exit(1);
+    }
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+int32_t pow_fun_int32_t(int32_t a, int32_t b) {
+    int32_t r = 1;
+    int i;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %" PRId32 " `pow` %d" PRId32, a, b);
+        exit(1);
+    }
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+int64_t pow_fun_int64_t(int64_t a, int64_t b) {
+    int64_t r = 1;
+    int i;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %" PRId64 " `pow` %" PRId64, a, b);
+        exit(1);
+    }
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+uint8_t pow_fun_uint8_t(uint8_t a, uint8_t b) {
+    uint8_t r = 1;
+    int i;
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+uint16_t pow_fun_uint16_t(uint16_t a, uint16_t b) {
+    uint16_t r = 1;
+    int i;
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+uint32_t pow_fun_uint32_t(uint32_t a, uint32_t b) {
+    uint32_t r = 1;
+    int i;
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+uint64_t pow_fun_uint64_t(uint64_t a, uint64_t b) {
+    uint64_t r = 1;
+    int i;
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+int8_t abs_fun_int8_t(int8_t a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    int8_t mask = a >> 7;
+    return (a + mask) ^ mask;
+}
+
+int16_t abs_fun_int16_t(int16_t a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    int16_t mask = a >> 15;
+    return (a + mask) ^ mask;
+}
+
+int32_t abs_fun_int32_t(int32_t a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    int32_t mask = a >> 31;
+    return (a + mask) ^ mask;
+}
+
+int64_t abs_fun_int64_t(int64_t a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    int64_t mask = a >> 63;
+    return (a + mask) ^ mask;
+}
+
+float abs_fun_float(float a) {
+    return fabsf(a);
+}
+
+double abs_fun_double(double a) {
+    return fabs(a);
+}
+
+
+int8_t signum_fun_int8_t(int8_t a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 7);
+}
+
+int16_t signum_fun_int16_t(int16_t a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 15);
+}
+
+int32_t signum_fun_int32_t(int32_t a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 31);
+}
+
+int64_t signum_fun_int64_t(int64_t a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 63);
+}
+
+uint8_t signum_fun_uint8_t(uint8_t a) {
+    return (a > 0);
+}
+
+uint16_t signum_fun_uint16_t(uint16_t a) {
+    return (a > 0);
+}
+
+uint32_t signum_fun_uint32_t(uint32_t a) {
+    return (a > 0);
+}
+
+uint64_t signum_fun_uint64_t(uint64_t a) {
+    return (a > 0);
+}
+
+float signum_fun_float(float a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a > 0) - (a < 0);
+}
+
+float logBase_fun_float(float a, float b) {
+    return logf(b) / logf(a);
+}
+
+double signum_fun_double(double a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a > 0) - (a < 0);
+}
+
+double logBase_fun_double(double a, double b) {
+    return log(b) / log(a);
+}
+
+
+/*--------------------------------------------------------------------------*
+ *                 Bit operations                                           *
+ *--------------------------------------------------------------------------*/
+
+int8_t setBit_fun_int8_t(int8_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+int16_t setBit_fun_int16_t(int16_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+int32_t setBit_fun_int32_t(int32_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+int64_t setBit_fun_int64_t(int64_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+uint8_t setBit_fun_uint8_t(uint8_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+uint16_t setBit_fun_uint16_t(uint16_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+uint32_t setBit_fun_uint32_t(uint32_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+uint64_t setBit_fun_uint64_t(uint64_t x, uint32_t i) {
+    return x | 1 << i;
+}
+
+int8_t clearBit_fun_int8_t(int8_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+int16_t clearBit_fun_int16_t(int16_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+int32_t clearBit_fun_int32_t(int32_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+int64_t clearBit_fun_int64_t(int64_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+uint8_t clearBit_fun_uint8_t(uint8_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+uint16_t clearBit_fun_uint16_t(uint16_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+uint32_t clearBit_fun_uint32_t(uint32_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+uint64_t clearBit_fun_uint64_t(uint64_t x, uint32_t i) {
+    return x & ~(1 << i);
+}
+
+int8_t complementBit_fun_int8_t(int8_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+int16_t complementBit_fun_int16_t(int16_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+int32_t complementBit_fun_int32_t(int32_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+int64_t complementBit_fun_int64_t(int64_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+uint8_t complementBit_fun_uint8_t(uint8_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+uint16_t complementBit_fun_uint16_t(uint16_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+uint32_t complementBit_fun_uint32_t(uint32_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+uint64_t complementBit_fun_uint64_t(uint64_t x, uint32_t i) {
+    return x ^ 1 << i;
+}
+
+int testBit_fun_int8_t(int8_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_int16_t(int16_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_int32_t(int32_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_int64_t(int64_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_uint8_t(uint8_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_uint16_t(uint16_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_uint32_t(uint32_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_uint64_t(uint64_t x, uint32_t i) {
+    return (x & 1 << i) != 0;
+}
+
+int8_t rotateL_fun_int8_t(int8_t x, int32_t i) {
+    if ((i %= 8) == 0) return x;
+    return (x << i) | ((0x7f >> (7 - i)) & (x >> (8 - i)));
+}
+
+int16_t rotateL_fun_int16_t(int16_t x, int32_t i) {
+    if ((i %= 16) == 0) return x;
+    return (x << i) | ((0x7fff >> (15 - i)) & (x >> (16 - i)));
+}
+
+int32_t rotateL_fun_int32_t(int32_t x, int32_t i) {
+    if ((i %= 32) == 0) return x;
+    return (x << i) | ((0x7fffffff >> (31 - i)) & (x >> (32 - i)));
+}
+
+int64_t rotateL_fun_int64_t(int64_t x, int32_t i) {
+    if ((i %= 64) == 0) return x;
+    return (x << i) | ((0x7fffffffffffffffll >> (63 - i)) & (x >> (64 - i)));
+}
+
+uint8_t rotateL_fun_uint8_t(uint8_t x, int32_t i) {
+    if ((i %= 8) == 0) return x;
+    return (x << i) | (x >> (8 - i));
+}
+
+uint16_t rotateL_fun_uint16_t(uint16_t x, int32_t i) {
+    if ((i %= 16) == 0) return x;
+    return (x << i) | (x >> (16 - i));
+}
+
+uint32_t rotateL_fun_uint32_t(uint32_t x, int32_t i) {
+    if ((i %= 32) == 0) return x;
+    return (x << i) | (x >> (32 - i));
+}
+
+uint64_t rotateL_fun_uint64_t(uint64_t x, int32_t i) {
+    if ((i %= 64) == 0) return x;
+    return (x << i) | (x >> (64 - i));
+}
+
+int8_t rotateR_fun_int8_t(int8_t x, int32_t i) {
+    if ((i %= 8) == 0) return x;
+    return (x << (8 - i)) | ((0x7f >> (i - 1)) & (x >> i));
+}
+
+int16_t rotateR_fun_int16_t(int16_t x, int32_t i) {
+    if ((i %= 16) == 0) return x;
+    return (x << (16 - i)) | ((0x7fff >> (i - 1)) & (x >> i));
+}
+
+int32_t rotateR_fun_int32_t(int32_t x, int32_t i) {
+    if ((i %= 32) == 0) return x;
+    return (x << (32 - i)) | ((0x7fffffff >> (i - 1)) & (x >> i));
+}
+
+int64_t rotateR_fun_int64_t(int64_t x, int32_t i) {
+    if ((i %= 64) == 0) return x;
+    return (x << (64 - i)) | ((0x7fffffffffffffffll >> (i - 1)) & (x >> i));
+}
+
+uint8_t rotateR_fun_uint8_t(uint8_t x, int32_t i) {
+    if ((i %= 8) == 0) return x;
+    return (x << (8 - i)) | (x >> i);
+}
+
+uint16_t rotateR_fun_uint16_t(uint16_t x, int32_t i) {
+    if ((i %= 16) == 0) return x;
+    return (x << (16 - i)) | (x >> i);
+}
+
+uint32_t rotateR_fun_uint32_t(uint32_t x, int32_t i) {
+    if ((i %= 32) == 0) return x;
+    return (x << (32 - i)) | (x >> i);
+}
+
+uint64_t rotateR_fun_uint64_t(uint64_t x, int32_t i) {
+    if ((i %= 64) == 0) return x;
+    return (x << (64 - i)) | (x >> i);
+}
+
+int8_t reverseBits_fun_int8_t(int8_t x) {
+    int8_t r = x;
+    int i = 7;
+    for (x = x >> 1 & 0x7f; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+int16_t reverseBits_fun_int16_t(int16_t x) {
+    int16_t r = x;
+    int i = 15;
+    for (x = x >> 1 & 0x7fff; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+int32_t reverseBits_fun_int32_t(int32_t x) {
+    int32_t r = x;
+    int i = 31;
+    for (x = x >> 1 & 0x7fffffff; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+int64_t reverseBits_fun_int64_t(int64_t x) {
+    int64_t r = x;
+    int i = 63;
+    for (x = x >> 1 & 0x7fffffffffffffffll; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+uint8_t reverseBits_fun_uint8_t(uint8_t x) {
+    uint8_t r = x;
+    int i = 7;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+uint16_t reverseBits_fun_uint16_t(uint16_t x) {
+    uint16_t r = x;
+    int i = 15;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+uint32_t reverseBits_fun_uint32_t(uint32_t x) {
+    uint32_t r = x;
+    int i = 31;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+uint64_t reverseBits_fun_uint64_t(uint64_t x) {
+    uint64_t r = x;
+    int i = 63;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+uint32_t bitScan_fun_int8_t(int8_t x) {
+    uint32_t r = 0;
+    int8_t s = (x & 0x80);
+    if (x == 0) return 7;
+    while ((int8_t)((x <<= 1) & 0x80) == s)
+        ++r;
+    return r;
+}
+
+uint32_t bitScan_fun_int16_t(int16_t x) {
+    uint32_t r = 0;
+    int16_t s = (x & 0x8000);
+    if (x == 0) return 15;
+    while ((int16_t)((x <<= 1) & 0x8000) == s)
+        ++r;
+    return r;
+}
+
+uint32_t bitScan_fun_int32_t(int32_t x) {
+    uint32_t r = 0;
+    int32_t s = (x & 0x80000000);
+    if (x == 0) return 31;
+    while ((int32_t)((x <<= 1) & 0x80000000) == s)
+        ++r;
+    return r;
+}
+
+uint32_t bitScan_fun_int64_t(int64_t x) {
+    uint32_t r = 0;
+    int64_t s = (x & 0x8000000000000000ll);
+    if (x == 0) return 63;
+    while ((int64_t)((x <<= 1) & 0x8000000000000000ll) == s)
+        ++r;
+    return r;
+}
+
+uint32_t bitScan_fun_uint8_t(uint8_t x) {
+    uint32_t r = 8;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+uint32_t bitScan_fun_uint16_t(uint16_t x) {
+    uint32_t r = 16;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+uint32_t bitScan_fun_uint32_t(uint32_t x) {
+    uint32_t r = 32;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+uint32_t bitScan_fun_uint64_t(uint64_t x) {
+    uint32_t r = 64;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+uint32_t bitCount_fun_int8_t(int8_t x) {
+    uint32_t r = x & 1;
+    for (x = x >> 1 & 0x7f; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_int16_t(int16_t x) {
+    uint32_t r = x & 1;
+    for (x = x >> 1 & 0x7fff; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_int32_t(int32_t x) {
+    uint32_t r = x & 1;
+    for (x = x >> 1 & 0x7fffffff; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_int64_t(int64_t x) {
+    uint32_t r = x & 1;
+    for (x = x >> 1 & 0x7fffffffffffffffll; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_uint8_t(uint8_t x) {
+    uint32_t r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_uint16_t(uint16_t x) {
+    uint32_t r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_uint32_t(uint32_t x) {
+    uint32_t r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+uint32_t bitCount_fun_uint64_t(uint64_t x) {
+    uint32_t r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+/*--------------------------------------------------------------------------*
+ *                 Complex numbers                                          *
+ *--------------------------------------------------------------------------*/
+
+int equal_fun_complexOf_int8_t(complexOf_int8_t a, complexOf_int8_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_int16_t(complexOf_int16_t a, complexOf_int16_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_int32_t(complexOf_int32_t a, complexOf_int32_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_int64_t(complexOf_int64_t a, complexOf_int64_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_uint8_t(complexOf_uint8_t a, complexOf_uint8_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_uint16_t(complexOf_uint16_t a, complexOf_uint16_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_uint32_t(complexOf_uint32_t a, complexOf_uint32_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_uint64_t(complexOf_uint64_t a, complexOf_uint64_t b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+complexOf_int8_t negate_fun_complexOf_int8_t(complexOf_int8_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int16_t negate_fun_complexOf_int16_t(complexOf_int16_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int32_t negate_fun_complexOf_int32_t(complexOf_int32_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int64_t negate_fun_complexOf_int64_t(complexOf_int64_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint8_t negate_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint16_t negate_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint32_t negate_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint64_t negate_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int8_t abs_fun_complexOf_int8_t(complexOf_int8_t a) {
+    a.re = magnitude_fun_complexOf_int8_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_int16_t abs_fun_complexOf_int16_t(complexOf_int16_t a) {
+    a.re = magnitude_fun_complexOf_int16_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_int32_t abs_fun_complexOf_int32_t(complexOf_int32_t a) {
+    a.re = magnitude_fun_complexOf_int32_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_int64_t abs_fun_complexOf_int64_t(complexOf_int64_t a) {
+    a.re = magnitude_fun_complexOf_int64_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_uint8_t abs_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    a.re = magnitude_fun_complexOf_uint8_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_uint16_t abs_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    a.re = magnitude_fun_complexOf_uint16_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_uint32_t abs_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    a.re = magnitude_fun_complexOf_uint32_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_uint64_t abs_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    a.re = magnitude_fun_complexOf_uint64_t(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_int8_t signum_fun_complexOf_int8_t(complexOf_int8_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        int8_t m = magnitude_fun_complexOf_int8_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_int16_t signum_fun_complexOf_int16_t(complexOf_int16_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        int16_t m = magnitude_fun_complexOf_int16_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_int32_t signum_fun_complexOf_int32_t(complexOf_int32_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        int32_t m = magnitude_fun_complexOf_int32_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_int64_t signum_fun_complexOf_int64_t(complexOf_int64_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        int64_t m = magnitude_fun_complexOf_int64_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_uint8_t signum_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        uint8_t m = magnitude_fun_complexOf_uint8_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_uint16_t signum_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        uint16_t m = magnitude_fun_complexOf_uint16_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_uint32_t signum_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        uint32_t m = magnitude_fun_complexOf_uint32_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_uint64_t signum_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        uint64_t m = magnitude_fun_complexOf_uint64_t(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+float complex signum_fun_complexOf_float(float complex a) {
+    if (a == 0)
+        return a;
+    else {
+        float m = cabsf(a);
+        return crealf(a) / m + cimagf(a) / m * I;
+    }
+}
+
+double complex signum_fun_complexOf_double(double complex a) {
+    if (a == 0)
+        return a;
+    else {
+        double m = cabsf(a);
+        return crealf(a) / m + cimagf(a) / m * I;
+    }
+}
+
+complexOf_int8_t add_fun_complexOf_int8_t(complexOf_int8_t a, complexOf_int8_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_int16_t add_fun_complexOf_int16_t(complexOf_int16_t a, complexOf_int16_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_int32_t add_fun_complexOf_int32_t(complexOf_int32_t a, complexOf_int32_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_int64_t add_fun_complexOf_int64_t(complexOf_int64_t a, complexOf_int64_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_uint8_t add_fun_complexOf_uint8_t(complexOf_uint8_t a, complexOf_uint8_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_uint16_t add_fun_complexOf_uint16_t(complexOf_uint16_t a, complexOf_uint16_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_uint32_t add_fun_complexOf_uint32_t(complexOf_uint32_t a, complexOf_uint32_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_uint64_t add_fun_complexOf_uint64_t(complexOf_uint64_t a, complexOf_uint64_t b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_int8_t sub_fun_complexOf_int8_t(complexOf_int8_t a, complexOf_int8_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_int16_t sub_fun_complexOf_int16_t(complexOf_int16_t a, complexOf_int16_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_int32_t sub_fun_complexOf_int32_t(complexOf_int32_t a, complexOf_int32_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_int64_t sub_fun_complexOf_int64_t(complexOf_int64_t a, complexOf_int64_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_uint8_t sub_fun_complexOf_uint8_t(complexOf_uint8_t a, complexOf_uint8_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_uint16_t sub_fun_complexOf_uint16_t(complexOf_uint16_t a, complexOf_uint16_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_uint32_t sub_fun_complexOf_uint32_t(complexOf_uint32_t a, complexOf_uint32_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_uint64_t sub_fun_complexOf_uint64_t(complexOf_uint64_t a, complexOf_uint64_t b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_int8_t mult_fun_complexOf_int8_t(complexOf_int8_t a, complexOf_int8_t b) {
+    complexOf_int8_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_int16_t mult_fun_complexOf_int16_t(complexOf_int16_t a, complexOf_int16_t b) {
+    complexOf_int16_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_int32_t mult_fun_complexOf_int32_t(complexOf_int32_t a, complexOf_int32_t b) {
+    complexOf_int32_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_int64_t mult_fun_complexOf_int64_t(complexOf_int64_t a, complexOf_int64_t b) {
+    complexOf_int64_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_uint8_t mult_fun_complexOf_uint8_t(complexOf_uint8_t a, complexOf_uint8_t b) {
+    complexOf_uint8_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_uint16_t mult_fun_complexOf_uint16_t(complexOf_uint16_t a, complexOf_uint16_t b) {
+    complexOf_uint16_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_uint32_t mult_fun_complexOf_uint32_t(complexOf_uint32_t a, complexOf_uint32_t b) {
+    complexOf_uint32_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_uint64_t mult_fun_complexOf_uint64_t(complexOf_uint64_t a, complexOf_uint64_t b) {
+    complexOf_uint64_t r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+#ifdef __FreeBSD__
+float complex clogf(float complex x) {
+    return (I * atan2f(cimagf(x), crealf(x))) + logf(cabsf(x));
+}
+#endif
+
+
+float complex logBase_fun_complexOf_float(float complex a, float complex b) {
+    return clogf(b) / clogf(a);
+}
+
+double complex logBase_fun_complexOf_double(double complex a, double complex b) {
+    return clogf(b) / clogf(a);
+}
+
+complexOf_int8_t complex_fun_int8_t(int8_t re, int8_t im) {
+    complexOf_int8_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_int16_t complex_fun_int16_t(int16_t re, int16_t im) {
+    complexOf_int16_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_int32_t complex_fun_int32_t(int32_t re, int32_t im) {
+    complexOf_int32_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_int64_t complex_fun_int64_t(int64_t re, int64_t im) {
+    complexOf_int64_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_uint8_t complex_fun_uint8_t(uint8_t re, uint8_t im) {
+    complexOf_uint8_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_uint16_t complex_fun_uint16_t(uint16_t re, uint16_t im) {
+    complexOf_uint16_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_uint32_t complex_fun_uint32_t(uint32_t re, uint32_t im) {
+    complexOf_uint32_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_uint64_t complex_fun_uint64_t(uint64_t re, uint64_t im) {
+    complexOf_uint64_t r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+float complex complex_fun_float(float re, float im) {
+    return re + im * I;
+}
+
+double complex complex_fun_double(double re, double im) {
+    return re + im * I;
+}
+
+int8_t creal_fun_complexOf_int8_t(complexOf_int8_t a) {
+    return a.re;
+}
+
+int16_t creal_fun_complexOf_int16_t(complexOf_int16_t a) {
+    return a.re;
+}
+
+int32_t creal_fun_complexOf_int32_t(complexOf_int32_t a) {
+    return a.re;
+}
+
+int64_t creal_fun_complexOf_int64_t(complexOf_int64_t a) {
+    return a.re;
+}
+
+uint8_t creal_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    return a.re;
+}
+
+uint16_t creal_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    return a.re;
+}
+
+uint32_t creal_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    return a.re;
+}
+
+uint64_t creal_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    return a.re;
+}
+
+int8_t cimag_fun_complexOf_int8_t(complexOf_int8_t a) {
+    return a.im;
+}
+
+int16_t cimag_fun_complexOf_int16_t(complexOf_int16_t a) {
+    return a.im;
+}
+
+int32_t cimag_fun_complexOf_int32_t(complexOf_int32_t a) {
+    return a.im;
+}
+
+int64_t cimag_fun_complexOf_int64_t(complexOf_int64_t a) {
+    return a.im;
+}
+
+uint8_t cimag_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    return a.im;
+}
+
+uint16_t cimag_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    return a.im;
+}
+
+uint32_t cimag_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    return a.im;
+}
+
+uint64_t cimag_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    return a.im;
+}
+
+complexOf_int8_t conj_fun_complexOf_int8_t(complexOf_int8_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int16_t conj_fun_complexOf_int16_t(complexOf_int16_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int32_t conj_fun_complexOf_int32_t(complexOf_int32_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int64_t conj_fun_complexOf_int64_t(complexOf_int64_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint8_t conj_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint16_t conj_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint32_t conj_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint64_t conj_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    a.im = -a.im;
+    return a;
+}
+
+int8_t magnitude_fun_complexOf_int8_t(complexOf_int8_t a) {
+    return lroundf(hypotf(a.re, a.im));
+}
+
+int16_t magnitude_fun_complexOf_int16_t(complexOf_int16_t a) {
+    return lroundf(hypotf(a.re, a.im));
+}
+
+int32_t magnitude_fun_complexOf_int32_t(complexOf_int32_t a) {
+    return lroundf(hypotf(a.re, a.im));
+}
+
+int64_t magnitude_fun_complexOf_int64_t(complexOf_int64_t a) {
+    return llroundf(hypotf(a.re, a.im));
+}
+
+uint8_t magnitude_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    return lroundf(hypotf(a.re, a.im));
+}
+
+uint16_t magnitude_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    return lroundf(hypotf(a.re, a.im));
+}
+
+uint32_t magnitude_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    return lroundf(hypotf(a.re, a.im));
+}
+
+uint64_t magnitude_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    return llroundf(hypotf(a.re, a.im));
+}
+
+int8_t phase_fun_complexOf_int8_t(complexOf_int8_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return lroundf(atan2f(a.im, a.re));
+}
+
+int16_t phase_fun_complexOf_int16_t(complexOf_int16_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return lroundf(atan2f(a.im, a.re));
+}
+
+int32_t phase_fun_complexOf_int32_t(complexOf_int32_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return lroundf(atan2f(a.im, a.re));
+}
+
+int64_t phase_fun_complexOf_int64_t(complexOf_int64_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return llroundf(atan2f(a.im, a.re));
+}
+
+uint8_t phase_fun_complexOf_uint8_t(complexOf_uint8_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return lroundf(atan2f(a.im, a.re));
+}
+
+uint16_t phase_fun_complexOf_uint16_t(complexOf_uint16_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return lroundf(atan2f(a.im, a.re));
+}
+
+uint32_t phase_fun_complexOf_uint32_t(complexOf_uint32_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return lroundf(atan2f(a.im, a.re));
+}
+
+uint64_t phase_fun_complexOf_uint64_t(complexOf_uint64_t a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return llroundf(atan2f(a.im, a.re));
+}
+
+complexOf_int8_t mkPolar_fun_int8_t(int8_t r, int8_t t) {
+    complexOf_int8_t a;
+    a.re = lroundf(r * cosf(t));
+    a.im = lroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_int16_t mkPolar_fun_int16_t(int16_t r, int16_t t) {
+    complexOf_int16_t a;
+    a.re = lroundf(r * cosf(t));
+    a.im = lroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_int32_t mkPolar_fun_int32_t(int32_t r, int32_t t) {
+    complexOf_int32_t a;
+    a.re = lroundf(r * cosf(t));
+    a.im = lroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_int64_t mkPolar_fun_int64_t(int64_t r, int64_t t) {
+    complexOf_int64_t a;
+    a.re = llroundf(r * cosf(t));
+    a.im = llroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_uint8_t mkPolar_fun_uint8_t(uint8_t r, uint8_t t) {
+    complexOf_uint8_t a;
+    a.re = lroundf(r * cosf(t));
+    a.im = lroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_uint16_t mkPolar_fun_uint16_t(uint16_t r, uint16_t t) {
+    complexOf_uint16_t a;
+    a.re = lroundf(r * cosf(t));
+    a.im = lroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_uint32_t mkPolar_fun_uint32_t(uint32_t r, uint32_t t) {
+    complexOf_uint32_t a;
+    a.re = lroundf(r * cosf(t));
+    a.im = lroundf(r * sinf(t));
+    return a;
+}
+
+complexOf_uint64_t mkPolar_fun_uint64_t(uint64_t r, uint64_t t) {
+    complexOf_uint64_t a;
+    a.re = llroundf(r * cosf(t));
+    a.im = llroundf(r * sinf(t));
+    return a;
+}
+
+float complex mkPolar_fun_float(float r, float t) {
+    return r * cosf(t) + r * sinf(t) * I;
+}
+
+double complex mkPolar_fun_double(double r, double t) {
+    return r * cosf(t) + r * sinf(t) * I;
+}
+
+complexOf_int8_t cis_fun_int8_t(int8_t t) {
+    complexOf_int8_t r;
+    r.re = lroundf(cosf(t));
+    r.im = lroundf(sinf(t));
+    return r;
+}
+
+complexOf_int16_t cis_fun_int16_t(int16_t t) {
+    complexOf_int16_t r;
+    r.re = lroundf(cosf(t));
+    r.im = lroundf(sinf(t));
+    return r;
+}
+
+complexOf_int32_t cis_fun_int32_t(int32_t t) {
+    complexOf_int32_t r;
+    r.re = lroundf(cosf(t));
+    r.im = lroundf(sinf(t));
+    return r;
+}
+
+complexOf_int64_t cis_fun_int64_t(int64_t t) {
+    complexOf_int64_t r;
+    r.re = llroundf(cosf(t));
+    r.im = llroundf(sinf(t));
+    return r;
+}
+
+complexOf_uint8_t cis_fun_uint8_t(uint8_t t) {
+    complexOf_uint8_t r;
+    r.re = lroundf(cosf(t));
+    r.im = lroundf(sinf(t));
+    return r;
+}
+
+complexOf_uint16_t cis_fun_uint16_t(uint16_t t) {
+    complexOf_uint16_t r;
+    r.re = lroundf(cosf(t));
+    r.im = lroundf(sinf(t));
+    return r;
+}
+
+complexOf_uint32_t cis_fun_uint32_t(uint32_t t) {
+    complexOf_uint32_t r;
+    r.re = lroundf(cosf(t));
+    r.im = lroundf(sinf(t));
+    return r;
+}
+
+complexOf_uint64_t cis_fun_uint64_t(uint64_t t) {
+    complexOf_uint64_t r;
+    r.re = llroundf(cosf(t));
+    r.im = llroundf(sinf(t));
+    return r;
+}
+
+float complex cis_fun_float(float t) {
+    return cosf(t) + sinf(t) * I;
+}
+
+
+double complex cis_fun_double(double t) {
+    return cosf(t) + sinf(t) * I;
+}

--- a/clib/feldspar_c99.h
+++ b/clib/feldspar_c99.h
@@ -1,0 +1,342 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef FELDSPAR_C99_H
+#define FELDSPAR_C99_H
+
+#include <stdint.h>
+#include <complex.h>
+
+
+int feldspar_c99_hook(void);
+
+#define min(X, Y)  ((X) < (Y) ? (X) : (Y))
+#define max(X, Y)  ((X) > (Y) ? (X) : (Y))
+
+int8_t pow_fun_int8_t(int8_t, int8_t);
+int16_t pow_fun_int16_t(int16_t, int16_t);
+int32_t pow_fun_int32_t(int32_t, int32_t);
+int64_t pow_fun_int64_t(int64_t, int64_t);
+uint8_t pow_fun_uint8_t(uint8_t, uint8_t);
+uint16_t pow_fun_uint16_t(uint16_t, uint16_t);
+uint32_t pow_fun_uint32_t(uint32_t, uint32_t);
+uint64_t pow_fun_uint64_t(uint64_t, uint64_t);
+
+int8_t abs_fun_int8_t(int8_t);
+int16_t abs_fun_int16_t(int16_t);
+int32_t abs_fun_int32_t(int32_t);
+int64_t abs_fun_int64_t(int64_t);
+float abs_fun_float(float);
+double abs_fun_double(double);
+
+int8_t signum_fun_int8_t(int8_t);
+int16_t signum_fun_int16_t(int16_t);
+int32_t signum_fun_int32_t(int32_t);
+int64_t signum_fun_int64_t(int64_t);
+uint8_t signum_fun_uint8_t(uint8_t);
+uint16_t signum_fun_uint16_t(uint16_t);
+uint32_t signum_fun_uint32_t(uint32_t);
+uint64_t signum_fun_uint64_t(uint64_t);
+float signum_fun_float(float);
+double signum_fun_double(double);
+
+float logBase_fun_float(float, float);
+double logBase_fun_double(double, double);
+
+
+
+int8_t setBit_fun_int8_t(int8_t, uint32_t);
+int16_t setBit_fun_int16_t(int16_t, uint32_t);
+int32_t setBit_fun_int32_t(int32_t, uint32_t);
+int64_t setBit_fun_int64_t(int64_t, uint32_t);
+uint8_t setBit_fun_uint8_t(uint8_t, uint32_t);
+uint16_t setBit_fun_uint16_t(uint16_t, uint32_t);
+uint32_t setBit_fun_uint32_t(uint32_t, uint32_t);
+uint64_t setBit_fun_uint64_t(uint64_t, uint32_t);
+
+int8_t clearBit_fun_int8_t(int8_t, uint32_t);
+int16_t clearBit_fun_int16_t(int16_t, uint32_t);
+int32_t clearBit_fun_int32_t(int32_t, uint32_t);
+int64_t clearBit_fun_int64_t(int64_t, uint32_t);
+uint8_t clearBit_fun_uint8_t(uint8_t, uint32_t);
+uint16_t clearBit_fun_uint16_t(uint16_t, uint32_t);
+uint32_t clearBit_fun_uint32_t(uint32_t, uint32_t);
+uint64_t clearBit_fun_uint64_t(uint64_t, uint32_t);
+
+int8_t complementBit_fun_int8_t(int8_t, uint32_t);
+int16_t complementBit_fun_int16_t(int16_t, uint32_t);
+int32_t complementBit_fun_int32_t(int32_t, uint32_t);
+int64_t complementBit_fun_int64_t(int64_t, uint32_t);
+uint8_t complementBit_fun_uint8_t(uint8_t, uint32_t);
+uint16_t complementBit_fun_uint16_t(uint16_t, uint32_t);
+uint32_t complementBit_fun_uint32_t(uint32_t, uint32_t);
+uint64_t complementBit_fun_uint64_t(uint64_t, uint32_t);
+
+int testBit_fun_int8_t(int8_t, uint32_t);
+int testBit_fun_int16_t(int16_t, uint32_t);
+int testBit_fun_int32_t(int32_t, uint32_t);
+int testBit_fun_int64_t(int64_t, uint32_t);
+int testBit_fun_uint8_t(uint8_t, uint32_t);
+int testBit_fun_uint16_t(uint16_t, uint32_t);
+int testBit_fun_uint32_t(uint32_t, uint32_t);
+int testBit_fun_uint64_t(uint64_t, uint32_t);
+
+int8_t rotateL_fun_int8_t(int8_t, int32_t);
+int16_t rotateL_fun_int16_t(int16_t, int32_t);
+int32_t rotateL_fun_int32_t(int32_t, int32_t);
+int64_t rotateL_fun_int64_t(int64_t, int32_t);
+uint8_t rotateL_fun_uint8_t(uint8_t, int32_t);
+uint16_t rotateL_fun_uint16_t(uint16_t, int32_t);
+uint32_t rotateL_fun_uint32_t(uint32_t, int32_t);
+uint64_t rotateL_fun_uint64_t(uint64_t, int32_t);
+
+int8_t rotateR_fun_int8_t(int8_t, int32_t);
+int16_t rotateR_fun_int16_t(int16_t, int32_t);
+int32_t rotateR_fun_int32_t(int32_t, int32_t);
+int64_t rotateR_fun_int64_t(int64_t, int32_t);
+uint8_t rotateR_fun_uint8_t(uint8_t, int32_t);
+uint16_t rotateR_fun_uint16_t(uint16_t, int32_t);
+uint32_t rotateR_fun_uint32_t(uint32_t, int32_t);
+uint64_t rotateR_fun_uint64_t(uint64_t, int32_t);
+
+int8_t reverseBits_fun_int8_t(int8_t);
+int16_t reverseBits_fun_int16_t(int16_t);
+int32_t reverseBits_fun_int32_t(int32_t);
+int64_t reverseBits_fun_int64_t(int64_t);
+uint8_t reverseBits_fun_uint8_t(uint8_t);
+uint16_t reverseBits_fun_uint16_t(uint16_t);
+uint32_t reverseBits_fun_uint32_t(uint32_t);
+uint64_t reverseBits_fun_uint64_t(uint64_t);
+
+uint32_t bitScan_fun_int8_t(int8_t);
+uint32_t bitScan_fun_int16_t(int16_t);
+uint32_t bitScan_fun_int32_t(int32_t);
+uint32_t bitScan_fun_int64_t(int64_t);
+uint32_t bitScan_fun_uint8_t(uint8_t);
+uint32_t bitScan_fun_uint16_t(uint16_t);
+uint32_t bitScan_fun_uint32_t(uint32_t);
+uint32_t bitScan_fun_uint64_t(uint64_t);
+
+uint32_t bitCount_fun_int8_t(int8_t);
+uint32_t bitCount_fun_int16_t(int16_t);
+uint32_t bitCount_fun_int32_t(int32_t);
+uint32_t bitCount_fun_int64_t(int64_t);
+uint32_t bitCount_fun_uint8_t(uint8_t);
+uint32_t bitCount_fun_uint16_t(uint16_t);
+uint32_t bitCount_fun_uint32_t(uint32_t);
+uint32_t bitCount_fun_uint64_t(uint64_t);
+
+#define mkComplex(d1,d2) ((d1) + (d2) * I)
+
+typedef struct {
+    int8_t re;
+    int8_t im;
+} complexOf_int8_t;
+
+typedef struct {
+    int16_t re;
+    int16_t im;
+} complexOf_int16_t;
+
+typedef struct {
+    int32_t re;
+    int32_t im;
+} complexOf_int32_t;
+
+typedef struct {
+    int64_t re;
+    int64_t im;
+} complexOf_int64_t;
+
+typedef struct {
+    uint8_t re;
+    uint8_t im;
+} complexOf_uint8_t;
+
+typedef struct {
+    uint16_t re;
+    uint16_t im;
+} complexOf_uint16_t;
+
+typedef struct {
+    uint32_t re;
+    uint32_t im;
+} complexOf_uint32_t;
+
+typedef struct {
+    uint64_t re;
+    uint64_t im;
+} complexOf_uint64_t;
+
+int equal_fun_complexOf_int8_t(complexOf_int8_t, complexOf_int8_t);
+int equal_fun_complexOf_int16_t(complexOf_int16_t, complexOf_int16_t);
+int equal_fun_complexOf_int32_t(complexOf_int32_t, complexOf_int32_t);
+int equal_fun_complexOf_int64_t(complexOf_int64_t, complexOf_int64_t);
+int equal_fun_complexOf_uint8_t(complexOf_uint8_t, complexOf_uint8_t);
+int equal_fun_complexOf_uint16_t(complexOf_uint16_t, complexOf_uint16_t);
+int equal_fun_complexOf_uint32_t(complexOf_uint32_t, complexOf_uint32_t);
+int equal_fun_complexOf_uint64_t(complexOf_uint64_t, complexOf_uint64_t);
+
+complexOf_int8_t negate_fun_complexOf_int8_t(complexOf_int8_t);
+complexOf_int16_t negate_fun_complexOf_int16_t(complexOf_int16_t);
+complexOf_int32_t negate_fun_complexOf_int32_t(complexOf_int32_t);
+complexOf_int64_t negate_fun_complexOf_int64_t(complexOf_int64_t);
+complexOf_uint8_t negate_fun_complexOf_uint8_t(complexOf_uint8_t);
+complexOf_uint16_t negate_fun_complexOf_uint16_t(complexOf_uint16_t);
+complexOf_uint32_t negate_fun_complexOf_uint32_t(complexOf_uint32_t);
+complexOf_uint64_t negate_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+complexOf_int8_t abs_fun_complexOf_int8_t(complexOf_int8_t);
+complexOf_int16_t abs_fun_complexOf_int16_t(complexOf_int16_t);
+complexOf_int32_t abs_fun_complexOf_int32_t(complexOf_int32_t);
+complexOf_int64_t abs_fun_complexOf_int64_t(complexOf_int64_t);
+complexOf_uint8_t abs_fun_complexOf_uint8_t(complexOf_uint8_t);
+complexOf_uint16_t abs_fun_complexOf_uint16_t(complexOf_uint16_t);
+complexOf_uint32_t abs_fun_complexOf_uint32_t(complexOf_uint32_t);
+complexOf_uint64_t abs_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+complexOf_int8_t signum_fun_complexOf_int8_t(complexOf_int8_t);
+complexOf_int16_t signum_fun_complexOf_int16_t(complexOf_int16_t);
+complexOf_int32_t signum_fun_complexOf_int32_t(complexOf_int32_t);
+complexOf_int64_t signum_fun_complexOf_int64_t(complexOf_int64_t);
+complexOf_uint8_t signum_fun_complexOf_uint8_t(complexOf_uint8_t);
+complexOf_uint16_t signum_fun_complexOf_uint16_t(complexOf_uint16_t);
+complexOf_uint32_t signum_fun_complexOf_uint32_t(complexOf_uint32_t);
+complexOf_uint64_t signum_fun_complexOf_uint64_t(complexOf_uint64_t);
+float complex signum_fun_complexOf_float(float complex);
+double complex signum_fun_complexOf_double(double complex);
+
+complexOf_int8_t add_fun_complexOf_int8_t(complexOf_int8_t, complexOf_int8_t);
+complexOf_int16_t add_fun_complexOf_int16_t(complexOf_int16_t, complexOf_int16_t);
+complexOf_int32_t add_fun_complexOf_int32_t(complexOf_int32_t, complexOf_int32_t);
+complexOf_int64_t add_fun_complexOf_int64_t(complexOf_int64_t, complexOf_int64_t);
+complexOf_uint8_t add_fun_complexOf_uint8_t(complexOf_uint8_t, complexOf_uint8_t);
+complexOf_uint16_t add_fun_complexOf_uint16_t(complexOf_uint16_t, complexOf_uint16_t);
+complexOf_uint32_t add_fun_complexOf_uint32_t(complexOf_uint32_t, complexOf_uint32_t);
+complexOf_uint64_t add_fun_complexOf_uint64_t(complexOf_uint64_t, complexOf_uint64_t);
+
+complexOf_int8_t sub_fun_complexOf_int8_t(complexOf_int8_t, complexOf_int8_t);
+complexOf_int16_t sub_fun_complexOf_int16_t(complexOf_int16_t, complexOf_int16_t);
+complexOf_int32_t sub_fun_complexOf_int32_t(complexOf_int32_t, complexOf_int32_t);
+complexOf_int64_t sub_fun_complexOf_int64_t(complexOf_int64_t, complexOf_int64_t);
+complexOf_uint8_t sub_fun_complexOf_uint8_t(complexOf_uint8_t, complexOf_uint8_t);
+complexOf_uint16_t sub_fun_complexOf_uint16_t(complexOf_uint16_t, complexOf_uint16_t);
+complexOf_uint32_t sub_fun_complexOf_uint32_t(complexOf_uint32_t, complexOf_uint32_t);
+complexOf_uint64_t sub_fun_complexOf_uint64_t(complexOf_uint64_t, complexOf_uint64_t);
+
+complexOf_int8_t mult_fun_complexOf_int8_t(complexOf_int8_t, complexOf_int8_t);
+complexOf_int16_t mult_fun_complexOf_int16_t(complexOf_int16_t, complexOf_int16_t);
+complexOf_int32_t mult_fun_complexOf_int32_t(complexOf_int32_t, complexOf_int32_t);
+complexOf_int64_t mult_fun_complexOf_int64_t(complexOf_int64_t, complexOf_int64_t);
+complexOf_uint8_t mult_fun_complexOf_uint8_t(complexOf_uint8_t, complexOf_uint8_t);
+complexOf_uint16_t mult_fun_complexOf_uint16_t(complexOf_uint16_t, complexOf_uint16_t);
+complexOf_uint32_t mult_fun_complexOf_uint32_t(complexOf_uint32_t, complexOf_uint32_t);
+complexOf_uint64_t mult_fun_complexOf_uint64_t(complexOf_uint64_t, complexOf_uint64_t);
+
+float complex logBase_fun_complexOf_float(float complex, float complex);
+double complex logBase_fun_complexOf_double(double complex, double complex);
+
+complexOf_int8_t complex_fun_int8_t(int8_t, int8_t);
+complexOf_int16_t complex_fun_int16_t(int16_t, int16_t);
+complexOf_int32_t complex_fun_int32_t(int32_t, int32_t);
+complexOf_int64_t complex_fun_int64_t(int64_t, int64_t);
+complexOf_uint8_t complex_fun_uint8_t(uint8_t, uint8_t);
+complexOf_uint16_t complex_fun_uint16_t(uint16_t, uint16_t);
+complexOf_uint32_t complex_fun_uint32_t(uint32_t, uint32_t);
+complexOf_uint64_t complex_fun_uint64_t(uint64_t, uint64_t);
+float complex complex_fun_float(float, float);
+double complex complex_fun_double(double, double);
+
+int8_t creal_fun_complexOf_int8_t(complexOf_int8_t);
+int16_t creal_fun_complexOf_int16_t(complexOf_int16_t);
+int32_t creal_fun_complexOf_int32_t(complexOf_int32_t);
+int64_t creal_fun_complexOf_int64_t(complexOf_int64_t);
+uint8_t creal_fun_complexOf_uint8_t(complexOf_uint8_t);
+uint16_t creal_fun_complexOf_uint16_t(complexOf_uint16_t);
+uint32_t creal_fun_complexOf_uint32_t(complexOf_uint32_t);
+uint64_t creal_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+int8_t cimag_fun_complexOf_int8_t(complexOf_int8_t);
+int16_t cimag_fun_complexOf_int16_t(complexOf_int16_t);
+int32_t cimag_fun_complexOf_int32_t(complexOf_int32_t);
+int64_t cimag_fun_complexOf_int64_t(complexOf_int64_t);
+uint8_t cimag_fun_complexOf_uint8_t(complexOf_uint8_t);
+uint16_t cimag_fun_complexOf_uint16_t(complexOf_uint16_t);
+uint32_t cimag_fun_complexOf_uint32_t(complexOf_uint32_t);
+uint64_t cimag_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+complexOf_int8_t conj_fun_complexOf_int8_t(complexOf_int8_t);
+complexOf_int16_t conj_fun_complexOf_int16_t(complexOf_int16_t);
+complexOf_int32_t conj_fun_complexOf_int32_t(complexOf_int32_t);
+complexOf_int64_t conj_fun_complexOf_int64_t(complexOf_int64_t);
+complexOf_uint8_t conj_fun_complexOf_uint8_t(complexOf_uint8_t);
+complexOf_uint16_t conj_fun_complexOf_uint16_t(complexOf_uint16_t);
+complexOf_uint32_t conj_fun_complexOf_uint32_t(complexOf_uint32_t);
+complexOf_uint64_t conj_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+int8_t magnitude_fun_complexOf_int8_t(complexOf_int8_t);
+int16_t magnitude_fun_complexOf_int16_t(complexOf_int16_t);
+int32_t magnitude_fun_complexOf_int32_t(complexOf_int32_t);
+int64_t magnitude_fun_complexOf_int64_t(complexOf_int64_t);
+uint8_t magnitude_fun_complexOf_uint8_t(complexOf_uint8_t);
+uint16_t magnitude_fun_complexOf_uint16_t(complexOf_uint16_t);
+uint32_t magnitude_fun_complexOf_uint32_t(complexOf_uint32_t);
+uint64_t magnitude_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+int8_t phase_fun_complexOf_int8_t(complexOf_int8_t);
+int16_t phase_fun_complexOf_int16_t(complexOf_int16_t);
+int32_t phase_fun_complexOf_int32_t(complexOf_int32_t);
+int64_t phase_fun_complexOf_int64_t(complexOf_int64_t);
+uint8_t phase_fun_complexOf_uint8_t(complexOf_uint8_t);
+uint16_t phase_fun_complexOf_uint16_t(complexOf_uint16_t);
+uint32_t phase_fun_complexOf_uint32_t(complexOf_uint32_t);
+uint64_t phase_fun_complexOf_uint64_t(complexOf_uint64_t);
+
+complexOf_int8_t mkPolar_fun_int8_t(int8_t, int8_t);
+complexOf_int16_t mkPolar_fun_int16_t(int16_t, int16_t);
+complexOf_int32_t mkPolar_fun_int32_t(int32_t, int32_t);
+complexOf_int64_t mkPolar_fun_int64_t(int64_t, int64_t);
+complexOf_uint8_t mkPolar_fun_uint8_t(uint8_t, uint8_t);
+complexOf_uint16_t mkPolar_fun_uint16_t(uint16_t, uint16_t);
+complexOf_uint32_t mkPolar_fun_uint32_t(uint32_t, uint32_t);
+complexOf_uint64_t mkPolar_fun_uint64_t(uint64_t, uint64_t);
+float complex mkPolar_fun_float(float, float);
+double complex mkPolar_fun_double(double, double);
+
+complexOf_int8_t cis_fun_int8_t(int8_t);
+complexOf_int16_t cis_fun_int16_t(int16_t);
+complexOf_int32_t cis_fun_int32_t(int32_t);
+complexOf_int64_t cis_fun_int64_t(int64_t);
+complexOf_uint8_t cis_fun_uint8_t(uint8_t);
+complexOf_uint16_t cis_fun_uint16_t(uint16_t);
+complexOf_uint32_t cis_fun_uint32_t(uint32_t);
+complexOf_uint64_t cis_fun_uint64_t(uint64_t);
+float complex cis_fun_float(float);
+double complex cis_fun_double(double);
+
+#endif /* FELDSPAR_C99_H */

--- a/clib/feldspar_future.h
+++ b/clib/feldspar_future.h
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <pthread.h>

--- a/clib/feldspar_tic64x.c
+++ b/clib/feldspar_tic64x.c
@@ -1,0 +1,1737 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice, 
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "feldspar_tic64x.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <time.h>
+
+float hypotf(float x, float y) {
+  return sqrtf(x * x + y * y);
+}
+
+
+
+/*--------------------------------------------------------------------------*
+ *                 pow(), abs(), signum(), logBase()                        *
+ *--------------------------------------------------------------------------*/
+
+char pow_fun_char(char a, char b) {
+    char r = 1;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %d `pow` %d", a, b);
+        exit(1);
+    }
+    for (int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+short pow_fun_short(short a, short b) {
+    short r = 1;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %d `pow` %d", a, b);
+        exit(1);
+    }
+    for(int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+int pow_fun_int(int a, int b) {
+    int r = 1;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %d `pow` %d", a, b);
+        exit(1);
+    }
+    for (int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+long pow_fun_long(long a, long b) {
+    long r = 1;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %ld `pow` %ld", a, b);
+        exit(1);
+    }
+    for (int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+long long pow_fun_llong(long long a, long long b) {
+    long long r = 1;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %lld `pow` %lld", a, b);
+        exit(1);
+    }
+    for (int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+unsigned char pow_fun_uchar(unsigned char a, unsigned char b) {
+    unsigned char r = 1;
+    for (int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+unsigned short pow_fun_ushort(unsigned short a, unsigned short b) {
+    unsigned short r = 1;
+    for (int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+unsigned pow_fun_uint(unsigned a, unsigned b) {
+    unsigned r = 1;
+    for(int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+unsigned long pow_fun_ulong(unsigned long a, unsigned long b) {
+    unsigned long r = 1;
+    for(int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+unsigned long long pow_fun_ullong(unsigned long long a, unsigned long long b) {
+    unsigned long long r = 1;
+    for(int i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+
+char abs_fun_char(char a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    char mask = a >> 7;
+    return (a + mask) ^ mask;
+}
+
+short abs_fun_short(short a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    short mask = a >> 15;
+    return (a + mask) ^ mask;
+}
+
+long abs_fun_long(long a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    long mask = a >> 39;
+    return (a + mask) ^ mask;
+}
+
+long long abs_fun_llong(long long a) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    long long mask = a >> 63;
+    return (a + mask) ^ mask;
+}
+
+char signum_fun_char(char a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 7);
+}
+
+short signum_fun_short(short a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 15);
+}
+
+int signum_fun_int(int a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 31);
+}
+
+long signum_fun_long(long a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 39);
+}
+
+long long signum_fun_llong(long long a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 63);
+}
+
+unsigned char signum_fun_uchar(unsigned char a) {
+    return a > 0;
+}
+
+unsigned short signum_fun_ushort(unsigned short a) {
+    return a > 0;
+}
+
+unsigned signum_fun_uint(unsigned a) {
+    return a > 0;
+}
+
+unsigned long signum_fun_ulong(unsigned long a) {
+    return a > 0;
+}
+
+unsigned long long signum_fun_ullong(unsigned long long a) {
+    return a > 0;
+}
+
+float signum_fun_float(float a) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a > 0) - (a < 0);
+}
+
+float logBase_fun_float(float a, float b) {
+    return logf(b) / logf(a);
+}
+
+/*--------------------------------------------------------------------------*
+ *                 Bit operations                                           *
+ *--------------------------------------------------------------------------*/
+
+char setBit_fun_char(char x, unsigned i) {
+    return x | 1 << i;
+}
+
+short setBit_fun_short(short x, unsigned i) {
+    return x | 1 << i;
+}
+
+int setBit_fun_int(int x, unsigned i) {
+    return x | 1 << i;
+}
+
+long setBit_fun_long(long x, unsigned i) {
+    return x | 1 << i;
+}
+
+long long setBit_fun_llong(long long x, unsigned i) {
+    return x | 1 << i;
+}
+
+unsigned char setBit_fun_uchar(unsigned char x, unsigned i) {
+    return x | 1 << i;
+}
+
+unsigned short setBit_fun_ushort(unsigned short x, unsigned i) {
+    return x | 1 << i;
+}
+
+unsigned setBit_fun_uint(unsigned x, unsigned i) {
+    return x | 1 << i;
+}
+
+unsigned long setBit_fun_ulong(unsigned long x, unsigned i) {
+    return x | 1 << i;
+}
+
+unsigned long long setBit_fun_ullong(unsigned long long x, unsigned i) {
+    return x | 1 << i;
+}
+
+char clearBit_fun_char(char x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+short clearBit_fun_short(short x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+int clearBit_fun_int(int x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+long clearBit_fun_long(long x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+long long clearBit_fun_llong(long long x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+unsigned char clearBit_fun_uchar(unsigned char x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+unsigned short clearBit_fun_ushort(unsigned short x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+unsigned clearBit_fun_uint(unsigned x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+unsigned long clearBit_fun_ulong(unsigned long x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+unsigned long long clearBit_fun_ullong(unsigned long long x, unsigned i) {
+    return x & ~(1 << i);
+}
+
+char complementBit_fun_char(char x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+short complementBit_fun_short(short x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+int complementBit_fun_int(int x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+long complementBit_fun_long(long x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+long long complementBit_fun_llong(long long x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+unsigned char complementBit_fun_uchar(unsigned char x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+unsigned short complementBit_fun_ushort(unsigned short x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+unsigned complementBit_fun_uint(unsigned x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+unsigned long complementBit_fun_ulong(unsigned long x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+unsigned long long complementBit_fun_ullong(unsigned long long x, unsigned i) {
+    return x ^ 1 << i;
+}
+
+int testBit_fun_char(char x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_short(short x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_int(int x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_long(long x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_llong(long long x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_uchar(unsigned char x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_ushort(unsigned short x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_uint(unsigned x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_ulong(unsigned long x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+int testBit_fun_ullong(unsigned long long x, unsigned i) {
+    return (x & 1 << i) != 0;
+}
+
+char rotateL_fun_char(char x, int i) {
+    if ((i %= 8) == 0) return x;
+    return (x << i) | ((0x7f >> (7 - i)) & (x >> (8 - i)));
+}
+
+short rotateL_fun_short(short x, int i) {
+    if ((i %= 16) == 0) return x;
+    return (x << i) | ((0x7fff >> (15 - i)) & (x >> (16 - i)));
+}
+
+long rotateL_fun_long(long x, int i) {
+    if ((i %= 40) == 0) return x;
+    return (x << i) | ((0x7fffffffffl >> (39 - i)) & (x >> (40 - i)));
+}
+
+long long rotateL_fun_llong(long long x, int i) {
+    if ((i %= 64) == 0) return x;
+    return (x << i) | ((0x7fffffffffffffffll >> (63 - i)) & (x >> (64 - i)));
+}
+
+int rotateL_fun_int(int x, int i) {
+    return (int)_rotl((unsigned)x, (unsigned)i);
+}
+
+unsigned char rotateL_fun_uchar(unsigned char x, int i) {
+    if ((i %= 8) == 0) return x;
+    return (x << i) | (x >> (8 - i));
+}
+
+unsigned short rotateL_fun_ushort(unsigned short x, int i) {
+    if ((i %= 16) == 0) return x;
+    return (x << i) | (x >> (16 - i));
+}
+
+unsigned long rotateL_fun_ulong(unsigned long x, int i) {
+    if ((i %= 40) == 0) return x;
+    return (x << i) | (x >> (40 - i));
+}
+
+unsigned long long rotateL_fun_ullong(unsigned long long x, int i) {
+    if ((i %= 64) == 0) return x;
+    return (x << i) | (x >> (64 - i));
+}
+
+char rotateR_fun_char(char x, int i) {
+    if ((i %= 8) == 0) return x;
+    return (x << (8 - i)) | ((0x7f >> (i - 1)) & (x >> i));
+}
+
+short rotateR_fun_short(short x, int i) {
+    if ((i %= 16) == 0) return x;
+    return (x << (16 - i)) | ((0x7fff >> (i - 1)) & (x >> i));
+}
+
+int rotateR_fun_int(int x, int i) {
+    if ((i %= 32) == 0) return x;
+    return (x << (32 - i)) | ((0x7fffffff >> (i - 1)) & (x >> i));
+}
+
+long rotateR_fun_long(long x, int i) {
+    if ((i %= 40) == 0) return x;
+    return (x << (40 - i)) | ((0x7fffffffffl >> (i - 1)) & (x >> i));
+}
+
+long long rotateR_fun_llong(long long x, int i) {
+    if ((i %= 64) == 0) return x;
+    return (x << (64 - i)) | ((0x7fffffffffffffffll >> (i - 1)) & (x >> i));
+}
+
+unsigned char rotateR_fun_uchar(unsigned char x, int i) {
+    if ((i %= 8) == 0) return x;
+    return (x << (8 - i)) | (x >> i);
+}
+
+unsigned short rotateR_fun_ushort(unsigned short x, int i) {
+    if ((i %= 16) == 0) return x;
+    return (x << (16 - i)) | (x >> i);
+}
+
+unsigned rotateR_fun_uint(unsigned x, int i) {
+    if ((i %= 32) == 0) return x;
+    return (x << (32 - i)) | (x >> i);
+}
+
+unsigned long rotateR_fun_ulong(unsigned long x, int i) {
+    if ((i %= 40) == 0) return x;
+    return (x << (40 - i)) | (x >> i);
+}
+
+unsigned long long rotateR_fun_ullong(unsigned long long x, int i) {
+    if ((i %= 64) == 0) return x;
+    return (x << (64 - i)) | (x >> i);
+}
+
+char reverseBits_fun_char(char x) {
+    char r = x;
+    int i = 7;
+    for (x = x >> 1 & 0x7f; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+short reverseBits_fun_short(short x) {
+    short r = x;
+    int i = 15;
+    for (x = x >> 1 & 0x7fff; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+int reverseBits_fun_int(int x) {
+    int r = x;
+    int i = 31;
+    for (x = x >> 1 & 0x7fffffff; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+long reverseBits_fun_long(long x) {
+    long r = x;
+    int i = 39;
+    for (x = x >> 1 & 0x7fffffffffl; x; x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+long long reverseBits_fun_llong(long long x) {
+    long long r = x;
+    int i = 63;
+    for (x = x >> 1 & 0x7fffffffffffffffll; x; x >>= 1)
+    {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+unsigned char reverseBits_fun_uchar(unsigned char x) {
+    unsigned char r = x;
+    int i = 7;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+unsigned short reverseBits_fun_ushort(unsigned short x) {
+    unsigned short r = x;
+    int i = 15;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+unsigned long reverseBits_fun_ulong(unsigned long x) {
+    unsigned long r = x;
+    int i = 39;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+unsigned long long reverseBits_fun_ullong(unsigned long long x) {
+    unsigned long long r = x;
+    int i = 63;
+    while (x >>= 1) {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+
+unsigned bitScan_fun_char(char x) {
+    unsigned r = 0;
+    char s = (x & 0x80);
+    if (x == 0) return 7;
+    while (((x <<= 1) & 0x80) == s)
+        ++r;
+    return r;
+}
+
+unsigned bitScan_fun_short(short x) {
+    unsigned r = 0;
+    short s = (x & 0x8000);
+    if (x == 0) return 15;
+    while (((x <<= 1) & 0x8000) == s)
+        ++r;
+    return r;
+}
+
+unsigned bitScan_fun_int(int x) {
+    unsigned r = 0;
+    int s = (x & 0x80000000);
+    if (x == 0) return 31;
+    while (((x <<= 1) & 0x80000000) == s)
+        ++r;
+    return r;
+}
+
+unsigned bitScan_fun_long(long x) {
+    unsigned r = 0;
+    long s = (x & 0x8000000000l);
+    if (x == 0) return 39;
+    while (((x <<= 1) & 0x8000000000l) == s)
+        ++r;
+    return r;
+}
+
+unsigned bitScan_fun_llong(long long x) {
+    unsigned r = 0;
+    long long s = (x & 0x8000000000000000ll);
+    if (x == 0) return 63;
+    while (((x <<= 1) & 0x8000000000000000ll) == s)
+        ++r;
+    return r;
+}
+
+unsigned bitScan_fun_uchar(unsigned char x) {
+    unsigned r = 8;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+unsigned bitScan_fun_ushort(unsigned short x) {
+    unsigned r = 16;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+unsigned bitScan_fun_uint(unsigned x) {
+    unsigned r = 32;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+unsigned bitScan_fun_ulong(unsigned long x) {
+    unsigned r = 40;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+unsigned bitScan_fun_ullong(unsigned long long x) {
+    unsigned r = 64;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+
+unsigned bitCount_fun_char(char x) {
+    unsigned r = x & 1;
+    for (x = x >> 1 & 0x7f; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_short(short x) {
+    unsigned r = x & 1;
+    for (x = x >> 1 & 0x7fff; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_int(int x) {
+    unsigned r = x & 1;
+    for (x = x >> 1 & 0x7fffffff; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_long(long x) {
+    unsigned r = x & 1;
+    for (x = x >> 1 & 0x7fffffffffl; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_llong(long long x) {
+    unsigned r = x & 1;
+    for (x = x >> 1 & 0x7fffffffffffffffll; x; x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_uchar(unsigned char x) {
+    unsigned r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_ushort(unsigned short x) {
+    unsigned r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_ulong(unsigned long x) {
+    unsigned r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+unsigned bitCount_fun_ullong(unsigned long long x) {
+    unsigned r = x & 1;
+    while (x >>= 1)
+        r += x & 1;
+    return r;
+}
+
+/*--------------------------------------------------------------------------*
+ *                 Complex numbers                                          *
+ *--------------------------------------------------------------------------*/
+
+int equal_fun_complexOf_char(complexOf_char a, complexOf_char b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_int(complexOf_int a, complexOf_int b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_long(complexOf_long a, complexOf_long b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_llong(complexOf_llong a, complexOf_llong b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_uchar(complexOf_uchar a, complexOf_uchar b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_uint(complexOf_uint a, complexOf_uint b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_ulong(complexOf_ulong a, complexOf_ulong b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_ullong(complexOf_ullong a, complexOf_ullong b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+int equal_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    return a.re == b.re && a.im == b.im;
+}
+
+complexOf_char negate_fun_complexOf_char(complexOf_char a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int negate_fun_complexOf_int(complexOf_int a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_long negate_fun_complexOf_long(complexOf_long a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+ 
+complexOf_llong negate_fun_complexOf_llong(complexOf_llong a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uchar negate_fun_complexOf_uchar(complexOf_uchar a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint negate_fun_complexOf_uint(complexOf_uint a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_ulong negate_fun_complexOf_ulong(complexOf_ulong a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_ullong negate_fun_complexOf_ullong(complexOf_ullong a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_float negate_fun_complexOf_float(complexOf_float a) {
+    a.re = -a.re;
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_char abs_fun_complexOf_char(complexOf_char a) {
+    a.re = magnitude_fun_complexOf_char(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_int abs_fun_complexOf_int(complexOf_int a) {
+    a.re = magnitude_fun_complexOf_int(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_long abs_fun_complexOf_long(complexOf_long a) {
+    a.re = magnitude_fun_complexOf_long(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_llong abs_fun_complexOf_llong(complexOf_llong a) {
+    a.re = magnitude_fun_complexOf_llong(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_uchar abs_fun_complexOf_uchar(complexOf_uchar a) {
+    a.re = magnitude_fun_complexOf_uchar(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_uint abs_fun_complexOf_uint(complexOf_uint a) {
+    a.re = magnitude_fun_complexOf_uint(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_ulong abs_fun_complexOf_ulong(complexOf_ulong a) {
+    a.re = magnitude_fun_complexOf_ulong(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_ullong abs_fun_complexOf_ullong(complexOf_ullong a) {
+    a.re = magnitude_fun_complexOf_ullong(a);
+    a.im = 0;
+    return a;
+}
+
+complexOf_float abs_fun_complexOf_float(complexOf_float a) {
+    a.re = magnitude_fun_complexOf_float(a);
+    a.im = 0;
+    return a;
+}
+
+unsigned abs_fun_complexOf_short(unsigned a) {
+    return _pack2(magnitude_fun_complexOf_short(a), 0);
+}
+
+unsigned abs_fun_complexOf_ushort(unsigned a) {
+    return _pack2(magnitude_fun_complexOf_ushort(a), 0);
+}
+
+complexOf_char signum_fun_complexOf_char(complexOf_char a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        char m = magnitude_fun_complexOf_char(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_int signum_fun_complexOf_int(complexOf_int a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        int m = magnitude_fun_complexOf_int(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_long signum_fun_complexOf_long(complexOf_long a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        long m = magnitude_fun_complexOf_long(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_llong signum_fun_complexOf_llong(complexOf_llong a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        long long m = magnitude_fun_complexOf_llong(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_uchar signum_fun_complexOf_uchar(complexOf_uchar a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        unsigned char m = magnitude_fun_complexOf_uchar(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_uint signum_fun_complexOf_uint(complexOf_uint a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        unsigned m = magnitude_fun_complexOf_uint(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_ulong signum_fun_complexOf_ulong(complexOf_ulong a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        unsigned long m = magnitude_fun_complexOf_ulong(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_ullong signum_fun_complexOf_ullong(complexOf_ullong a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        unsigned long long m = magnitude_fun_complexOf_ullong(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+complexOf_float signum_fun_complexOf_float(complexOf_float a) {
+    if (a.re == 0 && a.im == 0)
+        return a;
+    else {
+        float m = magnitude_fun_complexOf_float(a);
+        a.re = a.re / m;
+        a.im = a.im / m;
+        return a;
+    }
+}
+
+unsigned signum_fun_complexOf_short(unsigned a) {
+    if (a == 0)
+        return a;
+    else {
+        short m = magnitude_fun_complexOf_short(a);
+        return _pack2((a >> 16) / m, (a & 0x0000ffff) / m);
+    }
+}
+
+unsigned signum_fun_complexOf_ushort(unsigned a) {
+    if (a == 0)
+        return a;
+    else {
+        unsigned short m = magnitude_fun_complexOf_ushort(a);
+        return _pack2((a >> 16) / m, (a & 0x0000ffff) / m);
+    }
+}
+
+complexOf_char add_fun_complexOf_char(complexOf_char a, complexOf_char b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_int add_fun_complexOf_int(complexOf_int a, complexOf_int b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_long add_fun_complexOf_long(complexOf_long a, complexOf_long b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_llong add_fun_complexOf_llong(complexOf_llong a, complexOf_llong b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_uchar add_fun_complexOf_uchar(complexOf_uchar a, complexOf_uchar b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_uint add_fun_complexOf_uint(complexOf_uint a, complexOf_uint b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_ulong add_fun_complexOf_ulong(complexOf_ulong a, complexOf_ulong b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_ullong add_fun_complexOf_ullong(complexOf_ullong a, complexOf_ullong b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_float add_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    a.re = a.re + b.re;
+    a.im = a.im + b.im;
+    return a;
+}
+
+complexOf_char sub_fun_complexOf_char(complexOf_char a, complexOf_char b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_int sub_fun_complexOf_int(complexOf_int a, complexOf_int b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_long sub_fun_complexOf_long(complexOf_long a, complexOf_long b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_llong sub_fun_complexOf_llong(complexOf_llong a, complexOf_llong b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_uchar sub_fun_complexOf_uchar(complexOf_uchar a, complexOf_uchar b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_uint sub_fun_complexOf_uint(complexOf_uint a, complexOf_uint b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_ulong sub_fun_complexOf_ulong(complexOf_ulong a, complexOf_ulong b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_ullong sub_fun_complexOf_ullong(complexOf_ullong a, complexOf_ullong b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_float sub_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    a.re = a.re - b.re;
+    a.im = a.im - b.im;
+    return a;
+}
+
+complexOf_char mult_fun_complexOf_char(complexOf_char a, complexOf_char b) {
+    complexOf_char r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_int mult_fun_complexOf_int(complexOf_int a, complexOf_int b) {
+    complexOf_int r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_long mult_fun_complexOf_long(complexOf_long a, complexOf_long b) {
+    complexOf_long r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_llong mult_fun_complexOf_llong(complexOf_llong a, complexOf_llong b) {
+    complexOf_llong r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_uchar mult_fun_complexOf_uchar(complexOf_uchar a, complexOf_uchar b) {
+    complexOf_uchar r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_uint mult_fun_complexOf_uint(complexOf_uint a, complexOf_uint b) {
+    complexOf_uint r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_ulong mult_fun_complexOf_ulong(complexOf_ulong a, complexOf_ulong b) {
+    complexOf_ulong r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_ullong mult_fun_complexOf_ullong(complexOf_ullong a, complexOf_ullong b) {
+    complexOf_ullong r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+complexOf_float mult_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    complexOf_float r;
+    r.re = a.re * b.re - a.im * b.im;
+    r.im = a.im * b.re + a.re * b.im;
+    return r;
+}
+
+unsigned mult_fun_complexOf_short(unsigned a, unsigned b) {
+    short are = (short)(a >> 16);
+    short aim = (short)(a & 0x0000ffff);
+    short bre = (short)(b >> 16);
+    short bim = (short)(b & 0x0000ffff);
+    return _pack2(are * bre - aim * bim, aim * bre + are * bim);
+}
+
+unsigned mult_fun_complexOf_ushort(unsigned a, unsigned b) {
+    unsigned short are = (unsigned short)(a >> 16);
+    unsigned short aim = (unsigned short)(a & 0x0000ffff);
+    unsigned short bre = (unsigned short)(b >> 16);
+    unsigned short bim = (unsigned short)(b & 0x0000ffff);
+    return _pack2(are * bre - aim * bim, aim * bre + are * bim);
+}
+
+complexOf_float div_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    float x = b.re * b.re + b.im * b.im;
+    complexOf_float r;
+    r.re = (a.re * b.re + a.im * b.im) / x;
+    r.im = (a.im * b.re - a.re * b.im) / x;
+    return r;
+}
+
+complexOf_float exp_fun_complexOf_float(complexOf_float a) {
+    float expre = expf(a.re);
+    a.re = expre * cosf(a.im);
+    a.im = expre * sinf(a.im);
+    return a;
+}
+
+complexOf_float sqrt_fun_complexOf_float(complexOf_float a) {
+    float magare = magnitude_fun_complexOf_float(a) + a.re;
+    a.re = sqrtf(magare / 2);
+    a.im = a.im / sqrtf(2 * magare);
+    return a;
+}
+
+complexOf_float log_fun_complexOf_float(complexOf_float a) {
+    complexOf_float r;
+    r.re = logf(magnitude_fun_complexOf_float(a));
+    r.im = phase_fun_complexOf_float(a);
+    return r;
+}
+
+complexOf_float pow_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    return exp_fun_complexOf_float(mult_fun_complexOf_float(log_fun_complexOf_float(a), b));
+}
+
+complexOf_float logBase_fun_complexOf_float(complexOf_float a, complexOf_float b) {
+    return div_fun_complexOf_float(log_fun_complexOf_float(b), log_fun_complexOf_float(a));
+}
+
+complexOf_float sin_fun_complexOf_float(complexOf_float a) {
+    complexOf_float r;
+    r.re = sinf(a.re) * coshf(a.im);
+    r.im = cosf(a.re) * sinhf(a.im);
+    return  r;
+}
+
+complexOf_float cos_fun_complexOf_float(complexOf_float a) {
+    complexOf_float r;
+    r.re = cosf(a.re) * coshf(a.im);
+    r.im = - sinf(a.re) * sinhf(a.im);
+    return  r;
+}
+
+complexOf_float tan_fun_complexOf_float(complexOf_float a) {
+    return div_fun_complexOf_float(sin_fun_complexOf_float(a), cos_fun_complexOf_float(a));
+}
+
+complexOf_float sinh_fun_complexOf_float(complexOf_float a) {
+    complexOf_float r;
+    r.re = sinhf(a.re) * cosf(a.im);
+    r.im = coshf(a.re) * sinf(a.im);
+    return  r;
+}
+
+complexOf_float cosh_fun_complexOf_float(complexOf_float a) {
+    complexOf_float r;
+    r.re = cosf(a.re) * coshf(a.im);
+    r.im = sinhf(a.re) * sinf(a.im);
+    return  r;
+}
+
+complexOf_float tanh_fun_complexOf_float(complexOf_float a) {
+    return div_fun_complexOf_float(sinh_fun_complexOf_float(a), cosh_fun_complexOf_float(a));
+}
+
+complexOf_float asin_fun_complexOf_float(complexOf_float a) {
+    complexOf_float b = add_fun_complexOf_float(log_fun_complexOf_float(complex_fun_float(-a.im, a.re)), sqrt_fun_complexOf_float(sub_fun_complexOf_float(complex_fun_float(1, 0), mult_fun_complexOf_float(a, a))));
+    a.re = b.im;
+    a.im = -b.re;
+    return a;
+}
+
+complexOf_float acos_fun_complexOf_float(complexOf_float a) {
+    complexOf_float b = sqrt_fun_complexOf_float(sub_fun_complexOf_float(complex_fun_float(1, 0), mult_fun_complexOf_float(a, a)));
+    complexOf_float c = log_fun_complexOf_float(add_fun_complexOf_float(a, complex_fun_float(-b.im, b.re)));
+    a.re = c.im;
+    a.im = -c.re;
+    return a;
+}
+
+complexOf_float atan_fun_complexOf_float(complexOf_float a) {
+    complexOf_float b = log_fun_complexOf_float(div_fun_complexOf_float(complex_fun_float(1 - a.im, a.re), sqrt_fun_complexOf_float(add_fun_complexOf_float(complex_fun_float(1, 0), mult_fun_complexOf_float(a, a)))));
+    a.re = b.im;
+    a.im = -b.re;
+    return a;
+}
+
+complexOf_float asinh_fun_complexOf_float(complexOf_float a) {
+    return log_fun_complexOf_float(add_fun_complexOf_float(a, sqrt_fun_complexOf_float(add_fun_complexOf_float(complex_fun_float(1, 0), mult_fun_complexOf_float(a, a)))));
+}
+
+complexOf_float acosh_fun_complexOf_float(complexOf_float a) {
+    complexOf_float b = {1, 0};
+    complexOf_float c = add_fun_complexOf_float(a, b);
+    return log_fun_complexOf_float(add_fun_complexOf_float(a, mult_fun_complexOf_float(c, sqrt_fun_complexOf_float(div_fun_complexOf_float(sub_fun_complexOf_float(a, b), c)))));
+}
+
+complexOf_float atanh_fun_complexOf_float(complexOf_float a) {
+    complexOf_float b = {1, 0};
+    return log_fun_complexOf_float(div_fun_complexOf_float(add_fun_complexOf_float(b, a), sqrt_fun_complexOf_float(sub_fun_complexOf_float(b, mult_fun_complexOf_float(a, a)))));
+}
+
+complexOf_char complex_fun_char(char re, char im) {
+    complexOf_char r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_int complex_fun_int(int re, int im) {
+    complexOf_int r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_long complex_fun_long(long re, long im) {
+    complexOf_long r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_llong complex_fun_llong(long long re, long long im) {
+    complexOf_llong r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_uchar complex_fun_uchar(unsigned char re, unsigned char im) {
+    complexOf_uchar r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_uint complex_fun_uint(unsigned re, unsigned im) {
+    complexOf_uint r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_ulong complex_fun_ulong(unsigned long re, unsigned long im) {
+    complexOf_ulong r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_ullong complex_fun_ullong(unsigned long long re, unsigned long long im) {
+    complexOf_ullong r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+complexOf_float complex_fun_float(float re, float im) {
+    complexOf_float r;
+    r.re = re;
+    r.im = im;
+    return r;
+}
+
+char creal_fun_complexOf_char(complexOf_char a) {
+    return a.re;
+}
+
+int creal_fun_complexOf_int(complexOf_int a) {
+    return a.re;
+}
+
+long creal_fun_complexOf_long(complexOf_long a) {
+    return a.re;
+}
+
+long long creal_fun_complexOf_llong(complexOf_llong a) {
+    return a.re;
+}
+
+unsigned char creal_fun_complexOf_uchar(complexOf_uchar a) {
+    return a.re;
+}
+
+unsigned creal_fun_complexOf_uint(complexOf_uint a) {
+    return a.re;
+}
+
+unsigned long creal_fun_complexOf_ulong(complexOf_ulong a) {
+    return a.re;
+}
+
+unsigned long long creal_fun_complexOf_ullong(complexOf_ullong a) {
+    return a.re;
+}
+
+float creal_fun_complexOf_float(complexOf_float a) {
+    return a.re;
+}
+
+short creal_fun_complexOf_short(unsigned a) {
+    return a >> 16;
+}
+
+unsigned short creal_fun_complexOf_ushort(unsigned a) {
+    return a >> 16;
+}
+
+char cimag_fun_complexOf_char(complexOf_char a) {
+    return a.im;
+}
+
+int cimag_fun_complexOf_int(complexOf_int a) {
+    return a.im;
+}
+
+long cimag_fun_complexOf_long(complexOf_long a) {
+    return a.im;
+}
+
+long long cimag_fun_complexOf_llong(complexOf_llong a) {
+    return a.im;
+}
+
+unsigned char cimag_fun_complexOf_uchar(complexOf_uchar a) {
+    return a.im;
+}
+
+unsigned cimag_fun_complexOf_uint(complexOf_uint a) {
+    return a.im;
+}
+
+unsigned long cimag_fun_complexOf_ulong(complexOf_ulong a) {
+    return a.im;
+}
+
+unsigned long long cimag_fun_complexOf_ullong(complexOf_ullong a) {
+    return a.im;
+}
+
+float cimag_fun_complexOf_float(complexOf_float a) {
+    return a.im;
+}
+
+short cimag_fun_complexOf_short(unsigned a) {
+    return a & 0x0000ffff;
+}
+
+unsigned short cimag_fun_complexOf_ushort(unsigned a) {
+    return a & 0x0000ffff;
+}
+
+complexOf_char conj_fun_complexOf_char(complexOf_char a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_int conj_fun_complexOf_int(complexOf_int a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_long conj_fun_complexOf_long(complexOf_long a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_llong conj_fun_complexOf_llong(complexOf_llong a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uchar conj_fun_complexOf_uchar(complexOf_uchar a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_uint conj_fun_complexOf_uint(complexOf_uint a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_ulong conj_fun_complexOf_ulong(complexOf_ulong a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_ullong conj_fun_complexOf_ullong(complexOf_ullong a) {
+    a.im = -a.im;
+    return a;
+}
+
+complexOf_float conj_fun_complexOf_float(complexOf_float a) {
+    a.im = -a.im;
+    return a;
+}
+
+unsigned conj_fun_complexOf_short(unsigned a) {
+    return _pack2(a >> 16, -(a & 0x0000ffff));
+}
+
+unsigned conj_fun_complexOf_ushort(unsigned a) {
+    return _pack2(a >> 16, -(a & 0x0000ffff));
+}
+
+char magnitude_fun_complexOf_char(complexOf_char a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+int magnitude_fun_complexOf_int(complexOf_int a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+long magnitude_fun_complexOf_long(complexOf_long a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+long long magnitude_fun_complexOf_llong(complexOf_llong a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+unsigned char magnitude_fun_complexOf_uchar(complexOf_uchar a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+unsigned magnitude_fun_complexOf_uint(complexOf_uint a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+unsigned long magnitude_fun_complexOf_ulong(complexOf_ulong a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+unsigned long long magnitude_fun_complexOf_ullong(complexOf_ullong a) {
+    return roundf(hypotf(a.re, a.im));
+}
+
+float magnitude_fun_complexOf_float(complexOf_float a) {
+    return (hypotf(a.re, a.im));
+}
+
+short magnitude_fun_complexOf_short(unsigned a) {
+    return roundf(hypotf((a >> 16), (a & 0x0000ffff)));
+}
+
+unsigned short magnitude_fun_complexOf_ushort(unsigned a) {
+    return roundf(hypotf((a >> 16), (a & 0x0000ffff)));
+}
+
+char phase_fun_complexOf_char(complexOf_char a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+int phase_fun_complexOf_int(complexOf_int a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+long phase_fun_complexOf_long(complexOf_long a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+long long phase_fun_complexOf_llong(complexOf_llong a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+unsigned char phase_fun_complexOf_uchar(complexOf_uchar a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+unsigned phase_fun_complexOf_uint(complexOf_uint a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+unsigned long phase_fun_complexOf_ulong(complexOf_ulong a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+unsigned long long phase_fun_complexOf_ullong(complexOf_ullong a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return roundf(atan2f(a.im, a.re));
+}
+
+float phase_fun_complexOf_float(complexOf_float a) {
+    if (a.re == 0 && a.im == 0) return 0;
+    return (atan2f(a.im, a.re));
+}
+
+short phase_fun_complexOf_short(unsigned a) {
+    short re = (a >> 16);
+    short im = (a & 0x0000ffff);
+    if (re == 0 && im == 0) return 0;
+    return roundf(atan2f(im, re));
+}
+
+unsigned short phase_fun_complexOf_ushort(unsigned a) {
+    unsigned short re = (a >> 16);
+    unsigned short im = (a & 0x0000ffff);
+    if (re == 0 && im == 0) return 0;
+    return roundf(atan2f(im, re));
+}
+
+complexOf_char mkPolar_fun_char(char r, char t) {
+    complexOf_char a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_int mkPolar_fun_int(int r, int t) {
+    complexOf_int a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_long mkPolar_fun_long(long r, long t) {
+    complexOf_long a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_llong mkPolar_fun_llong(long long r, long long t) {
+    complexOf_llong a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_uchar mkPolar_fun_uchar(unsigned char r, unsigned char t) {
+    complexOf_uchar a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_uint mkPolar_fun_uint(unsigned r, unsigned t) {
+    complexOf_uint a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_ulong mkPolar_fun_ulong(unsigned long r, unsigned long t) {
+    complexOf_ulong a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_ullong mkPolar_fun_ullong(unsigned long long r, unsigned long long t) {
+    complexOf_ullong a;
+    a.re = roundf(r * cosf(t));
+    a.im = roundf(r * sinf(t));
+    return a;
+}
+
+complexOf_float mkPolar_fun_float(float r, float t) {
+    complexOf_float a;
+    a.re = (r * cosf(t));
+    a.im = (r * sinf(t));
+    return a;
+}
+
+unsigned mkPolar_fun_short(short r, short t) {
+    return _pack2(roundf(r * cosf(t)), roundf(r * sinf(t)));
+}
+
+unsigned mkPolar_fun_ushort(unsigned short r, unsigned short t) {
+    return _pack2(roundf(r * cosf(t)), roundf(r * sinf(t)));
+}
+
+complexOf_char cis_fun_char(char t) {
+    complexOf_char r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_int cis_fun_int(int t) {
+    complexOf_int r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_long cis_fun_long(long t) {
+    complexOf_long r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_llong cis_fun_llong(long long t) {
+    complexOf_llong r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_uchar cis_fun_uchar(unsigned char t) {
+    complexOf_uchar r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_uint cis_fun_uint(unsigned t) {
+    complexOf_uint r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_ulong cis_fun_ulong(unsigned long t) {
+    complexOf_ulong r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_ullong cis_fun_ullong(unsigned long long t) {
+    complexOf_ullong r;
+    r.re = roundf(cosf(t));
+    r.im = roundf(sinf(t));
+    return r;
+}
+
+complexOf_float cis_fun_float(float t) {
+    complexOf_float r;
+    r.re = (cosf(t));
+    r.im = (sinf(t));
+    return r;
+}
+
+unsigned cis_fun_short(short t) {
+    return _pack2(roundf(cosf(t)), roundf(sinf(t)));
+}
+
+unsigned cis_fun_ushort(unsigned short t) {
+    return _pack2(roundf(cosf(t)), roundf(sinf(t)));
+}

--- a/clib/feldspar_tic64x.h
+++ b/clib/feldspar_tic64x.h
@@ -1,0 +1,415 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef FELDSPAR_TI_C64X_H
+#define FELDSPAR_TI_C64X_H
+
+
+
+char pow_fun_char(char, char);
+short pow_fun_short(short, short);
+int pow_fun_int(int, int);
+long pow_fun_long(long, long);
+long long pow_fun_llong(long long, long long);
+unsigned char pow_fun_uchar(unsigned char, unsigned char);
+unsigned short pow_fun_ushort(unsigned short, unsigned short);
+unsigned pow_fun_uint(unsigned, unsigned);
+unsigned long pow_fun_ulong(unsigned long, unsigned long);
+unsigned long long pow_fun_ullong(unsigned long long, unsigned long long);
+
+char abs_fun_char(char);
+short abs_fun_short(short);
+long abs_fun_long(long);
+long long abs_fun_llong(long long);
+
+char signum_fun_char(char);
+short signum_fun_short(short);
+int signum_fun_int(int);
+long signum_fun_long(long);
+long long signum_fun_llong(long long);
+unsigned char signum_fun_uchar(unsigned char);
+unsigned short signum_fun_ushort(unsigned short);
+unsigned signum_fun_uint(unsigned);
+unsigned long signum_fun_ulong(unsigned long);
+unsigned long long signum_fun_ullong(unsigned long long);
+float signum_fun_float(float);
+
+float logBase_fun_float(float, float);
+
+
+
+char setBit_fun_char(char, unsigned);
+short setBit_fun_short(short, unsigned);
+int setBit_fun_int(int, unsigned);
+long setBit_fun_long(long, unsigned);
+long long setBit_fun_llong(long long, unsigned);
+unsigned char setBit_fun_uchar(unsigned char, unsigned);
+unsigned short setBit_fun_ushort(unsigned short, unsigned);
+unsigned setBit_fun_uint(unsigned, unsigned);
+unsigned long setBit_fun_ulong(unsigned long, unsigned);
+unsigned long long setBit_fun_ullong(unsigned long long, unsigned);
+
+char clearBit_fun_char(char, unsigned);
+short clearBit_fun_short(short, unsigned);
+int clearBit_fun_int(int, unsigned);
+long clearBit_fun_long(long, unsigned);
+long long clearBit_fun_llong(long long, unsigned);
+unsigned char clearBit_fun_uchar(unsigned char, unsigned);
+unsigned short clearBit_fun_ushort(unsigned short, unsigned);
+unsigned clearBit_fun_uint(unsigned, unsigned);
+unsigned long clearBit_fun_ulong(unsigned long, unsigned);
+unsigned long long clearBit_fun_ullong(unsigned long long, unsigned);
+
+char complementBit_fun_char(char, unsigned);
+short complementBit_fun_short(short, unsigned);
+int complementBit_fun_int(int, unsigned);
+long complementBit_fun_long(long, unsigned);
+long long complementBit_fun_llong(long long, unsigned);
+unsigned char complementBit_fun_uchar(unsigned char, unsigned);
+unsigned short complementBit_fun_ushort(unsigned short, unsigned);
+unsigned complementBit_fun_uint(unsigned, unsigned);
+unsigned long complementBit_fun_ulong(unsigned long, unsigned);
+unsigned long long complementBit_fun_ullong(unsigned long long, unsigned);
+
+int testBit_fun_char(char, unsigned);
+int testBit_fun_short(short, unsigned);
+int testBit_fun_int(int, unsigned);
+int testBit_fun_long(long, unsigned);
+int testBit_fun_llong(long long, unsigned);
+int testBit_fun_uchar(unsigned char, unsigned);
+int testBit_fun_ushort(unsigned short, unsigned);
+int testBit_fun_uint(unsigned, unsigned);
+int testBit_fun_ulong(unsigned long, unsigned);
+int testBit_fun_ullong(unsigned long long, unsigned);
+
+char rotateL_fun_char(char, int);
+short rotateL_fun_short(short, int);
+long rotateL_fun_long(long, int);
+long long rotateL_fun_llong(long long, int);
+int rotateL_fun_int(int, int);
+unsigned char rotateL_fun_uchar(unsigned char, int);
+unsigned short rotateL_fun_ushort(unsigned short, int);
+unsigned long rotateL_fun_ulong(unsigned long, int);
+unsigned long long rotateL_fun_ullong(unsigned long long, int);
+
+char rotateR_fun_char(char, int);
+short rotateR_fun_short(short, int);
+int rotateR_fun_int(int, int);
+long rotateR_fun_long(long, int);
+long long rotateR_fun_llong(long long, int);
+unsigned char rotateR_fun_uchar(unsigned char, int);
+unsigned short rotateR_fun_ushort(unsigned short, int);
+unsigned rotateR_fun_uint(unsigned, int);
+unsigned long rotateR_fun_ulong(unsigned long, int);
+unsigned long long rotateR_fun_ullong(unsigned long long, int);
+
+char reverseBits_fun_char(char);
+short reverseBits_fun_short(short);
+int reverseBits_fun_int(int);
+long reverseBits_fun_long(long);
+long long reverseBits_fun_llong(long long);
+unsigned char reverseBits_fun_uchar(unsigned char);
+unsigned short reverseBits_fun_ushort(unsigned short);
+unsigned long reverseBits_fun_ulong(unsigned long);
+unsigned long long reverseBits_fun_ullong(unsigned long long);
+
+unsigned bitScan_fun_char(char);
+unsigned bitScan_fun_short(short);
+unsigned bitScan_fun_int(int);
+unsigned bitScan_fun_long(long);
+unsigned bitScan_fun_llong(long long);
+unsigned bitScan_fun_uchar(unsigned char);
+unsigned bitScan_fun_ushort(unsigned short);
+unsigned bitScan_fun_uint(unsigned);
+unsigned bitScan_fun_ulong(unsigned long);
+unsigned bitScan_fun_ullong(unsigned long long);
+
+unsigned bitCount_fun_char(char);
+unsigned bitCount_fun_short(short);
+unsigned bitCount_fun_int(int);
+unsigned bitCount_fun_long(long);
+unsigned bitCount_fun_llong(long long);
+unsigned bitCount_fun_uchar(unsigned char);
+unsigned bitCount_fun_ushort(unsigned short);
+unsigned bitCount_fun_ulong(unsigned long);
+unsigned bitCount_fun_ullong(unsigned long long);
+
+
+
+typedef struct {
+    char re;
+    char im;
+} complexOf_char;
+
+typedef struct {
+    int re;
+    int im;
+} complexOf_int;
+
+typedef struct {
+    long re;
+    long im;
+} complexOf_long;
+
+typedef struct {
+    long long re;
+    long long im;
+} complexOf_llong;
+
+typedef struct {
+    unsigned char re;
+    unsigned char im;
+} complexOf_uchar;
+
+typedef struct {
+    unsigned re;
+    unsigned im;
+} complexOf_uint;
+
+typedef struct {
+    unsigned long re;
+    unsigned long im;
+} complexOf_ulong;
+
+typedef struct {
+    unsigned long long re;
+    unsigned long long im;
+} complexOf_ullong;
+
+typedef struct {
+    float re;
+    float im;
+} complexOf_float;
+
+int equal_fun_complexOf_char(complexOf_char, complexOf_char);
+int equal_fun_complexOf_int(complexOf_int, complexOf_int);
+int equal_fun_complexOf_long(complexOf_long, complexOf_long);
+int equal_fun_complexOf_llong(complexOf_llong, complexOf_llong);
+int equal_fun_complexOf_uchar(complexOf_uchar, complexOf_uchar);
+int equal_fun_complexOf_uint(complexOf_uint, complexOf_uint);
+int equal_fun_complexOf_ulong(complexOf_ulong, complexOf_ulong);
+int equal_fun_complexOf_ullong(complexOf_ullong, complexOf_ullong);
+int equal_fun_complexOf_float(complexOf_float, complexOf_float);
+
+complexOf_char negate_fun_complexOf_char(complexOf_char);
+complexOf_int negate_fun_complexOf_int(complexOf_int);
+complexOf_long negate_fun_complexOf_long(complexOf_long);
+complexOf_llong negate_fun_complexOf_llong(complexOf_llong);
+complexOf_uchar negate_fun_complexOf_uchar(complexOf_uchar);
+complexOf_uint negate_fun_complexOf_uint(complexOf_uint);
+complexOf_ulong negate_fun_complexOf_ulong(complexOf_ulong);
+complexOf_ullong negate_fun_complexOf_ullong(complexOf_ullong);
+complexOf_float negate_fun_complexOf_float(complexOf_float);
+
+complexOf_char abs_fun_complexOf_char(complexOf_char);
+complexOf_int abs_fun_complexOf_int(complexOf_int);
+complexOf_long abs_fun_complexOf_long(complexOf_long);
+complexOf_llong abs_fun_complexOf_llong(complexOf_llong);
+complexOf_uchar abs_fun_complexOf_uchar(complexOf_uchar);
+complexOf_uint abs_fun_complexOf_uint(complexOf_uint);
+complexOf_ulong abs_fun_complexOf_ulong(complexOf_ulong);
+complexOf_ullong abs_fun_complexOf_ullong(complexOf_ullong);
+complexOf_float abs_fun_complexOf_float(complexOf_float);
+unsigned abs_fun_complexOf_short(unsigned);
+unsigned abs_fun_complexOf_ushort(unsigned);
+
+complexOf_char signum_fun_complexOf_char(complexOf_char);
+complexOf_int signum_fun_complexOf_int(complexOf_int);
+complexOf_long signum_fun_complexOf_long(complexOf_long);
+complexOf_llong signum_fun_complexOf_llong(complexOf_llong);
+complexOf_uchar signum_fun_complexOf_uchar(complexOf_uchar);
+complexOf_uint signum_fun_complexOf_uint(complexOf_uint);
+complexOf_ulong signum_fun_complexOf_ulong(complexOf_ulong);
+complexOf_ullong signum_fun_complexOf_ullong(complexOf_ullong);
+complexOf_float signum_fun_complexOf_float(complexOf_float);
+unsigned signum_fun_complexOf_short(unsigned);
+unsigned signum_fun_complexOf_ushort(unsigned);
+
+complexOf_char add_fun_complexOf_char(complexOf_char, complexOf_char);
+complexOf_int add_fun_complexOf_int(complexOf_int, complexOf_int);
+complexOf_long add_fun_complexOf_long(complexOf_long, complexOf_long);
+complexOf_llong add_fun_complexOf_llong(complexOf_llong, complexOf_llong);
+complexOf_uchar add_fun_complexOf_uchar(complexOf_uchar, complexOf_uchar);
+complexOf_uint add_fun_complexOf_uint(complexOf_uint, complexOf_uint);
+complexOf_ulong add_fun_complexOf_ulong(complexOf_ulong, complexOf_ulong);
+complexOf_ullong add_fun_complexOf_ullong(complexOf_ullong, complexOf_ullong);
+complexOf_float add_fun_complexOf_float(complexOf_float, complexOf_float);
+
+complexOf_char sub_fun_complexOf_char(complexOf_char, complexOf_char);
+complexOf_int sub_fun_complexOf_int(complexOf_int, complexOf_int);
+complexOf_long sub_fun_complexOf_long(complexOf_long, complexOf_long);
+complexOf_llong sub_fun_complexOf_llong(complexOf_llong, complexOf_llong);
+complexOf_uchar sub_fun_complexOf_uchar(complexOf_uchar, complexOf_uchar);
+complexOf_uint sub_fun_complexOf_uint(complexOf_uint, complexOf_uint);
+complexOf_ulong sub_fun_complexOf_ulong(complexOf_ulong, complexOf_ulong);
+complexOf_ullong sub_fun_complexOf_ullong(complexOf_ullong, complexOf_ullong);
+complexOf_float sub_fun_complexOf_float(complexOf_float, complexOf_float);
+
+complexOf_char mult_fun_complexOf_char(complexOf_char, complexOf_char);
+complexOf_int mult_fun_complexOf_int(complexOf_int, complexOf_int);
+complexOf_long mult_fun_complexOf_long(complexOf_long, complexOf_long);
+complexOf_llong mult_fun_complexOf_llong(complexOf_llong, complexOf_llong);
+complexOf_uchar mult_fun_complexOf_uchar(complexOf_uchar, complexOf_uchar);
+complexOf_uint mult_fun_complexOf_uint(complexOf_uint, complexOf_uint);
+complexOf_ulong mult_fun_complexOf_ulong(complexOf_ulong, complexOf_ulong);
+complexOf_ullong mult_fun_complexOf_ullong(complexOf_ullong, complexOf_ullong);
+complexOf_float mult_fun_complexOf_float(complexOf_float, complexOf_float);
+unsigned mult_fun_complexOf_short(unsigned, unsigned);
+unsigned mult_fun_complexOf_ushort(unsigned, unsigned);
+
+complexOf_float div_fun_complexOf_float(complexOf_float, complexOf_float);
+
+complexOf_float exp_fun_complexOf_float(complexOf_float);
+
+complexOf_float sqrt_fun_complexOf_float(complexOf_float);
+
+complexOf_float log_fun_complexOf_float(complexOf_float);
+
+complexOf_float pow_fun_complexOf_float(complexOf_float, complexOf_float);
+
+complexOf_float logBase_fun_complexOf_float(complexOf_float, complexOf_float);
+
+complexOf_float sin_fun_complexOf_float(complexOf_float);
+
+complexOf_float cos_fun_complexOf_float(complexOf_float);
+
+complexOf_float tan_fun_complexOf_float(complexOf_float);
+
+complexOf_float sinh_fun_complexOf_float(complexOf_float);
+
+complexOf_float cosh_fun_complexOf_float(complexOf_float);
+
+complexOf_float tanh_fun_complexOf_float(complexOf_float);
+
+complexOf_float asin_fun_complexOf_float(complexOf_float);
+
+complexOf_float acos_fun_complexOf_float(complexOf_float);
+
+complexOf_float atan_fun_complexOf_float(complexOf_float);
+
+complexOf_float asinh_fun_complexOf_float(complexOf_float);
+
+complexOf_float acosh_fun_complexOf_float(complexOf_float);
+
+complexOf_float atanh_fun_complexOf_float(complexOf_float);
+
+complexOf_char complex_fun_char(char, char);
+complexOf_int complex_fun_int(int, int);
+complexOf_long complex_fun_long(long, long);
+complexOf_llong complex_fun_llong(long long, long long);
+complexOf_uchar complex_fun_uchar(unsigned char, unsigned char);
+complexOf_uint complex_fun_uint(unsigned, unsigned);
+complexOf_ulong complex_fun_ulong(unsigned long, unsigned long);
+complexOf_ullong complex_fun_ullong(unsigned long long, unsigned long long);
+complexOf_float complex_fun_float(float, float);
+
+char creal_fun_complexOf_char(complexOf_char);
+int creal_fun_complexOf_int(complexOf_int);
+long creal_fun_complexOf_long(complexOf_long);
+long long creal_fun_complexOf_llong(complexOf_llong);
+unsigned char creal_fun_complexOf_uchar(complexOf_uchar);
+unsigned creal_fun_complexOf_uint(complexOf_uint);
+unsigned long creal_fun_complexOf_ulong(complexOf_ulong);
+unsigned long long creal_fun_complexOf_ullong(complexOf_ullong);
+float creal_fun_complexOf_float(complexOf_float);
+short creal_fun_complexOf_short(unsigned);
+unsigned short creal_fun_complexOf_ushort(unsigned);
+
+char cimag_fun_complexOf_char(complexOf_char);
+int cimag_fun_complexOf_int(complexOf_int);
+long cimag_fun_complexOf_long(complexOf_long);
+long long cimag_fun_complexOf_llong(complexOf_llong);
+unsigned char cimag_fun_complexOf_uchar(complexOf_uchar);
+unsigned cimag_fun_complexOf_uint(complexOf_uint);
+unsigned long cimag_fun_complexOf_ulong(complexOf_ulong);
+unsigned long long cimag_fun_complexOf_ullong(complexOf_ullong);
+float cimag_fun_complexOf_float(complexOf_float);
+short cimag_fun_complexOf_short(unsigned);
+unsigned short cimag_fun_complexOf_ushort(unsigned);
+
+complexOf_char conj_fun_complexOf_char(complexOf_char);
+complexOf_int conj_fun_complexOf_int(complexOf_int);
+complexOf_long conj_fun_complexOf_long(complexOf_long);
+complexOf_llong conj_fun_complexOf_llong(complexOf_llong);
+complexOf_uchar conj_fun_complexOf_uchar(complexOf_uchar);
+complexOf_uint conj_fun_complexOf_uint(complexOf_uint);
+complexOf_ulong conj_fun_complexOf_ulong(complexOf_ulong);
+complexOf_ullong conj_fun_complexOf_ullong(complexOf_ullong);
+complexOf_float conj_fun_complexOf_float(complexOf_float);
+unsigned conj_fun_complexOf_short(unsigned);
+unsigned conj_fun_complexOf_ushort(unsigned);
+
+char magnitude_fun_complexOf_char(complexOf_char);
+int magnitude_fun_complexOf_int(complexOf_int);
+long magnitude_fun_complexOf_long(complexOf_long);
+long long magnitude_fun_complexOf_llong(complexOf_llong);
+unsigned char magnitude_fun_complexOf_uchar(complexOf_uchar);
+unsigned magnitude_fun_complexOf_uint(complexOf_uint);
+unsigned long magnitude_fun_complexOf_ulong(complexOf_ulong);
+unsigned long long magnitude_fun_complexOf_ullong(complexOf_ullong);
+float magnitude_fun_complexOf_float(complexOf_float);
+short magnitude_fun_complexOf_short(unsigned);
+unsigned short magnitude_fun_complexOf_ushort(unsigned);
+
+char phase_fun_complexOf_char(complexOf_char);
+int phase_fun_complexOf_int(complexOf_int);
+long phase_fun_complexOf_long(complexOf_long);
+long long phase_fun_complexOf_llong(complexOf_llong);
+unsigned char phase_fun_complexOf_uchar(complexOf_uchar);
+unsigned phase_fun_complexOf_uint(complexOf_uint);
+unsigned long phase_fun_complexOf_ulong(complexOf_ulong);
+unsigned long long phase_fun_complexOf_ullong(complexOf_ullong);
+float phase_fun_complexOf_float(complexOf_float);
+short phase_fun_complexOf_short(unsigned);
+unsigned short phase_fun_complexOf_ushort(unsigned);
+
+complexOf_char mkPolar_fun_char(char, char);
+complexOf_int mkPolar_fun_int(int, int);
+complexOf_long mkPolar_fun_long(long, long);
+complexOf_llong mkPolar_fun_llong(long long, long long);
+complexOf_uchar mkPolar_fun_uchar(unsigned char, unsigned char);
+complexOf_uint mkPolar_fun_uint(unsigned, unsigned);
+complexOf_ulong mkPolar_fun_ulong(unsigned long, unsigned long);
+complexOf_ullong mkPolar_fun_ullong(unsigned long long, unsigned long long);
+complexOf_float mkPolar_fun_float(float, float);
+unsigned mkPolar_fun_short(short, short);
+unsigned mkPolar_fun_ushort(unsigned short, unsigned short);
+
+complexOf_char cis_fun_char(char);
+complexOf_int cis_fun_int(int);
+complexOf_long cis_fun_long(long);
+complexOf_llong cis_fun_llong(long long);
+complexOf_uchar cis_fun_uchar(unsigned char);
+complexOf_uint cis_fun_uint(unsigned);
+complexOf_ulong cis_fun_ulong(unsigned long);
+complexOf_ullong cis_fun_ullong(unsigned long long);
+complexOf_float cis_fun_float(float);
+unsigned cis_fun_short(short);
+unsigned cis_fun_ushort(unsigned short);
+
+#endif /* FELDSPAR_TI_C64X_H */

--- a/clib/ivar.c
+++ b/clib/ivar.c
@@ -1,0 +1,224 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdlib.h>
+#include <string.h>
+//#define LOG
+#include "log.h"
+
+/* Type of function pointer */
+typedef void* array_copy_t(void* dst, int32_t dstLen, void* src, int32_t srcLen);
+
+int feldspar_ivar_hook(void) {
+  return 0;
+}
+
+void *worker(void *p);
+
+void ivar_init(struct ivar *iv) {
+    struct ivar_internals *ivi;
+    log_1("ivar_init %p - enter\n", iv);
+    ivi = iv->internals = (struct ivar_internals*)malloc(sizeof(struct ivar_internals));
+    int err = pthread_mutex_init(&(ivi->mutex), NULL);
+    if (err) exit(err);
+    err = pthread_cond_init(&(ivi->cond), NULL);
+    if (err) exit(err);
+    ivi->full = 0;
+    iv->self = iv;
+    log_1("ivar_init %p - leave\n", iv);
+}
+
+void ivar_destroy(struct ivar *iv) {    // TODO: Think about ivars escaping from their scope...
+    log_1("ivar_destroy %p - enter\n", iv);
+    if (iv->self == iv) {   // This is true iff this iVar is not a copy.
+        struct ivar_internals *ivi = iv->internals;
+        pthread_mutex_destroy(&(ivi->mutex));
+        pthread_cond_destroy(&(ivi->cond));
+        if (ivi->full)
+            free(ivi->data); // TODO: Destroy deep?
+        free(ivi);
+    }
+    log_1("ivar_destroy %p - leave\n", iv);
+}
+
+void ivar_put_with_size(struct ivar iv, void *d, int size) {
+    struct ivar_internals *ivi = iv.internals;
+    log_3("ivar_put_with_size %p %p %d - enter\n", &iv, d, size);
+    pthread_mutex_lock(&(ivi->mutex));
+    ivi->data = malloc(size);
+    memcpy(ivi->data, d, size);
+    ivi->full = 1;
+    pthread_cond_broadcast(&(ivi->cond));
+    pthread_mutex_unlock(&(ivi->mutex));
+    log_3("ivar_put_with_size %p %p %d - leave\n", &iv, d, size);
+}
+
+void ivar_put_array(struct ivar iv, void *dv, void* vcf) {
+    struct ivar_internals *ivi = iv.internals;
+    log_2("ivar_put_array %p %p - enter\n", &iv, d);
+    pthread_mutex_lock(&(ivi->mutex));
+    array_copy_t *cf = (array_copy_t*) vcf;
+    struct array *str = allocArray(ivi->data);
+    struct array *d = dv;
+    str->buffer = cf(str->buffer, str->length, d->buffer, d->length);
+    str->length = d->length;
+    ivi->data = str;
+    ivi->full = 1;
+    pthread_cond_broadcast(&(ivi->cond));
+    pthread_mutex_unlock(&(ivi->mutex));
+    log_2("ivar_put_array %p %p - leave\n", &iv, d);
+}
+
+void ivar_put_array_shallow(struct ivar iv, void *dv, int32_t size) {
+    struct ivar_internals *ivi = iv.internals;
+    log_2("ivar_put_array_shallow %p %p - enter\n", &iv, d);
+    pthread_mutex_lock(&(ivi->mutex));
+    struct array *str = allocArray(ivi->data);
+    struct array *d = dv;
+    str->buffer = initCopyArray(str->buffer, str->length, size, d->buffer, d->length);
+    str->length = d->length;
+    ivi->data = str;
+    ivi->full = 1;
+    pthread_cond_broadcast(&(ivi->cond));
+    pthread_mutex_unlock(&(ivi->mutex));
+    log_2("ivar_put_array_shallow %p %p - leave\n", &iv, d);
+}
+
+void ivar_get_helper(struct ivar_internals *iv) {
+    log_1("ivar_get_helper %p - enter\n", iv);
+    pthread_mutex_lock(&(iv->mutex));
+    if (!iv->full) {
+        log_1("ivar_get_helper %p - ivar is empty\n", iv);
+        taskpool_spawn_worker();
+        log_1("ivar_get_helper %p - blocking while waiting for data\n", iv);
+        pthread_cond_wait(&(iv->cond), &(iv->mutex));
+        log_1("ivar_get_helper %p - data arrived\n" , iv);
+    }
+    pthread_mutex_unlock(&(iv->mutex));
+    log_1("ivar_get_helper %p - leave\n", iv);
+}
+
+void ivar_get_with_size(void *var, struct ivar iv, int size) {
+    log_3("ivar_get_with_size %p %p %d - enter\n", var, &iv, size);
+    ivar_get_helper(iv.internals);
+    memcpy(var, iv.internals->data, size);
+    log_3("ivar_get_with_size %p %p %d - leave\n", var, &iv, size);
+}
+
+void ivar_get_array(void *vvar, struct ivar iv, void* vcf) {
+    struct array *ptr;
+    log_2("ivar_get_array %p %p - enter\n", var, &iv);
+    ivar_get_helper(iv.internals);
+    ptr = (struct array*)iv.internals->data;
+    assert(ptr);
+    struct array *var = vvar;
+    array_copy_t* cf = (array_copy_t*) vcf;
+    var->buffer = cf(var->buffer, var->length, ptr->buffer, ptr->length);
+    var->length = ptr->length;
+    log_2("ivar_get_array %p %p - leave\n", var, &iv);
+}
+
+void ivar_get_array_shallow(void *vvar, struct ivar iv, int32_t size) {
+    struct array *ptr;
+    log_2("ivar_get_array_shallow %p %p - enter\n", var, &iv);
+    ivar_get_helper(iv.internals);
+    ptr = (struct array*)iv.internals->data;
+    assert(ptr);
+    struct array *var = vvar;
+    var->buffer = initCopyArray(var->buffer, var->length, size, ptr->buffer, ptr->length);
+    var->length = ptr->length;
+    log_2("ivar_get_arra_shallowy %p %p - leave\n", var, &iv);
+}
+
+void ivar_get_nontask_with_size(void *var, struct ivar iv, int size) {
+    struct ivar_internals *ivi = iv.internals;
+    log_3("ivar_get_nontask_with_size %p %p %d - enter\n", var, &iv, size);
+    pthread_mutex_lock(&(ivi->mutex));
+    if (!ivi->full)
+        log_3("ivar_get_nontask_with_size %p %p %d -> waiting for data\n"
+             , var, &iv, size);
+    while (!ivi->full) {
+        int err = pthread_cond_wait(&(ivi->cond), &(ivi->mutex));
+        if (err) exit(err);
+    }
+    pthread_mutex_unlock(&(ivi->mutex));
+    assert(ivi->data);
+    memcpy(var, ivi->data, size);
+    log_3("ivar_get_nontask_with_size %p %p %d - leave\n", var, &iv, size);
+}
+
+void ivar_get_array_nontask(void *vvar, struct ivar iv, void* vcf) {
+    struct ivar_internals *ivi = iv.internals;
+    struct array *ptr;
+    log_2("ivar_get_array_nontask %p %p - enter\n", var, &iv);
+    pthread_mutex_lock(&(ivi->mutex));
+    if (!ivi->full)
+        log_2("ivar_get_array_nontask %p %p - waiting for data\n", var, &iv);
+    while (!ivi->full) {
+        int err = pthread_cond_wait(&(ivi->cond), &(ivi->mutex));
+        if (err) { exit(err); }
+    }
+    assert(ivi->full);
+    pthread_mutex_unlock(&(ivi->mutex));
+    if (NULL == ivi->data) {
+        log_2("ivar_get_array_nontask %p %p - data uninitialized\n", var, &iv);
+    } else {
+        ptr = (struct array*)ivi->data;
+        struct array *var = vvar;
+        array_copy_t* cf = (array_copy_t*) vcf;
+        var->buffer = cf(var->buffer, var->length, ptr->buffer, ptr->length);
+        var->length = ptr->length;
+    }
+    log_2("ivar_get_array_nontask %p %p - leave\n", var, &iv);
+}
+
+void ivar_get_array_shallow_nontask(void *vvar, struct ivar iv, int32_t size) {
+    struct ivar_internals *ivi = iv.internals;
+    struct array *ptr;
+    log_2("ivar_get_array_shallow_nontask %p %p - enter\n", var, &iv);
+    pthread_mutex_lock(&(ivi->mutex));
+    if (!ivi->full)
+        log_2("ivar_get_array_shallow_nontask %p %p - waiting for data\n", var, &iv);
+    while (!ivi->full) {
+        int err = pthread_cond_wait(&(ivi->cond), &(ivi->mutex));
+        if (err) exit(err);
+    }
+    assert(ivi->full);
+    pthread_mutex_unlock(&(ivi->mutex));
+    if (NULL == ivi->data) {
+        log_2("ivar_get_array_shallow_nontask %p %p - data uninitialized\n", var, &iv);
+    } else {
+        ptr = (struct array*)ivi->data;
+        struct array *var = vvar;
+        var->buffer = initCopyArray(var->buffer, var->length, size, ptr->buffer, ptr->length);
+        var->length = ptr->length;
+    }
+    log_2("ivar_get_array_shallow_nontask %p %p - leave\n", var, &iv);
+}

--- a/clib/ivar.h
+++ b/clib/ivar.h
@@ -1,0 +1,92 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice, 
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef IVAR_H
+#define IVAR_H
+
+#include <pthread.h>
+#include "feldspar_array.h"
+
+int feldspar_ivar_hook(void);
+
+struct ivar_internals {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int full;
+    void *data;
+};
+
+struct ivar {
+    struct ivar_internals *internals;
+    struct ivar *self;
+};
+
+/* Initializes 'iv'. */
+void ivar_init(struct ivar *iv);
+
+/* Deinitializes ivar 'iv'. */
+void ivar_destroy(struct ivar *iv);
+
+/* Copies the data at 'd' of size 'size' into the ivar 'iv'. Ivars are 
+ * allowed to be written only once! */
+void ivar_put_with_size(struct ivar iv, void *d, int size);
+
+/* Wrapper to 'ivar_put_with_size'. */
+#define ivar_put(typ,iv,d) ivar_put_with_size(iv,d,sizeof(typ))
+
+/* Specialized version for arrays. */
+void ivar_put_array(struct ivar iv, void *d, void* cf);
+void ivar_put_array_shallow(struct ivar iv, void *d, int32_t size);
+
+/* Copies the data of size 'size' of the ivar 'iv' to 'var'. Ivars are
+ * allowed to be read any number of times. Reading an empty ivar blocks
+ * the thread, but a new worker thread is started instead.
+ * Use this function only inside tasks! */
+void ivar_get_with_size(void *var, struct ivar iv, int size);
+
+/* Wrapper to 'ivar_get_with_size'. */
+#define ivar_get(typ,var,iv) ivar_get_with_size(var,iv,sizeof(typ))
+
+/* Specialized version for arrays. */
+void ivar_get_array(void *var, struct ivar iv, void* cf);
+void ivar_get_array_shallow(void *var, struct ivar iv, int32_t size);
+
+/* Copies the data of size 'size' of the ivar 'iv' to 'var'. Ivars are
+ * allowed to be read any number of times. Reading an empty ivar blocks
+ * the thread.
+ * Use this function only outside tasks, eg. the main thread or similar! */
+void ivar_get_nontask_with_size(void *var, struct ivar iv, int size);
+
+/* Wrapper to 'ivar_get_nontask_with_size'. */
+#define ivar_get_nontask(typ,var,iv) ivar_get_nontask_with_size(var,iv,sizeof(typ))
+
+/* Specialized version for arrays. */
+void ivar_get_array_nontask(void *var, struct ivar iv, void* vcf);
+void ivar_get_array_shallow_nontask(void *var, struct ivar iv, int32_t size);
+
+#endif /* IVAR_H */

--- a/clib/log.h
+++ b/clib/log.h
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef LOG_H
+#define LOG_H
+
+#include <stdio.h>
+
+#ifdef LOG
+    #define log_0(text) printf(text)
+    #define log_1(text,x1) printf(text,x1)
+    #define log_2(text,x1,x2) printf(text,x1,x2)
+    #define log_3(text,x1,x2,x3) printf(text,x1,x2,x3)
+    #define log_4(text,x1,x2,x3,x4) printf(text,x1,x2,x3,x4)
+    #define log_5(text,x1,x2,x3,x4,x5) printf(text,x1,x2,x3,x4,x5)
+#else
+    #define log_0(text) 
+    #define log_1(text,x1) 
+    #define log_2(text,x1,x2) 
+    #define log_3(text,x1,x2,x3)
+    #define log_4(text,x1,x2,x3,x4)
+    #define log_5(text,x1,x2,x3,x4,x5)
+#endif
+
+#endif /* LOG_H */

--- a/clib/taskpool.c
+++ b/clib/taskpool.c
@@ -1,0 +1,168 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include "taskpool.h"
+//#define LOG
+#include "log.h"
+
+int feldspar_taskpool_hook(void) {
+  return 0;
+}
+
+/* Definition of the Feldspar application's global taskpool. */
+typedef struct {
+    int capacity;
+    int num_threads, act_threads, min_threads, max_threads;
+    int head, tail;
+    void **closures;
+    int shutdown;
+    pthread_mutex_t mutex;
+} taskpool;
+
+static taskpool *feldspar_taskpool = 0;
+
+void *worker();
+
+void taskpool_init(int c, int n, int m)  {
+    log_3("taskpool_init %d %d %d - enter\n",c,n,m);
+    log_0("taskpool_init - allocating taskpool\n");
+    feldspar_taskpool = calloc(1, sizeof(taskpool));
+    log_1("taskpool_init - allocating %d closures\n",c);
+    feldspar_taskpool->closures = malloc(c * sizeof(void *));
+    feldspar_taskpool->capacity = c;
+    feldspar_taskpool->min_threads = m;
+    feldspar_taskpool->max_threads = n;
+    pthread_mutex_init(&(feldspar_taskpool->mutex), NULL);
+    log_1("taskpool_init - starting %d threads\n",n);
+    for (; n > 0; --n)
+      taskpool_spawn_worker();
+    log_0("taskpool_init - leave\n");
+}
+
+void taskpool_shutdown() {
+    log_0("taskpool_shutdown - enter\n");
+    feldspar_taskpool->shutdown = 1;
+    log_0("taskpool_shutdown - shutdown signalled, waiting for workers\n");
+    while (1) {
+      pthread_mutex_lock(&feldspar_taskpool->mutex);
+      int ths = feldspar_taskpool->num_threads;
+      pthread_mutex_unlock(&feldspar_taskpool->mutex);
+      if (0 == ths) break;
+    }
+    log_0("taskpool_shutdown - all threads have stopped\n");
+    pthread_mutex_destroy (&feldspar_taskpool->mutex);
+    log_0("taskpool_shutdown - leave\n");
+}
+
+void taskpool_spawn_worker() {
+  log_0("taskpool_spawn_worker - enter\n");
+  pthread_mutex_lock(&feldspar_taskpool->mutex);
+  if (!feldspar_taskpool->shutdown) {
+    pthread_t th;
+    pthread_create(&th, NULL, &worker, NULL);
+    pthread_detach(th);
+    log_1("taskpool_spawn_worker - create thread %d\n", (unsigned)th);
+    ++feldspar_taskpool->num_threads;
+    ++feldspar_taskpool->act_threads;
+  }
+  pthread_mutex_unlock(&feldspar_taskpool->mutex);
+  log_0("taskpool_spawn_worker - leave\n");
+}
+
+void spawn(void *closure) {
+    log_1("spawn %p - enter\n", closure);
+    assert(feldspar_taskpool);
+    pthread_mutex_lock(&(feldspar_taskpool->mutex));
+    feldspar_taskpool->closures[feldspar_taskpool->tail] = closure;
+    log_3("spawn %p - saved as task %d at %p\n"
+         , closure, feldspar_taskpool->tail
+         , &feldspar_taskpool->closures[feldspar_taskpool->tail]);
+    ++feldspar_taskpool->tail;
+    if (feldspar_taskpool->tail == feldspar_taskpool->capacity)
+        feldspar_taskpool->tail = 0;
+    pthread_mutex_unlock(&(feldspar_taskpool->mutex));
+    log_1("spawn %p - leave\n", closure);
+}
+
+void *worker() {
+#ifdef LOG
+    unsigned int self = (unsigned long)pthread_self();
+#endif
+    log_1("worker %d - enter\n", self);
+    taskpool *pool = feldspar_taskpool;
+    void (*fun)();
+    void *closure;
+    int awake = 1;
+    log_1("worker %d - entering the loop\n", self);
+    while (1) {
+        if (pool->shutdown && pool->head == pool->tail) {
+            log_1("worker %d - shutdown detected, going to terminate\n", self);
+            break;
+        }
+        if (pool->act_threads > pool->max_threads) {
+            log_1("worker %d - too many active threads, going to terminate\n", self);
+            break;
+        }
+        fun = NULL;
+        closure = NULL;
+        pthread_mutex_lock(&(pool->mutex));
+        if (pool->head != pool->tail) {
+            log_2("worker %d - pop task %d\n", self, pool->head);
+            closure = pool->closures[pool->head];
+            ++pool->head;
+            if (pool->head == pool->capacity)
+                pool->head = 0;
+        }
+        pthread_mutex_unlock(&(pool->mutex));
+        if (closure == NULL) {
+            if (1 == awake) {
+                log_1("worker %d - sleep\n", self);
+                awake = 0;
+            }
+        } else {
+            awake = 1;
+            fun = *((void(**)())closure);
+            log_2("worker %d - closure %p enter\n", self, fun);
+            fun(closure + sizeof(void(*)())); /* TODO: sizeof(void*) == sizeof(void(**)()) is assumed here */
+            log_2("worker %d - closure %p leave\n", self, fun);
+        }
+    }
+    /* Cleanup before exit: */
+    log_1("worker %d - cleanup\n", self);
+    pthread_mutex_lock(&(pool->mutex));
+    --pool->num_threads;
+    --pool->act_threads;
+    log_3("worker %d - cleanup done; active: %d, all: %d\n"
+         , self, pool->act_threads, pool->num_threads);
+    pthread_mutex_unlock(&(pool->mutex));
+    log_1("worker %d - leave\n", self);
+    pthread_exit(NULL);
+}

--- a/clib/taskpool.h
+++ b/clib/taskpool.h
@@ -1,0 +1,365 @@
+//
+// Copyright (c) 2009-2011, ERICSSON AB
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of the ERICSSON AB nor the names of its contributors
+//       may be used to endorse or promote products derived from this software
+//       without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef TASKPOOL_H
+#define TASKPOOL_H
+
+#include <pthread.h>
+
+int feldspar_taskpool_hook(void);
+
+void taskpool_init(int c, int num, int min);
+
+void taskpool_shutdown();
+
+void taskpool_spawn_worker();
+
+void spawn(void *closure);
+
+/* Helper macro: */
+/* TODO: Replace runtime check with a compile time one! */
+#define check_array(t, temp)   \
+    if (!strcmp(#t,"struct array *")) { \
+        void *m = malloc(sizeof(struct array)); \
+        memcpy(m, *(void**)(&(temp)), sizeof(struct array));    \
+        memcpy((void*)&(temp), (void*)&m, sizeof(void*));   \
+    }   \
+
+/* Wrappers for spawn with different number of arguments: */
+
+#define spawn0(task)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        spawn(buffer);    \
+    }   \
+
+#define spawn1(task, t1, p1)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        spawn(buffer);    \
+    }   \
+
+#define spawn2(task, t1, p1, t2, p2)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1) + sizeof(t2));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        t2 temp2 = (p2);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        p += sizeof(t1);    \
+        check_array(t2, temp2);   \
+        memcpy(p, &temp2, sizeof(t2));    \
+        spawn(buffer);    \
+    }   \
+
+#define spawn3(task, t1, p1, t2, p2, t3, p3)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1) + sizeof(t2) + sizeof(t3));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        t2 temp2 = (p2);    \
+        t3 temp3 = (p3);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        p += sizeof(t1);    \
+        check_array(t2, temp2);   \
+        memcpy(p, &temp2, sizeof(t2));    \
+        p += sizeof(t2);    \
+        check_array(t3, temp3);   \
+        memcpy(p, &temp3, sizeof(t3));    \
+        spawn(buffer);    \
+    }   \
+
+#define spawn4(task, t1, p1, t2, p2, t3, p3, t4, p4)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1) + sizeof(t2) + sizeof(t3) + sizeof(t4));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        t2 temp2 = (p2);    \
+        t3 temp3 = (p3);    \
+        t4 temp4 = (p4);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        p += sizeof(t1);    \
+        check_array(t2, temp2);   \
+        memcpy(p, &temp2, sizeof(t2));    \
+        p += sizeof(t2);    \
+        check_array(t3, temp3);   \
+        memcpy(p, &temp3, sizeof(t3));    \
+        p += sizeof(t3);    \
+        check_array(t4, temp4);   \
+        memcpy(p, &temp4, sizeof(t4));    \
+        spawn(buffer);    \
+    }   \
+
+#define spawn5(task, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1) + sizeof(t2) + sizeof(t3) + sizeof(t4) + sizeof(t5));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        t2 temp2 = (p2);    \
+        t3 temp3 = (p3);    \
+        t4 temp4 = (p4);    \
+        t5 temp5 = (p5);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        p += sizeof(t1);    \
+        check_array(t2, temp2);   \
+        memcpy(p, &temp2, sizeof(t2));    \
+        p += sizeof(t2);    \
+        check_array(t3, temp3);   \
+        memcpy(p, &temp3, sizeof(t3));    \
+        p += sizeof(t3);    \
+        check_array(t4, temp4);   \
+        memcpy(p, &temp4, sizeof(t4));    \
+        p += sizeof(t4);    \
+        check_array(t5, temp5);   \
+        memcpy(p, &temp5, sizeof(t5));    \
+        spawn(buffer);    \
+    }   \
+
+#define spawn6(task, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1) + sizeof(t2) + sizeof(t3) + sizeof(t4) + sizeof(t5) + sizeof(t6));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        t2 temp2 = (p2);    \
+        t3 temp3 = (p3);    \
+        t4 temp4 = (p4);    \
+        t5 temp5 = (p5);    \
+        t6 temp6 = (p6);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        p += sizeof(t1);    \
+        check_array(t2, temp2);   \
+        memcpy(p, &temp2, sizeof(t2));    \
+        p += sizeof(t2);    \
+        check_array(t3, temp3);   \
+        memcpy(p, &temp3, sizeof(t3));    \
+        p += sizeof(t3);    \
+        check_array(t4, temp4);   \
+        memcpy(p, &temp4, sizeof(t4));    \
+        p += sizeof(t4);    \
+        check_array(t5, temp5);   \
+        memcpy(p, &temp5, sizeof(t5));    \
+        p += sizeof(t5);    \
+        check_array(t6, temp6);   \
+        memcpy(p, &temp6, sizeof(t6));    \
+        spawn(buffer);    \
+    }   \
+
+#define spawn7(task, t1, p1, t2, p2, t3, p3, t4, p4, t5, p5, t6, p6 , t7, p7)  \
+    {   \
+        void *buffer = malloc(sizeof(void(*)()) + sizeof(t1) + sizeof(t2) + sizeof(t3) + sizeof(t4) + sizeof(t5) + sizeof(t6) + sizeof(t7));   \
+        char *p = buffer;   \
+        void *t0 = &task;    \
+        t1 temp1 = (p1);    \
+        t2 temp2 = (p2);    \
+        t3 temp3 = (p3);    \
+        t4 temp4 = (p4);    \
+        t5 temp5 = (p5);    \
+        t6 temp6 = (p6);    \
+        t7 temp7 = (p7);    \
+        memcpy(p, &t0, sizeof(void(*)()));   \
+        p += sizeof(void(*)()); \
+        check_array(t1, temp1);   \
+        memcpy(p, &temp1, sizeof(t1));    \
+        p += sizeof(t1);    \
+        check_array(t2, temp2);   \
+        memcpy(p, &temp2, sizeof(t2));    \
+        p += sizeof(t2);    \
+        check_array(t3, temp3);   \
+        memcpy(p, &temp3, sizeof(t3));    \
+        p += sizeof(t3);    \
+        check_array(t4, temp4);   \
+        memcpy(p, &temp4, sizeof(t4));    \
+        p += sizeof(t4);    \
+        check_array(t5, temp5);   \
+        memcpy(p, &temp5, sizeof(t5));    \
+        p += sizeof(t5);    \
+        check_array(t6, temp6);   \
+        memcpy(p, &temp6, sizeof(t6));    \
+        p += sizeof(t6);    \
+        check_array(t7, temp7);   \
+        memcpy(p, &temp7, sizeof(t7));    \
+        spawn(buffer);    \
+    }   \
+
+/* Wrappers for task cores with different number of arguments: */
+
+#define run0(task_core)   \
+    {   \
+        (task_core)();   \
+    }   \
+
+#define run1(task_core, t1)   \
+    {   \
+        t1 p1;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        (task_core)(p1);   \
+    }   \
+
+#define run2(task_core, t1, t2)   \
+    {   \
+        t1 p1;  \
+        t2 p2;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        p += sizeof(t1);    \
+        memcpy(&p2, p, sizeof(t2));  \
+        (task_core)(p1,p2);   \
+    }   \
+
+#define run3(task_core, t1, t2, t3)   \
+    {   \
+        t1 p1;  \
+        t2 p2;  \
+        t3 p3;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        p += sizeof(t1);    \
+        memcpy(&p2, p, sizeof(t2));  \
+        p += sizeof(t2);    \
+        memcpy(&p3, p, sizeof(t3));  \
+        (task_core)(p1,p2,p3);   \
+    }   \
+
+#define run4(task_core, t1, t2, t3, t4)   \
+    {   \
+        t1 p1;  \
+        t2 p2;  \
+        t3 p3;  \
+        t4 p4;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        p += sizeof(t1);    \
+        memcpy(&p2, p, sizeof(t2));  \
+        p += sizeof(t2);    \
+        memcpy(&p3, p, sizeof(t3));  \
+        p += sizeof(t3);    \
+        memcpy(&p4, p, sizeof(t4));  \
+        (task_core)(p1,p2,p3,p4);   \
+    }   \
+
+#define run5(task_core, t1, t2, t3, t4, t5)   \
+    {   \
+        t1 p1;  \
+        t2 p2;  \
+        t3 p3;  \
+        t4 p4;  \
+        t5 p5;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        p += sizeof(t1);    \
+        memcpy(&p2, p, sizeof(t2));  \
+        p += sizeof(t2);    \
+        memcpy(&p3, p, sizeof(t3));  \
+        p += sizeof(t3);    \
+        memcpy(&p4, p, sizeof(t4));  \
+        p += sizeof(t4);    \
+        memcpy(&p5, p, sizeof(t5));  \
+        (task_core)(p1,p2,p3,p4,p5);   \
+    }   \
+
+#define run6(task_core, t1, t2, t3, t4, t5, t6)   \
+    {   \
+        t1 p1;  \
+        t2 p2;  \
+        t3 p3;  \
+        t4 p4;  \
+        t5 p5;  \
+        t6 p6;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        p += sizeof(t1);    \
+        memcpy(&p2, p, sizeof(t2));  \
+        p += sizeof(t2);    \
+        memcpy(&p3, p, sizeof(t3));  \
+        p += sizeof(t3);    \
+        memcpy(&p4, p, sizeof(t4));  \
+        p += sizeof(t4);    \
+        memcpy(&p5, p, sizeof(t5));  \
+        p += sizeof(t5);    \
+        memcpy(&p6, p, sizeof(t6));  \
+        (task_core)(p1,p2,p3,p4,p5,p6);   \
+    }   \
+
+#define run7(task_core, t1, t2, t3, t4, t5, t6, t7)   \
+    {   \
+        t1 p1;  \
+        t2 p2;  \
+        t3 p3;  \
+        t4 p4;  \
+        t5 p5;  \
+        t6 p6;  \
+        t7 p7;  \
+        char *p = params;   \
+        memcpy(&p1, p, sizeof(t1));  \
+        p += sizeof(t1);    \
+        memcpy(&p2, p, sizeof(t2));  \
+        p += sizeof(t2);    \
+        memcpy(&p3, p, sizeof(t3));  \
+        p += sizeof(t3);    \
+        memcpy(&p4, p, sizeof(t4));  \
+        p += sizeof(t4);    \
+        memcpy(&p5, p, sizeof(t5));  \
+        p += sizeof(t5);    \
+        memcpy(&p6, p, sizeof(t6));  \
+        p += sizeof(t6);    \
+        memcpy(&p7, p, sizeof(t7));  \
+        (task_core)(p1,p2,p3,p4,p5,p6,p7);   \
+    }   \
+
+#endif /* TASKPOOL_H */

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -19,7 +19,7 @@ license-file:   LICENSE
 stability:      experimental
 homepage:       http://feldspar.github.com
 bug-reports:    https://github.com/feldspar/feldspar-language/issues
-build-type:     Simple
+build-type:     Custom
 cabal-version:  >= 1.14
 tested-with:    GHC==8.0.2, GHC==8.4.4
 
@@ -81,18 +81,56 @@ library
     Feldspar.Algorithm.FFT.Push
     Feldspar.Algorithm.FFT.Twids
     Feldspar.Algorithm.FFT.Utils
+    -- Compiler
+    Feldspar.Compiler
+    Feldspar.Compiler.Imperative.ArrayOps
+    Feldspar.Compiler.Imperative.Representation
+    Feldspar.Compiler.Imperative.ExternalProgram
+    Feldspar.Compiler.Imperative.FromCore
+    Feldspar.Compiler.Imperative.FromCore.Interpretation
+    Feldspar.Compiler.Imperative.Frontend
+    Feldspar.Compiler.Backend.C.CodeGeneration
+    Feldspar.Compiler.Backend.C.Library
+    Feldspar.Compiler.Backend.C.MachineLowering
+    Feldspar.Compiler.Backend.C.Tic64x
+    Feldspar.Compiler.Backend.C.Options
+    Feldspar.Compiler.Backend.C.Platforms
+    Feldspar.Compiler.Backend.C.RuntimeLibrary
+    Feldspar.Compiler.Frontend.Interactive.Interface
+    Feldspar.Compiler.Plugin
+    Feldspar.Compiler.Marshal
+    Feldspar.Compiler.CallConv
+    Feldspar.Compiler.Compiler
+    Feldspar.Compiler.Error
+    Feldspar.Compiler.ExternalProgram
+    Feldspar.Runtime
 
   default-language: Haskell2010
 
   build-depends:
     array,
     base                        >= 4.9.1  && < 5.9,
+    base-compat                 >= 0.8,
     bytestring                  >= 0.10   && < 0.11,
+    Cabal,
     containers                  >= 0.4    && < 0.7,
+    data-default                >= 0.5,
+    directory                   >= 1.1,
+    filepath,
+    ghc,
+    ghci,
+    ghc-paths,
+    language-c-quote            >= 0.12  && < 0.13,
     mtl                         >= 2.0    && < 2.3,
     QuickCheck                  >= 2.7    && < 3,
     patch-combinators           >= 0.2    && < 0.3,
+    plugins-multistage          >= 0.6.3 && < 0.7,
     prelude-edsl                             < 0.4,
+    pretty,
+    process,
+    srcloc,
+    storable-tuple              >= 0.0.2,
+    storable-record             >= 0.0.2.5,
     template-haskell,
     tuple                       >= 0.2    && < 0.5,
     monad-par                   >= 0.3.4.5,
@@ -101,6 +139,35 @@ library
     data-default                >= 0.5.3  && < 0.8,
     data-hash                   >= 0.2.0.1 && < 100,
     tree-view
+
+  cpp-options: -DCABAL_IS_USED
+
+  c-sources:
+    clib/feldspar_c99.c
+    clib/taskpool.c
+    clib/ivar.c
+
+  cc-options: -std=c99 -Wall -fPIC
+
+  if os(linux)
+    extra-libraries: gcc_s pthread
+      -- pthread needed on Emil's Ubuntu (15.04), but apparently not on Travis
+
+  include-dirs:
+    ./clib
+
+  install-includes:
+    feldspar_array.h
+    feldspar_c99.h
+    feldspar_c99.c
+    feldspar_tic64x.h
+    feldspar_tic64x.c
+    feldspar_future.h
+    log.h
+    ivar.h
+    ivar.c
+    taskpool.h
+    taskpool.c
 
   hs-source-dirs: src examples
 
@@ -202,3 +269,48 @@ test-suite tutorial
     bytestring         >= 0.9 && < 0.11
 
   ghc-options: -threaded -with-rtsopts=-maxN4
+
+test-suite regression
+  type: exitcode-stdio-1.0
+
+  hs-source-dirs: tests
+
+  main-is: RegressionTests.hs
+
+  default-language: Haskell2010
+
+  build-depends:
+    feldspar-language,
+    mtl,
+    base,
+    Cabal,
+    process,
+    bytestring       >= 0.9 && < 0.11,
+    stringsearch     >= 0.3,
+    tasty            >= 0.3,
+    tasty-golden     >= 2.3.0.1,
+    tasty-quickcheck >= 0.3,
+    QuickCheck       >= 2.7.1 && < 3.0
+
+test-suite callconv
+  type: exitcode-stdio-1.0
+
+  hs-source-dirs: tests
+
+  main-is: CallingConvention.hs
+
+  default-language: Haskell2010
+
+  build-depends:
+    feldspar-language,
+    base,
+    tasty            >= 0.3,
+    tasty-quickcheck >= 0.3,
+    QuickCheck       >= 2.7.1 && < 3.0
+
+custom-setup
+  setup-depends:
+    base,
+    Cabal,
+    filepath,
+    process

--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -1,0 +1,27 @@
+module Feldspar.Compiler
+  ( compile
+  , compileUT
+  , icompile
+  , icompileWith
+  , icompile'
+  , program
+  , programOpts
+  , programOptsArgs
+  , getCore
+  , printCore
+  , Options(..)
+  , defaultOptions
+  , sicsOptions
+  , sicsOptions2
+  , sicsOptions3
+  , FeldOpts(..)
+  , Target(..)
+  , c99PlatformOptions
+  , c99OpenMpPlatformOptions
+  , tic64xPlatformOptions
+  ) where
+
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Compiler
+import Feldspar.Compiler.Frontend.Interactive.Interface
+import Feldspar.Core.Interpretation (FeldOpts(..), Target(..))

--- a/src/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/src/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -1,0 +1,335 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Backend.C.CodeGeneration where
+
+import Prelude hiding (Semigroup(..), (<>), init)
+
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Compiler.Error (handleError, ErrorClass(..))
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Imperative.Frontend (
+    isNativeArray, isArray, isPointer
+  )
+
+import Text.PrettyPrint
+
+codeGenerationError :: ErrorClass -> String -> a
+codeGenerationError = handleError "CodeGeneration"
+
+data PrintEnv = PEnv
+    { options :: Options
+    , parNestLevel :: Int
+    }
+
+compToCWithInfos :: Options -> Module () -> String
+compToCWithInfos opts procedure = render $ cgen (penv0 opts) procedure
+
+penv0 :: Options -> PrintEnv
+penv0 opts = PEnv opts 0
+
+class CodeGen a
+  where
+    cgen     :: PrintEnv -> a -> Doc
+    cgenList :: PrintEnv -> [a] -> Doc
+
+instance CodeGen (Module ())
+  where
+    cgen env Module{..} = cgenList env entities
+    cgenList env = vcat . map (cgen env)
+
+instance CodeGen (Entity ())
+  where
+    cgen env StructDef{..} = text "struct"   <+> text structName     $+$ block env (cgenList env structMembers) <> semi
+    cgen env TypeDef{..}   = text "typedef"  <+> cgen env actualType <+> text typeName <> semi
+    cgen env Proc{..}
+      | Just body <- procBody = start $$ block env (cgen env body)
+      | otherwise = start <> semi
+        where
+         start
+           | loopBody  = text ("LOOP_BODY_" ++ show (length inParams - 1))
+                          <> parens (sep $ punctuate comma loopH)
+           | otherwise = rtype <+> text procName <> parens (pvars env inParams)
+         rtype = cgen env procType
+         loopH = [text procName, text "LARGE_BODY"] ++
+                  concatMap (\v ->  [cgen env (typeof v), cgen env v]) inParams
+    cgen env ValueDef{..}
+      | isNativeArray $ typeof valVar
+      = cgen env (typeof valVar) <+> cgen env valVar <> brackets empty   <+> equals <+> cgen env valValue <> semi
+      | otherwise = cgen env valVar <+> equals              <+> cgen env valValue <> semi
+
+    cgenList env = vcat . punctuate (text "\n") . map (cgen env)
+
+instance CodeGen (StructMember ())
+  where
+    cgen env StructMember{..} = cgen env structMemberType <+> text structMemberName <> sizeInBrackets structMemberType <> semi
+
+    cgenList env = vcat . map (cgen env)
+
+instance CodeGen (Block ())
+  where
+    cgen env Block{..} = vcat [ cgenList env locals
+                            , if null locals then empty else text ""
+                            , cgen env blockBody
+                            ]
+    cgenList env = vcat . map (cgen env)
+
+instance CodeGen (Declaration ())
+  where
+    cgen env Declaration{..}
+     | Just i <- initVal
+     = var <+> nest (nestSize $ options env) equals <+> specialInit (typeof declVar) i <> semi
+     | otherwise = var <+> nest (nestSize $ options env) init <> semi
+      where
+        var  = pvar env declVar
+        init = initialize (varType declVar)
+        specialInit t i
+          | ConstExpr (StructConst es (StructType _ ts)) <- i
+          = printStruct env es ts
+          | ConstExpr (IntConst 0 _) <- i
+          , isArray t || isPointer t
+          = text "NULL"
+          | otherwise = cgen env i
+
+    cgenList env = vcat . map (cgen env)
+
+instance CodeGen (Program ())
+  where
+    cgen _   Empty = empty
+    cgen _   Comment{..}
+      | isBlockComment = blockComment $ map text $ lines commentValue
+      | otherwise      = text "//" <+> text commentValue
+    cgen env Assign{..} = cgen env lhs <+> equals <+> nest (nestSize $ options env) (cgen env rhs) <> semi
+    cgen env ProcedureCall{..} = stmt $ call (text procCallName) (map (cgen env) procCallParams)
+    cgen env Sequence{..} = cgenList env sequenceProgs
+    cgen env (Switch scrut [(Pat (ConstExpr (BoolConst True)), thenBlock)])
+                        = text "if" <+> parens (cgen env scrut)
+                       $$ block env (cgen env thenBlock)
+    cgen env (Switch scrut [(Pat (ConstExpr (BoolConst True)), thenBlock),
+                            (Pat (ConstExpr (BoolConst False)), elseBlock)])
+                        = text "if" <+> parens (cgen env scrut)
+                       $$ block env (cgen env thenBlock)
+                       $$ text "else"
+                       $$ block env (cgen env elseBlock)
+    cgen env Switch{..} =  text "switch" <+> parens (cgen env scrutinee)
+                       $$ block env (vcat [ cgen env p $$ nest (nestSize $ options env) (cgen env b $$ text "break" <> semi) | (p, b) <- alts])
+    cgen env SeqLoop{..} =  cgen env sLoopCondCalc
+                        $$ text "while" <+> parens (cgen env sLoopCond)
+                        $$ block env (cgen env sLoopBlock $+$ cgen env sLoopCondCalc)
+    cgen env ParLoop{..}
+     | WorkParallel <- pParallelType
+     = text "#pragma omp parallel" $$ block env forB
+     | Parallel <- pParallelType
+     , (name . platform . options $ env) == "c99OpenMp"
+     , parNestLevel env <= 1   -- OpenMP 4 has nested data parallelism,
+                               -- but it does not work well in practice.
+     = text "#pragma omp parallel for" $$ forL
+     | TaskParallel <- pParallelType
+     , Block _ (ProcedureCall n vs) <- pLoopBlock
+     = text "FOR" <> parens (sep $ punctuate comma ([text n, lstrt, loopB] ++
+                                       map (cgen env) vs)) <> semi
+     | otherwise = forL
+      where
+        forL  = text "for" <+> parens (sep $ map (nest 4) $ punctuate semi [ini, guard, next])
+              $$ block env1 forB
+        forB  = cgen env1 pLoopBlock
+        ixd   = pvar env pLoopCounter
+        ixv   = cgen env  pLoopCounter
+        lstrt = cgen env pLoopStart
+        ini   = ixd <+> equals    <+> lstrt
+        guard = ixv <+> char '<'  <+> loopB
+        loopB = cgen env pLoopEnd
+        next  = ixv <+> text "+=" <+> cgen env pLoopStep
+        env1 | Parallel <- pParallelType = env { parNestLevel = parNestLevel env + 1}
+             | otherwise = env
+
+    cgen env BlockProgram{..} = block env (cgen env blockProgram)
+
+    cgenList env = vcat . map (cgen env)
+
+instance CodeGen (Pattern ())
+  where
+    cgen _   PatDefault = text "default" <> colon
+    cgen env (Pat c)    = text "case" <+> cgen env c <> colon
+
+    cgenList env = vcat . map (cgen env)
+
+instance CodeGen (ActualParameter ())
+  where
+    cgen env ValueParameter{..}      = cgen env valueParam
+    cgen env TypeParameter{..}       = cgen env typeParam
+    cgen _   FunParameter{..}        = text funParamName
+    cgenList env = hsep . punctuate comma . map (cgen env)
+
+instance CodeGen (Expression ())
+  where
+    cgen env VarExpr{..} = cgen env varExpr
+    cgen env ArrayElem{..}
+     | c@ConstExpr{} <- array
+     , (NativeArray _ t) <- typeof c
+     = parens (parens (cgen env t <> brackets empty) <> cgen env c)
+       <> hcat (map (brackets . cgen env) arrayIndex)
+     | otherwise
+     = cgen env array <> hcat (map (brackets . cgen env) arrayIndex)
+    cgen env StructField{..}  = parens (cgen env struct) <> char '.' <> text fieldName
+    cgen env ConstExpr{..}    = cgen env constExpr
+    cgen env FunctionCall{..}
+        | [a,b] <- funCallParams
+        , isInfixFun (funName function)
+        = parens (cgen env a <+> text (funName function) <+> cgen env b)
+        | otherwise                 = call (text $ funName function) $ map (cgen env) funCallParams
+    cgen env Cast{..} = parens $ parens (cgen env castType) <> parens (cgen env castExpr)
+    cgen env AddrOf{..} = text "&" <> cgen env addrExpr
+    cgen env SizeOf{..} = call (text "sizeof") [cgen env sizeOf]
+    cgen env Deref{..} = text "*" <> cgen env ptrExpr
+
+    cgenList env = sep . punctuate comma . map (cgen env)
+
+instance CodeGen (Variable t)
+  where
+    cgen _ v = text $ varName v
+    cgenList env = hsep . punctuate comma . map (cgen env)
+
+instance CodeGen (Constant ())
+  where
+    cgen env cnst@(IntConst c _)     = maybe (integer c) text $ transformConst env cnst
+    cgen env cnst@(DoubleConst c)    = maybe (double c)  text $ transformConst env cnst
+    cgen env cnst@(FloatConst c)     = maybe (float c)   text $ transformConst env cnst
+    cgen env cnst@(BoolConst False)  = maybe (int 0)     text $ transformConst env cnst
+    cgen env cnst@(BoolConst True)   = maybe (int 1)     text $ transformConst env cnst
+    cgen env      (ArrayConst cs _)  = braces (cgenList env cs)
+    cgen env      (StructConst cs t) = printStruct env cs ts
+      where StructType _ ts = t
+    cgen env cnst@ComplexConst{..}  = maybe cmplxCnst   text $ transformConst env cnst
+      where
+        cmplxCnst = text "complex" <> parens (cgenList env [realPartComplexValue, imagPartComplexValue])
+    cgenList env = sep . punctuate comma . map (cgen env)
+
+instance CodeGen (Maybe String, Constant ())
+  where
+    cgen env (n, c) = name <+> cgen env c
+      where name = maybe empty (\s -> char '.' <> text s <+> equals) n
+    cgenList env = hsep . punctuate comma . map (cgen env)
+
+printStruct :: PrintEnv
+            -> [(Maybe String, Constant ())] -> [(String, Type)] -> Doc
+printStruct env cs ts = braces $ space <> hsep members <> space
+  where members = punctuate comma $ zipWith (printStructMember env) cs ts
+
+printStructMember :: PrintEnv
+                  -> (Maybe String, Constant ()) -> (String, Type) -> Doc
+printStructMember env e@(n, e') (_, t)
+ | (IntConst 0 _) <- e'
+ , isArray t || isPointer t
+ = maybe empty (\s -> char '.' <> text s <+> equals) n <+> text "NULL"
+ | otherwise = cgen env e
+
+transformConst :: PrintEnv -> Constant () -> Maybe String
+transformConst PEnv{..} cnst = do
+    f <- lookup (typeof cnst) $ values $ platform options
+    return $ f cnst
+
+instance CodeGen Type
+  where
+    cgen env = toC
+      where
+        toC VoidType                      = text "void"
+        toC (ArrayType _ t)               = toC t <+> text "*"
+        toC IVarType{}                    = text "struct ivar"
+        toC (StructType n _)              = text "struct" <+> text n
+        toC (NativeArray _ t)             = toC t
+        toC (1 :# (Pointer t))            = toC t <+> text "*"
+        toC t | Just s <- lookup t pts    = text s
+        toC t = codeGenerationError InternalError
+              $ unwords ["Unhandled type in platform ", name pfm,  ": ", show t]
+        pfm = platform $ options env
+        pts = types pfm
+
+    cgenList env = sep . map (cgen env)
+
+call :: Doc -> [Doc] -> Doc
+call fn args = fn <> parens (hsep $ punctuate comma args)
+
+-- Initializes local variables so that initArray/.. will get defined
+-- inputs.
+--
+-- First parameter is whether the initialization context is somewhere
+-- inside a compound type.
+initialize :: Type -> Doc
+-- Compound/Special types.
+initialize (1 :# Pointer{})  = equals <+> text "NULL"
+initialize ArrayType{}       = equals <+> text "NULL"
+initialize NativeArray{}     = equals <+> lbrace <+> text "0" <+> rbrace
+initialize StructType{}      = equals <+> lbrace <+> text "0" <+> rbrace
+-- Simple types.
+initialize _                 = empty
+
+blockComment :: [Doc] -> Doc
+blockComment ds = vcat (zipWith (<+>) (text "/*" : repeat (text " *")) ds)
+                  $$ text " */"
+
+sizeInBrackets :: Type -> Doc
+sizeInBrackets (NativeArray l t) = brackets (maybe empty (text . show) l) <> sizeInBrackets t
+sizeInBrackets _                 = empty
+
+stmt :: Doc -> Doc
+stmt = (<>semi)
+
+block :: PrintEnv -> Doc -> Doc
+block env d = lbrace $+$ nest (nestSize $ options env) d $+$ rbrace
+
+pvar :: PrintEnv -> Variable t -> Doc
+pvar env Variable{..} = typ <+> (name <> size)
+  where
+    typ  = cgen env varType
+    size = sizeInBrackets varType
+    name = text varName
+
+pvars :: PrintEnv -> [Variable t] -> Doc
+pvars env = hsep . punctuate comma . map (pvar env)
+
+-- C operators and their precedence.
+-- Precondition: s is a binop.
+isInfixFun :: String -> Bool
+isInfixFun s = s `elem` [
+    "*", "/", "%" -- 5
+  , "+", "-" -- 6
+  , "<<", ">>" -- 7
+  , "<", "<=", ">", ">=" -- 8
+  , "==", "!=" -- 9
+  , "&" -- 10
+  , "^" -- 11
+  , "|" -- 12
+  , "&&" -- 13
+  , "||" -- 14
+  , "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", "&=", "^=", "|=" -- 16
+  ]

--- a/src/Feldspar/Compiler/Backend/C/Library.hs
+++ b/src/Feldspar/Compiler/Backend/C/Library.hs
@@ -1,0 +1,57 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Backend.C.Library where
+
+import Data.List (isPrefixOf)
+import System.FilePath ((<.>))
+
+-- ===========================================================================
+--  == String tools
+-- ===========================================================================
+
+replace :: Eq a => [a] -> [a] -> [a] -> [a]
+replace [] _ _ = []
+replace s find repl
+  | find `isPrefixOf` s = repl ++ replace (drop (length find) s) find repl
+  | otherwise = head s : replace (tail s) find repl
+
+-- | Encode special characters in function names.
+encodeFunctionName :: String -> String
+encodeFunctionName functionName = replace (replace functionName "_" "__") "'" "_prime"
+
+makeDebugFileName :: String -> String
+makeDebugFileName = (<.> "dbg.txt")
+
+makeHFileName :: String -> String
+makeHFileName = (<.> "h")
+
+makeCFileName :: String -> String
+makeCFileName = (<.> "c")

--- a/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
+++ b/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PatternGuards #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Backend.C.MachineLowering where
+
+import qualified Data.Map as M
+
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Compiler.Imperative.Frontend
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Backend.C.Platforms (extend, c99, tic64x)
+import Feldspar.Compiler.Backend.C.RuntimeLibrary
+
+-- This module does function renaming as well as copy expansion, in a single pass.
+--
+-- Missing from the old C99 rules: Constant folding of 0 - x. That really belongs
+-- in the frontend but there is no negate in NUM and multiplying by -1 gives crazy
+-- results due to overflow.
+
+-- | External interface for renaming.
+rename :: Options -> Bool -> Module () -> Module ()
+rename opts _             | codeGenerator (platform opts) /= "c" = id
+rename opts addRuntimeLib = rename' opts addRuntimeLib x
+  where x = getPlatformRenames opts
+
+-- | Internal interface for renaming.
+rename' :: Options -> Bool -> M.Map String [(Which, Destination)] -> Module ()
+        -> Module ()
+rename' opts addRuntimeLib m (Module ents) = Module ents'
+  where ents' = extra ++ map (renameEnt opts m) ents
+        extra | addRuntimeLib = machineLibrary opts
+              | otherwise     = []
+
+-- | Rename entities.
+renameEnt :: Options -> M.Map String [(Which, Destination)] -> Entity () -> Entity ()
+renameEnt opts m p@Proc{..}
+  | Just body <- procBody = p { procBody = Just $ renameBlock opts m body }
+renameEnt _    _ e        = e
+
+-- | Rename blocks.
+renameBlock :: Options -> M.Map String [(Which, Destination)] -> Block () -> Block ()
+renameBlock opts m (Block vs p) = Block (map (renameDecl m) vs) (renameProg opts m p)
+
+-- | Rename declarations.
+renameDecl :: M.Map String [(Which, Destination)] -> Declaration () -> Declaration ()
+renameDecl m (Declaration v (Just e)) = Declaration v (Just $ renameExp m e)
+renameDecl _ d                        = d
+
+-- | Rename programs.
+renameProg :: Options -> M.Map String [(Which, Destination)] -> Program ()
+           -> Program ()
+renameProg _    _ e@Empty              = e
+renameProg _    _ c@Comment{}          = c
+renameProg _    m (Assign lhs rhs)     = Assign (renameExp m lhs) (renameExp m rhs)
+renameProg _    m (ProcedureCall n ps) = ProcedureCall n (map (renameParam m) ps)
+renameProg opts m (Sequence ps)        = Sequence $ map (renameProg opts m) ps
+renameProg opts m (Switch scrut alts)
+   = Switch (renameExp m scrut) (map (renameAlt opts m) alts)
+renameProg opts m (SeqLoop cond calc block)
+  = SeqLoop (renameExp m cond) (renameBlock opts m calc) (renameBlock opts m block)
+renameProg opts m (ParLoop p v e0 e1 e2 b)
+  = ParLoop p v (renameExp m e0) (renameExp m e1) (renameExp m e2) (renameBlock opts m b)
+renameProg opts m (BlockProgram b)     = BlockProgram $ renameBlock opts m b
+
+-- | Rename expressions.
+renameExp :: M.Map String [(Which, Destination)] -> Expression () -> Expression ()
+renameExp _ v@VarExpr{}         = v
+renameExp m (ArrayElem e es)    = ArrayElem (renameExp m e) $ map (renameExp m) es
+renameExp m (StructField e s)   = StructField (renameExp m e) s
+renameExp _ c@ConstExpr{}       = c
+renameExp m (FunctionCall f es) = res
+  where f'@(Function new t) = renameFun m (typeof $ head es) f
+        es' = map (renameExp m) es
+        res | new /= "div"      = FunctionCall f' es'
+            | [arg1,arg2] <- es
+            , (_ :# NumType Signed _) <- t
+            = StructField (fun div_t (div_f t) [arg1, arg2]) "quot"
+            | otherwise = fun t "/" es'
+          where
+           div_t = StructType "div_t" [("quot", t), ("rem", t)]
+           div_f (1 :# (NumType Signed S8))  = "div"
+           div_f (1 :# (NumType Signed S16)) = "div"
+           div_f (1 :# (NumType Signed S32)) = "div"
+           div_f (1 :# (NumType Signed S40)) = "ldiv"
+           div_f (1 :# (NumType Signed S64)) = "lldiv"
+           div_f typ = error $ "div not defined for " ++ show typ
+
+renameExp m (Cast t e)          = Cast t $ renameExp m e
+renameExp m (AddrOf e)          = AddrOf $ renameExp m e
+renameExp _ s@SizeOf{}          = s
+renameExp m (Deref e)           = Deref $ renameExp m e
+
+-- | Rename parameters.
+renameParam :: M.Map String [(Which, Destination)] -> ActualParameter ()
+            -> ActualParameter ()
+renameParam m (ValueParameter e) = ValueParameter $ renameExp m e
+renameParam _ p                  = p
+
+-- | Rename switch alternatives.
+renameAlt :: Options -> M.Map String [(Which, Destination)]
+          -> (Pattern (), Block ()) -> (Pattern (), Block ())
+renameAlt opts m (p, b) = (p, renameBlock opts m b)
+
+-- | Renames functions that should be renamed. Identity function on others.
+renameFun :: M.Map String [(Which, Destination)] -> Type -> Function -> Function
+renameFun m argtype f@(Function name t)
+  | Just ps <- M.lookup name m
+  , Just s <- findFun name argtype ps t = Function s t
+  | otherwise                           = f
+
+-- | Finds the new name of the function, if any.
+findFun :: String -> Type -> [(Which, Destination)] -> Type -> Maybe String
+findFun name argtype m tp = go m
+  where go []                          = Nothing
+        go ((Only p, s):_) | true p tp = Just (newName name argtype tp s)
+        go ((All, s):_)                = Just (newName name argtype tp s)
+        go (_:t)                       = go t
+
+-- | Returns a new name according to specification.
+newName :: String -> Type -> Type -> Destination -> String
+newName _    _       _  (Name s)                   = s
+newName name _       tp (Extend FunType p)         = extend p name tp
+newName name argtype _  (Extend ArgType p)         = extend p name argtype
+newName _    _       tp (ExtendRename FunType p s) = extend p s tp
+newName _    argtype _  (ExtendRename ArgType p s) = extend p s argtype
+
+-- | Tells whether a predicate holds for a type.
+true :: Predicate -> Type -> Bool
+true Complex    t             = isComplex t
+true Float      t             = isFloat t
+true Signed32   t
+  | Just 32 <- intWidth t
+  , Just True <- intSigned t  = True
+  | otherwise                 = False
+true Unsigned32 t
+  | Just 32 <- intWidth t
+  , Just False <- intSigned t = True
+  | otherwise                 = False
+
+-- A rename is the name of the function to be renamed coupled with a
+-- list of preconditions for renaming to happen and a the destination
+-- name if the precondition is held. First match is executed and the
+-- destination name becomes whatever the template specifies.
+
+-- | C99 renaming list.
+c99list :: [Rename]
+c99list =
+  [ ("/=",            [ (All, Name "!=")])
+  , ("not",           [ (All, Name "!")])
+  , ("quot",          [ (All, Name "/")])
+  , ("rem",           [ (All, Name "%")])
+  , (".&.",           [ (All, Name "&")])
+  , (".|.",           [ (All, Name "|")])
+  , ("xor",           [ (All, Name "^")])
+  , ("complement",    [ (All, Name "~")])
+  , ("shiftL",        [ (All, Name "<<")])
+  , ("shiftLU",       [ (All, Name "<<")])
+  , ("shiftR",        [ (All, Name ">>")])
+  , ("shiftRU",       [ (All, Name ">>")])
+  , ("creal",         [ (All, Name "crealf")])
+  , ("cimag",         [ (All, Name "cimagf")])
+  , ("conjugate",     [ (All, Name "conjf")])
+  , ("magnitude",     [ (All, Name "cabsf")])
+  , ("phase",         [ (All, Name "cargf")])
+  , ("atan2",         [ (Only Complex, Name "atan2f") ])
+  ] ++
+  map mkC99TrigRule ["exp", "sqrt", "log", "**", "sin", "tan", "cos", "asin"
+                    , "atan", "acos", "sinh", "tanh", "cosh", "asinh", "atanh"
+                    , "acosh"] ++
+  -- Extend these functions based on the function type.
+  map (mkC99ExtendRule FunType) [ "abs", "signum", "logBase", "setBit", "clearBit"
+                                , "complementBit", "rotateL", "rotateR"
+                                , "reverseBits" ] ++
+  -- Extend these functions based on the argument type.
+  map (mkC99ExtendRule ArgType) [ "testBit", "bitScan", "bitCount", "complex"
+                                 , "mkPolar", "cis"]
+
+-- | Make C99 extend rule.
+mkC99ExtendRule :: WhichType -> String -> Rename
+mkC99ExtendRule t s = (s, [ (All, Extend t c99) ])
+
+-- | Make C99 trig rule.
+mkC99TrigRule :: String -> Rename
+mkC99TrigRule s = (s, [ (Only Complex, Name ('c':s')), (All, Name s') ])
+  where s' = s ++ "f"
+
+-- | Tic64x renaming list.
+tic64xlist :: [Rename]
+tic64xlist =
+  [ ("==",          [ (Only Complex, ExtendRename ArgType tic64x "equal") ])
+  , ("abs",         [ (Only Float, Name "_fabs"), (Only Signed32, Name "_abs") ])
+  , ("+",           [ (Only Complex, ExtendRename ArgType tic64x "add") ])
+  , ("-",           [ (Only Complex, ExtendRename ArgType tic64x "sub") ])
+  , ("*",           [ (Only Complex, ExtendRename ArgType tic64x "mult") ])
+  , ("/",           [ (Only Complex, ExtendRename ArgType tic64x "div") ])
+  ] ++
+  map mkTic64xComplexRule ["exp", "sqrt", "log", "sin", "tan", "cos", "asin"
+                          ,"atan", "acos", "sinh", "tanh", "cosh", "asinh"
+                          ,"atanh","acosh","creal","cimag", "conjugate"
+                          ,"magnitude","phase", "logBase"] ++
+  [ ("**",          [ (Only Complex, ExtendRename ArgType tic64x "cpow") ])
+  , ("rotateL",     [ (Only Unsigned32, Name "_rotl") ])
+  , ("reverseBits", [ (Only Unsigned32, Name "_bitr") ])
+  ]
+
+-- | Create Tic64x rule for complex type.
+mkTic64xComplexRule :: String -> Rename
+mkTic64xComplexRule s = (s, [ (Only Complex, Extend ArgType tic64x) ] )
+
+-- | Returns the platform renames based on the platform name.
+getPlatformRenames :: Options -> M.Map String [(Which, Destination)]
+getPlatformRenames opt =
+  case name $ platform opt of
+    "tic64x"                                     -> M.fromList (tic64xlist ++ c99list)
+    s | s `elem` ["c99", "c99OpenMp", "c99Wool"] -> M.fromList c99list
+      | otherwise                                -> M.fromList []
+
+flattenProgram :: [Program ()] -> Program ()
+flattenProgram ss = if null ss then Empty else Sequence ss

--- a/src/Feldspar/Compiler/Backend/C/Options.hs
+++ b/src/Feldspar/Compiler/Backend/C/Options.hs
@@ -1,0 +1,76 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Backend.C.Options where
+
+import Feldspar.Core.Interpretation (FeldOpts)
+import Feldspar.Compiler.Imperative.Representation (Type, Constant)
+
+data Options = Options
+    { platform          :: Platform
+    , printHeader       :: Bool
+    , useNativeArrays   :: Bool
+    , useNativeReturns  :: Bool     -- ^ Should the generated function return by value or by
+                                    --   reference (fast return)? This option will be ignored for
+                                    --   types that can't be fast-returned.
+    , frontendOpts      :: FeldOpts -- ^ Options for the front end optimization chain
+    , safetyLimit       :: Integer  -- ^ Threshold to stop when the size information gets lost.
+    , nestSize          :: Int      -- ^ Indentation size for PrettyPrinting
+    }
+
+data Platform = Platform {
+    name            :: String,
+    types           :: [(Type, String)],
+    values          :: [(Type, ShowValue)],
+    includes        :: [String],
+    varFloating     :: Bool,
+    codeGenerator   :: String
+} deriving Show
+
+type ShowValue = Constant () -> String
+
+-- * Renamer data types to avoid cyclic imports.
+
+type Rename = (String, [(Which, Destination)])
+
+data Predicate = Complex | Float | Signed32 | Unsigned32
+   deriving Show
+
+data Which = All | Only Predicate
+   deriving Show
+
+data WhichType = FunType | ArgType
+   deriving Show
+
+data Destination =
+    Name String
+  | Extend WhichType Platform
+  | ExtendRename WhichType Platform String
+   deriving Show

--- a/src/Feldspar/Compiler/Backend/C/Platforms.hs
+++ b/src/Feldspar/Compiler/Backend/C/Platforms.hs
@@ -1,0 +1,149 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Backend.C.Platforms
+    ( availablePlatforms
+    , platformFromName
+    , c99
+    , c99OpenMp
+    , c99Wool
+    , tic64x
+    , extend
+    ) where
+
+import Data.Maybe (fromMaybe)
+
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Imperative.Representation
+
+availablePlatforms :: [Platform]
+availablePlatforms = [ c99, c99OpenMp, c99Wool, ba, tic64x ]
+
+platformFromName :: String -> Platform
+platformFromName str = head $ [pf | pf <- availablePlatforms, name pf == str]
+                              ++ error ("Platform.platformFromName: No platform named " ++ str)
+
+c99 :: Platform
+c99 = Platform {
+    name = "c99",
+    types =
+        [ (1 :# NumType Signed S8,             "int8_t")
+        , (1 :# NumType Signed S16,            "int16_t")
+        , (1 :# NumType Signed S32,            "int32_t")
+        , (1 :# NumType Signed S64,            "int64_t")
+        , (1 :# NumType Unsigned S8,           "uint8_t")
+        , (1 :# NumType Unsigned S16,          "uint16_t")
+        , (1 :# NumType Unsigned S32,          "uint32_t")
+        , (1 :# NumType Unsigned S64,          "uint64_t")
+        , (1 :# BoolType,                      "bool")
+        , (1 :# FloatType,                     "float")
+        , (1 :# DoubleType,                    "double")
+        , (1 :# ComplexType (1 :# FloatType),  "float complex")
+        , (1 :# ComplexType (1 :# DoubleType), "double complex")
+        ] ,
+    values =
+        [ (1 :# ComplexType (1 :# FloatType), \cx -> "(" ++ showRe cx ++ "+" ++ showIm cx ++ "i)")
+        , (1 :# ComplexType (1 :# DoubleType), \cx -> "(" ++ showRe cx ++ "+" ++ showIm cx ++ "i)")
+        , (1 :# BoolType, \b -> if boolValue b then "true" else "false")
+        ] ,
+    includes =
+        [ "feldspar_c99.h"
+        , "feldspar_array.h"
+        , "feldspar_future.h"
+        , "ivar.h"
+        , "taskpool.h"
+        , "<stdint.h>"
+        , "<string.h>"
+        , "<math.h>"
+        , "<stdbool.h>"
+        , "<complex.h>"],
+    varFloating = True,
+    codeGenerator = "c"
+}
+
+c99OpenMp :: Platform
+c99OpenMp = c99 { name = "c99OpenMp"
+                , varFloating = False
+                }
+
+c99Wool :: Platform
+c99Wool = c99 { name = "c99Wool"
+              , includes = "wool.h":includes c99
+              , varFloating = False
+              }
+
+ba :: Platform
+ba = c99 { name = "ba"
+         , codeGenerator = "ba"
+         }
+
+tic64x :: Platform
+tic64x = Platform {
+    name = "tic64x",
+    types =
+        [ (1 :# NumType Signed S8,             "char")
+        , (1 :# NumType Signed S16,            "short")
+        , (1 :# NumType Signed S32,            "int")
+        , (1 :# NumType Signed S40,            "long")
+        , (1 :# NumType Signed S64,            "long long")
+        , (1 :# NumType Unsigned S8,           "unsigned char")
+        , (1 :# NumType Unsigned S16,          "unsigned short")
+        , (1 :# NumType Unsigned S32,          "unsigned")
+        , (1 :# NumType Unsigned S40,          "unsigned long")
+        , (1 :# NumType Unsigned S64,          "unsigned long long")
+        , (1 :# BoolType,                      "int")
+        , (1 :# FloatType,                     "float")
+        , (1 :# DoubleType,                    "double")
+        , (1 :# ComplexType (1 :# FloatType),  "complexOf_float")
+        , (1 :# ComplexType (1 :# DoubleType), "complexOf_double")
+        ] ,
+    values =
+        [ (1 :# ComplexType (1 :# FloatType), \cx -> "complex_fun_float(" ++ showRe cx ++ "," ++ showIm cx ++ ")")
+        , (1 :# ComplexType (1 :# DoubleType), \cx -> "complex_fun_double(" ++ showRe cx ++ "," ++ showIm cx ++ ")")
+        , (1 :# BoolType, \b -> if boolValue b then "1" else "0")
+        ] ,
+    includes = [ "feldspar_tic64x.h", "feldspar_array.h", "<c6x.h>", "<string.h>"
+               , "<math.h>"],
+    varFloating = True,
+    codeGenerator = "c"
+}
+
+showRe, showIm :: Constant t -> String
+showRe = showConstant . realPartComplexValue
+showIm = showConstant . imagPartComplexValue
+
+showConstant :: Constant t -> String
+showConstant (DoubleConst c) = show c ++ "f"
+showConstant (FloatConst c)  = show c ++ "f"
+showConstant c               = show c
+
+extend :: Platform -> String -> Type -> String
+extend Platform{..} s t = s ++ "_fun_" ++ fromMaybe (show t) (lookup t types)

--- a/src/Feldspar/Compiler/Backend/C/RuntimeLibrary.hs
+++ b/src/Feldspar/Compiler/Backend/C/RuntimeLibrary.hs
@@ -1,0 +1,401 @@
+{-# OPTIONS_GHC -Wall #-}
+-- FIXME: Replace this module by splicing in ExternalProgram-input
+--        into the compilation chain.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module Feldspar.Compiler.Backend.C.RuntimeLibrary where
+
+import Data.Maybe (fromJust)
+import Text.PrettyPrint (render)
+
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Compiler.Imperative.Frontend
+import Feldspar.Compiler.Backend.C.Options hiding (name)
+import Feldspar.Compiler.Backend.C.CodeGeneration (cgen, penv0)
+
+machineLibrary :: Options -> [Entity ()]
+machineLibrary opts =
+  map (\t -> abs_fun opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> pow_fun opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> pow_fun opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> signum_fun_u opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> signum_fun_s opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> signum_fun_f opts (1 :# t)) floats ++
+  map (\t -> logbase_fun_f opts (1 :# t)) floats ++
+  map (\t -> setBit_fun opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> setBit_fun opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> clearBit_fun opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> clearBit_fun opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> complementBit_fun opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> complementBit_fun opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> testBit_fun opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> testBit_fun opts (1 :# NumType Signed t)) sizes ++
+  map (\t -> rotateL_fun_u opts (1 :# NumType Unsigned t)) sizes ++
+--  map (\t -> rotateL_fun_s opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> rotateR_fun_u opts (1 :# NumType Unsigned t)) sizes ++
+--  map (\t -> rotateR_fun_s opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> reverseBits_fun_u opts (1 :# NumType Unsigned t)) sizes ++
+--  map (\t -> rotateR_fun_s opts (1 :# NumType Unsigned t)) sizes ++
+  map (\t -> bitScan_fun_u opts (1 :# NumType Unsigned t)) sizes
+--  map (\t -> bitScan_fun_s opts (1 :# NumType Unsigned t)) sizes ++
+
+sizes :: [Size]
+sizes = [S8, S16, S32, S64]
+
+floats :: [ScalarType]
+floats = [FloatType, DoubleType]
+
+{-
+int8_t abs_fun_int8_t( int8_t a ) {
+    // From Bit Twiddling Hacks:
+    //    "Compute the integer absolute value (abs) without branching"
+    int8_t mask = a >> 7;
+    return (a + mask) ^ mask;
+}
+-}
+
+abs_fun :: Options -> Type -> Entity ()
+abs_fun opts typ = Proc name False [inVar] (typeof outVar) (Just body)
+ where name   = "abs_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar  = Variable typ "a"
+       inVar' = varToExpr inVar
+       outVar = Variable typ "out"
+       body   = Block lvars prg
+       mVar   = Variable typ "mask"
+       mVar'  = varToExpr mVar
+       prg    = call "return" [ValueParameter $ binop typ "^" (binop typ "+" inVar' mVar') mVar']
+       lvars  = [Declaration mVar (Just ival)]
+       ival   = binop typ ">>" inVar' arg2
+       arg2   = ConstExpr (IntConst (sizeToNum typ - 1) typ')
+       typ'   = case typ of
+                  _ :# t -> t
+
+{-
+uint8_t pow_fun_uint8_t( uint8_t a, uint8_t b ) {
+    uint8_t r = 1;
+    int i;
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+int8_t pow_fun_int8_t( int8_t a, int8_t b ) {
+    int8_t r = 1;
+    int i;
+    if (b < 0) {
+        fprintf(stderr, "Negative exponent in function pow_fun_(): %d `pow` %d", a, b);
+        exit(1);
+    }
+    for(i = 0; i < b; ++i)
+        r *= a;
+    return r;
+}
+-}
+
+pow_fun :: Options -> Type -> Entity ()
+pow_fun opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "pow_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1 = Variable typ "a"
+       inVar1'= varToExpr inVar1
+       inVar2 = Variable typ "b"
+       inVar2'= varToExpr inVar2
+       inVar3 = Variable typ "i"
+       outVar = Variable typ "r"
+       outVar'= varToExpr outVar
+       lvars  = [Declaration outVar $ Just (litI typ 1)]
+       body   = Block lvars prg
+       prg    = Sequence [ guard
+                         , for Sequential inVar3 (litI typ 0) inVar2' (litI typ 1) (Block [] body')
+                         , call "return" [ValueParameter $ outVar']]
+       body'  = Assign outVar' (binop typ "*" outVar' inVar1')
+       guard
+         | Just True <- intSigned typ
+         = Sequence [ call "assert" [ ValueParameter $
+                         binop (1 :# BoolType) "<" inVar2' (litI typ 0)]
+                    , Comment False "Negative exponent in function pow_fun"]
+         | otherwise = Empty
+
+{-
+int8_t signum_fun_int8_t( int8_t a ) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a != 0) | (a >> 7);
+}
+-}
+
+signum_fun_s :: Options -> Type -> Entity ()
+signum_fun_s opts typ = Proc name False [inVar] (typeof outVar) (Just body)
+ where name   = "signum_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar  = Variable typ "a"
+       inVar' = varToExpr inVar
+       outVar = Variable typ "out"
+       body   = toBlock prg
+       prg    = call "return" [ValueParameter $
+                   binop typ "|" (binop typ "!=" inVar' (litI typ 0)) ival]
+       ival   = binop typ ">>" inVar' arg2
+       arg2   = ConstExpr (IntConst (sizeToNum typ - 1) typ')
+       typ'   = case typ of
+                  _ :# t -> t
+
+{-
+uint8_t signum_fun_uint8_t( uint8_t a ) {
+    return (a > 0);
+}
+-}
+
+signum_fun_u :: Options -> Type -> Entity ()
+signum_fun_u opts typ = Proc name False [inVar] (typeof outVar) (Just body)
+ where name   = "signum_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar  = Variable typ "a"
+       inVar' = varToExpr inVar
+       outVar = Variable typ "out"
+       body   = toBlock prg
+       prg    = call "return" [ValueParameter $
+                   binop typ ">" inVar' (litI typ 0)]
+
+{-
+float signum_fun_float( float a ) {
+    // From Bit Twiddling Hacks: "Compute the sign of an integer"
+    return (a > 0) - (a < 0);
+}
+-}
+
+signum_fun_f :: Options -> Type -> Entity ()
+signum_fun_f opts typ = Proc name False [inVar] (typeof outVar) (Just body)
+ where name   = "signum_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar  = Variable typ "a"
+       inVar' = varToExpr inVar
+       outVar = Variable typ "out"
+       body   = toBlock prg
+       prg    = call "return" [ValueParameter $
+                   binop typ "-" gzero szero]
+       zero   = litI typ 0
+       gzero  = binop typ ">" inVar' zero
+       szero  = binop typ "<" inVar' zero
+
+
+{-
+float logBase_fun_float( float a, float b ) {
+    return logf(b) / logf(a);
+}
+-}
+logbase_fun_f :: Options -> Type -> Entity ()
+logbase_fun_f opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "logbase_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "a"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable typ "b"
+       inVar2' = varToExpr inVar2
+       outVar = Variable typ "out"
+       body   = toBlock prg
+       prg    = call "return" [ValueParameter $
+                   binop typ "/" numer denom]
+       numer  = fun typ (logNam typ) [inVar2']
+       denom  = fun typ (logNam typ) [inVar1']
+       logNam (_ :# FloatType)  = "logf"
+       logNam (_ :# DoubleType) = "log"
+
+{-
+int8_t setBit_fun_int8_t( int8_t x, uint32_t i ) {
+    return x | 1 << i;
+}
+-}
+setBit_fun :: Options -> Type -> Entity ()
+setBit_fun opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "setBit_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "x"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable (1 :# (NumType Unsigned S32)) "i"
+       inVar2' = varToExpr inVar2
+       outVar  = Variable typ "out"
+       body    = toBlock prg
+       prg     = call "return" [ValueParameter $
+                   binop typ "|" inVar1' ival]
+       ival    = binop typ "<<" (litI typ 1) inVar2'
+
+{-
+int8_t clearBit_fun_int8_t( int8_t x, uint32_t i ) {
+    return x & ~(1 << i);
+}
+-}
+clearBit_fun :: Options -> Type -> Entity ()
+clearBit_fun opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "clearBit_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "x"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable (1 :# (NumType Unsigned S32)) "i"
+       inVar2' = varToExpr inVar2
+       outVar  = Variable typ "out"
+       body    = toBlock prg
+       prg     = call "return" [ValueParameter $
+                   binop typ "&" inVar1' (fun typ "~" [ival])]
+       ival    = binop typ "<<" (litI typ 1) inVar2'
+
+{-
+int8_t complementBit_fun_int8_t( int8_t x, uint32_t i ) {
+    return x ^ 1 << i;
+}
+-}
+complementBit_fun :: Options -> Type -> Entity ()
+complementBit_fun opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "complementBit_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "x"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable (1 :# (NumType Unsigned S32)) "i"
+       inVar2' = varToExpr inVar2
+       outVar  = Variable typ "out"
+       body    = toBlock prg
+       prg     = call "return" [ValueParameter $
+                   binop typ "^" inVar1' ival]
+       ival    = binop typ "<<" (litI typ 1) inVar2'
+
+{-
+bool testBit_fun_int8_t( int8_t x, uint32_t i )
+{
+    return (x & 1 << i) != 0;
+}
+-}
+testBit_fun :: Options -> Type -> Entity ()
+testBit_fun opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "testBit_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "x"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable (1 :# (NumType Unsigned S32)) "i"
+       inVar2' = varToExpr inVar2
+       outVar  = Variable (1 :# BoolType) "out"
+       body    = toBlock prg
+       prg     = call "return" [ValueParameter $
+                   binop btyp "!=" (binop typ "&" inVar1' ival) (litI typ 0)]
+       ival    = binop typ "<<" (litI typ 1) inVar2'
+       btyp    = 1 :# BoolType
+
+-- TODO: rotateL signed
+
+{-
+uint8_t rotateL_fun_uint8_t( uint8_t x, int32_t i ) {
+    if ((i %= 8) == 0) return x;
+    return (x << i) | (x >> (8 - i));
+}
+-}
+rotateL_fun_u :: Options -> Type -> Entity ()
+rotateL_fun_u opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "rotateL_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "x"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable (1 :# (NumType Unsigned S32)) "i"
+       inVar2' = varToExpr inVar2
+       outVar  = Variable typ "out"
+       body    = toBlock prg
+       ret1    = call "return" [ValueParameter inVar1']
+       cnd     = binop (1 :# BoolType) "=="
+                     (binop typ "%=" inVar2' (litI typ sz)) (litI typ 0)
+       prg     = Sequence [mkIf cnd (toBlock ret1) Nothing,
+                  call "return" [ValueParameter $
+                    binop typ "|" (binop typ "<<" inVar1' inVar2') rsh]]
+       rsh     = binop typ ">>" inVar1' (binop typ "-" arg2 inVar2')
+       arg2    = ConstExpr (IntConst sz typ')
+       sz      = sizeToNum typ
+       typ'    = case typ of
+                  _ :# t -> t
+
+-- TODO: rotateR signed
+
+{-
+uint8_t rotateR_fun_uint8_t( uint8_t x, int32_t i ) {
+    if ((i %= 8) == 0) return x;
+    return (x << (8 - i)) | (x >> i);
+}
+-}
+rotateR_fun_u :: Options -> Type -> Entity ()
+rotateR_fun_u opts typ = Proc name False [inVar1, inVar2] (typeof outVar) (Just body)
+ where name   = "rotateR_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar1  = Variable typ "x"
+       inVar1' = varToExpr inVar1
+       inVar2  = Variable (1 :# (NumType Unsigned S32)) "i"
+       inVar2' = varToExpr inVar2
+       outVar  = Variable typ "out"
+       body    = toBlock prg
+       ret1    = call "return" [ValueParameter inVar1']
+       cnd     = binop (1 :# BoolType) "=="
+                     (binop typ "%=" inVar2' (litI typ sz)) (litI typ 0)
+       prg     = Sequence [mkIf cnd (toBlock ret1) Nothing,
+                  call "return" [ValueParameter $
+                    binop typ "|" lsh (binop typ ">>" inVar1' inVar2') ]]
+       lsh     = binop typ "<<" inVar1' (binop typ "-" arg2 inVar2')
+       arg2    = ConstExpr (IntConst sz typ')
+       sz      = sizeToNum typ
+       typ'    = case typ of
+                  _ :# t -> t
+
+-- TODO: reverseBits signed
+
+{-
+uint8_t reverseBits_fun_uint8_t( uint8_t x ) {
+    uint8_t r = x;
+    int i = 7;
+    while (x >>= 1)
+    {
+        r = (r << 1) | (x & 1);
+        --i;
+    }
+    return r << i;
+}
+-}
+
+reverseBits_fun_u :: Options -> Type -> Entity ()
+reverseBits_fun_u opts typ = Proc name False [inVar] (typeof outVar) (Just body)
+ where name   = "reverseBits_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar  = Variable typ "x"
+       inVar' = varToExpr inVar
+       outVar = Variable typ "r"
+       outVar'= varToExpr outVar
+       ivar   = Variable typ "i"
+       ivar'  = varToExpr ivar
+       lvars  = [ Declaration outVar $ Just inVar'
+                , Declaration ivar $ Just $ litI typ (sz - 1)]
+       body   = Block lvars prg
+       empty  = toBlock Empty
+       prg    = Sequence [ while empty (binop typ ">>=" inVar' (litI typ 1)) body'
+                         , call "return" [ValueParameter $
+                                             binop typ "<<" outVar' ivar']]
+       body'   = toBlock $ Sequence [ Assign outVar' shift
+                                    , Assign ivar' (binop typ "-" ivar' (litI typ 1))]
+       shift   = binop typ "|" (binop typ "<<" outVar' (litI typ 1))
+                               (binop typ "&" inVar' (litI typ 1))
+       sz      = sizeToNum typ
+
+-- TODO: bitScan for signed.
+
+{-
+uint32_t bitScan_fun_uint8_t( uint8_t x ) {
+    uint32_t r = 8;
+    while (x) {
+        --r;
+        x >>= 1;
+    }
+    return r;
+}
+-}
+bitScan_fun_u :: Options -> Type -> Entity ()
+bitScan_fun_u opts typ = Proc name False [inVar] (typeof outVar) (Just body)
+ where name   = "bitScan_fun_" ++ (render $ cgen (penv0 opts) typ)
+       inVar  = Variable typ "x"
+       inVar' = varToExpr inVar
+       ot     = 1 :# (NumType Unsigned S32)
+       outVar = Variable ot "r"
+       outVar'= varToExpr outVar
+       lvars  = [Declaration outVar $ Just $ litI ot sz]
+       body   = Block lvars prg
+       empty  = toBlock Empty
+       prg    = Sequence [ while empty inVar' body'
+                         , call "return" [ValueParameter outVar']]
+       body'   = toBlock $ Sequence [ Assign outVar' (binop ot "-" outVar' (litI typ 1))
+                                    , Assign inVar' shift ]
+       shift   = binop typ ">>" inVar' (litI typ 1)
+       sz      = sizeToNum typ
+
+-- TODO:  bitCount and forward in feldspar_c99.c
+
+sizeToNum :: Type -> Integer
+sizeToNum = fromJust . intWidth
+
+stderr :: Expression ()
+stderr = varToExpr $ Variable VoidType "stderr"

--- a/src/Feldspar/Compiler/Backend/C/Tic64x.hs
+++ b/src/Feldspar/Compiler/Backend/C/Tic64x.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE PatternGuards #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Backend.C.Tic64x (adaptTic64x) where
+
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Compiler.Imperative.Frontend
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Backend.C.Platforms (extend, tic64x)
+
+-- This module does two major things:
+--
+-- 1) Replaces all single argument functions where the argument is of complex
+--    type with a single named function. The renamer can't currently match on
+--    that.
+-- 2) Replaces complex typed "/=" and "bitCount" with an expression.
+--
+-- TODO: Extend the renamer to cope with #1.
+
+-- | External interface for tic64x specific fixes.
+adaptTic64x :: Options -> Module () -> Module ()
+adaptTic64x opts m
+ | "tic64x" == name (platform opts) = adaptTic64x' m
+ | otherwise = m
+
+-- | Internal interface for renaming.
+adaptTic64x' :: Module () -> Module ()
+adaptTic64x' (Module ents) = Module $ map adaptTic64xEnt ents
+
+-- | Adapts entities.
+adaptTic64xEnt :: Entity () -> Entity ()
+adaptTic64xEnt p@Proc{..}
+  | Just body <- procBody = p { procBody = Just $ adaptTic64xBlock body }
+adaptTic64xEnt e             = e
+
+-- | Adapts blocks.
+adaptTic64xBlock :: Block () -> Block ()
+adaptTic64xBlock (Block vs p) = Block (map adaptTic64xDecl vs) (adaptTic64xProg p)
+
+-- | Adapts declarations.
+adaptTic64xDecl :: Declaration () -> Declaration ()
+adaptTic64xDecl (Declaration v (Just e)) = Declaration v (Just $ adaptTic64xExp e)
+adaptTic64xDecl d                        = d
+
+-- | Adapts programs.
+adaptTic64xProg :: Program () -> Program ()
+adaptTic64xProg e@Empty              = e
+adaptTic64xProg c@Comment{}          = c
+adaptTic64xProg (Assign lhs rhs)     = Assign (adaptTic64xExp lhs) (adaptTic64xExp rhs)
+adaptTic64xProg (ProcedureCall n ps) = ProcedureCall n (map adaptTic64xParam ps)
+adaptTic64xProg (Sequence ps)        = Sequence $ map adaptTic64xProg ps
+adaptTic64xProg (Switch scrut alts)
+   = Switch (adaptTic64xExp scrut) (map adaptTic64xAlt alts)
+adaptTic64xProg (SeqLoop cond calc block)
+  = SeqLoop (adaptTic64xExp cond) (adaptTic64xBlock calc) (adaptTic64xBlock block)
+adaptTic64xProg (ParLoop p v e0 e1 e2 b)
+  = ParLoop p v (adaptTic64xExp e0) (adaptTic64xExp e1) (adaptTic64xExp e2) (adaptTic64xBlock b)
+adaptTic64xProg (BlockProgram b)     = BlockProgram $ adaptTic64xBlock b
+
+-- | Adapts expressions.
+adaptTic64xExp :: Expression () -> Expression ()
+adaptTic64xExp v@VarExpr{}         = v
+adaptTic64xExp (ArrayElem e es)    = ArrayElem (adaptTic64xExp e) $ map adaptTic64xExp es
+adaptTic64xExp (StructField e s)   = StructField (adaptTic64xExp e) s
+adaptTic64xExp c@ConstExpr{}       = c
+adaptTic64xExp (FunctionCall (Function "/=" t) [arg1,arg2]) | isComplex (typeof arg1)
+  = fun t "!" [fun t (extend tic64x "equal" $ typeof arg1) [arg1, arg2]]
+adaptTic64xExp (FunctionCall (Function "bitCount" t) [arg]) | isComplex (typeof arg)
+  = fun t "_dotpu4" [fun t "_bitc4" [arg], litI32 0x01010101]
+adaptTic64xExp (FunctionCall f es)
+  = FunctionCall (adaptTic64xFun argtype (length es) f) $ map adaptTic64xExp es
+   where argtype = typeof $ head es
+adaptTic64xExp (Cast t e)          = Cast t $ adaptTic64xExp e
+adaptTic64xExp (AddrOf e)          = AddrOf $ adaptTic64xExp e
+adaptTic64xExp s@SizeOf{}          = s
+adaptTic64xExp (Deref e)           = Deref $ adaptTic64xExp e
+
+-- | Adapts parameters.
+adaptTic64xParam :: ActualParameter ()    -> ActualParameter ()
+adaptTic64xParam (ValueParameter e) = ValueParameter $ adaptTic64xExp e
+adaptTic64xParam p                  = p
+
+-- | Adapts switch alternatives.
+adaptTic64xAlt :: (Pattern (), Block ()) -> (Pattern (), Block ())
+adaptTic64xAlt (p, b) = (p, adaptTic64xBlock b)
+
+-- | Adapts functions that should be adapted Identity function on others.
+adaptTic64xFun :: Type -> Int -> Function -> Function
+adaptTic64xFun argtype args f@(Function _ t)
+  | isComplex argtype
+  , args == 1 -- TODO: This transformation looks dangerous.
+  = Function (extend tic64x "creal" argtype) t
+  | otherwise                           = f

--- a/src/Feldspar/Compiler/CallConv.hs
+++ b/src/Feldspar/Compiler/CallConv.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wall #-}
+
+-- | Type rewriting for Feldspar programs
+module Feldspar.Compiler.CallConv
+  ( rewriteType
+  , buildHaskellType
+  , buildCType
+  ) where
+
+
+import Language.Haskell.TH
+
+import System.Plugins.MultiStage hiding (ref)
+
+import Foreign.Ptr (Ptr)
+
+import Feldspar (Syntactic(..))
+
+-- | Normalize the type (expand type synonyms and type families)
+rewriteType :: Type -> Q Type
+rewriteType = applyTF ''Internal
+
+haskellCC :: CallConv
+haskellCC = CallConv { arg  = return
+                     , res  = appT (conT ''IO) . return
+                     }
+
+feldsparCC :: CallConv
+feldsparCC = CallConv { arg = ref . rep . return
+                      , res = toIO . appT (conT ''Ptr) . rep . return
+                      }
+  where
+    ref    = appT (conT ''Ref)
+    rep    = appT (conT ''Rep)
+    toIO t = appT (appT arrowT t) (appT (conT ''IO) (tupleT 0))
+
+-- | Construct the corresponding Haskell type of a foreign Feldspar
+-- function
+--
+-- > prog1 :: Data Index -> Vector1 Index
+-- >
+-- > sigD (mkName "h_prog1") $ loadFunType 'prog1 >>= rewriteType >>= buildHaskellType
+--
+-- becomes
+--
+-- > h_prog1 :: Index -> IO [Index]
+--
+buildHaskellType :: Type -> Q Type
+buildHaskellType = buildType haskellCC
+
+-- | Construct the corresponding C type of a compiled Feldspar function
+--
+-- > sigD (mkName "c_prog1_fun") $ loadFunType 'prog1 >>= rewriteType
+--                                                    >>= buildCType
+--
+-- becomes
+--
+-- > c_prog1_fun :: Word32 -> Ptr (SA Word32) -> IO ()
+--
+buildCType :: Type -> Q Type
+buildCType = buildType feldsparCC

--- a/src/Feldspar/Compiler/Compiler.hs
+++ b/src/Feldspar/Compiler/Compiler.hs
@@ -1,0 +1,239 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wall #-}
+-- FIXME: Move the Pretty instances to the right place.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Feldspar.Compiler.Compiler (
+    compileToCCore
+  , compileToCCore'
+  , defaultOptions
+  , sicsOptions
+  , sicsOptions2
+  , sicsOptions3
+  , c99PlatformOptions
+  , c99OpenMpPlatformOptions
+  , tic64xPlatformOptions
+  , SplitModule(..)
+  , CompiledModule(..)
+  , BackendPass(..)
+  , backend
+  , fromCore
+  , ProgOpts(..)
+  , defaultProgOpts
+  ) where
+
+import Data.List (partition)
+import Data.Maybe (fromMaybe)
+
+import Feldspar.Core.Frontend (Syntactic, reifyFeld)
+import Feldspar.Core.Interpretation (defaultFeldOpts, FeldOpts(..), Target(..))
+import Feldspar.Core.UntypedRepresentation (UntypedFeld, VarId)
+import Feldspar.Core.Middleend.FromTyped (FrontendPass, frontend)
+import Feldspar.Compiler.Backend.C.Library
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Backend.C.Platforms
+import Feldspar.Compiler.Backend.C.CodeGeneration
+import Feldspar.Compiler.Backend.C.MachineLowering
+import Feldspar.Compiler.Backend.C.Tic64x
+import Feldspar.Compiler.Imperative.FromCore
+import Feldspar.Compiler.Imperative.ArrayOps
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Core.Middleend.PassManager
+
+data SplitModule = SplitModule
+    { implementation :: CompiledModule
+    , interface :: CompiledModule
+    }
+
+data CompiledModule = CompiledModule {
+    sourceCode      :: String,
+    debugModule     :: Module ()
+}
+
+-- | Split a module into interface and implemenation.
+splitModule :: Module () -> (Module (), Module ())
+splitModule m = (Module (hdr ++ createProcDecls (entities m)), Module body)
+  where
+    (hdr, body) = partition belongsToHeader (entities m)
+    belongsToHeader :: Entity () -> Bool
+    belongsToHeader StructDef{}                     = True
+    belongsToHeader Proc{..} | Nothing <- procBody  = True
+    belongsToHeader _                               = False
+    -- TODO These only belongs in the header iff the types are used in a
+    -- function interface
+    createProcDecls :: [Entity ()] -> [Entity ()]
+    createProcDecls = concatMap defToDecl
+    defToDecl :: Entity () -> [Entity ()]
+    defToDecl (Proc n False inp rtype _) = [Proc n False inp rtype Nothing]
+    defToDecl _ = []
+
+compileSplitModule :: Options -> (Module (), Module ()) -> SplitModule
+compileSplitModule opts (hmdl, cmdl)
+  = SplitModule
+    { interface = CompiledModule { sourceCode  = incls ++ hres
+                                 , debugModule = hmdl
+                                 }
+    , implementation = CompiledModule { sourceCode  = cres
+                                      , debugModule = cmdl
+                                      }
+    }
+  where
+    hres = compToCWithInfos opts hmdl
+    cres = compToCWithInfos opts cmdl
+    incls = genIncludeLines opts Nothing
+
+-- | Compiler core.
+-- Everything should call this function and only do a trivial interface adaptation.
+-- Do not duplicate.
+compileToCCore :: Syntactic c => String -> Options -> c -> SplitModule
+compileToCCore name opts prg = compileToCCore' opts mod'
+      where
+        mod' = fromCore opts (encodeFunctionName name) prg
+
+compileToCCore' :: Options -> Module () -> SplitModule
+compileToCCore' opts m = compileSplitModule opts $ splitModule mod'
+      where
+        mod' = adaptTic64x opts $ rename opts False $ arrayOps opts m
+
+genIncludeLines :: Options -> Maybe String -> String
+genIncludeLines opts mainHeader = concatMap include incs ++ "\n\n"
+  where
+    include []            = ""
+    include fname@('<':_) = "#include " ++ fname ++ "\n"
+    include fname         = "#include \"" ++ fname ++ "\"\n"
+    incs = includes (platform opts) ++ [fromMaybe "" mainHeader]
+
+-- | Predefined options
+
+defaultOptions :: Options
+defaultOptions
+    = Options
+    { platform          = c99
+    , printHeader       = False
+    , useNativeArrays   = False
+    , useNativeReturns  = False
+    , frontendOpts      = defaultFeldOpts
+    , safetyLimit       = 2000
+    , nestSize          = 2
+    }
+
+c99PlatformOptions :: Options
+c99PlatformOptions              = defaultOptions
+
+c99OpenMpPlatformOptions :: Options
+c99OpenMpPlatformOptions        = defaultOptions { platform = c99OpenMp }
+
+tic64xPlatformOptions :: Options
+tic64xPlatformOptions           = defaultOptions { platform = tic64x }
+
+sicsOptions :: Options
+sicsOptions = defaultOptions { frontendOpts = defaultFeldOpts { targets = [SICS,CSE] }}
+
+sicsOptions2 :: Options
+sicsOptions2 = defaultOptions { frontendOpts = defaultFeldOpts { targets = [SICS] }}
+
+sicsOptions3 :: Options
+sicsOptions3 = defaultOptions { platform = c99Wool, frontendOpts = defaultFeldOpts { targets = [SICS,CSE,Wool] }}
+
+data BackendPass = BPFromCore
+                 | BPArrayOps
+                 | BPRename
+                 | BPAdapt
+                 | BPSplit
+                 | BPCompile
+                 | BPUnsplit
+  deriving (Eq, Enum, Bounded, Read, Show)
+
+instance (Pretty a, Pretty b) => Pretty (a, b) where
+  pretty (x,y) = "(" ++ pretty x ++ ", " ++ pretty y ++ ")"
+
+instance Pretty (Module ()) where
+  pretty m = compToCWithInfos defaultOptions m
+
+instance Pretty VarId where
+  pretty v = show v
+
+instance Pretty SplitModule where
+  pretty (SplitModule impl intf) = "// Interface\n" ++ sourceCode intf ++
+                                   "\n// Implementation\n" ++ sourceCode impl
+
+backend :: PassCtrl BackendPass -> Options -> String -> UntypedFeld -> ([String], Maybe SplitModule)
+backend ctrl opts name = evalPasses 0
+                       $ codegen (codeGenerator $ platform opts) ctrl opts
+                       . pc BPRename   (rename opts False)
+                       . pc BPArrayOps (arrayOps opts)
+                       . pt BPFromCore (fst . fromCoreUT opts (encodeFunctionName name))
+  where pc :: Pretty a => BackendPass -> (a -> a) -> Prog a Int -> Prog a Int
+        pc = passC ctrl
+        pt :: (Pretty a, Pretty b) => BackendPass -> (a -> b) -> Prog a Int -> Prog b Int
+        pt = passT ctrl
+
+codegen :: String -> PassCtrl BackendPass -> Options -> Prog (Module ()) Int -> Prog SplitModule Int
+codegen "c"   ctrl opts  = passT ctrl BPCompile  (compileSplitModule opts)
+                         . passT ctrl BPSplit    splitModule
+                         . passC ctrl BPAdapt    (adaptTic64x opts)
+codegen gen   _    _     = error $ "Compiler.codegen: unknown code generator " ++ gen
+
+-- | Get the generated core for an expression.
+fromCore :: Syntactic a
+    => Options
+    -> String   -- ^ Name of the generated function
+    -> a        -- ^ Expression to generate code for
+    -> Module ()
+fromCore opt funname prog
+  | Just prg <- snd $ frontend ctrl (frontendOpts opt) $ reifyFeld prog
+  = fst $ fromCoreUT opt funname prg
+  | otherwise = error "fromCore: Internal error: frontend failed?"
+   where ctrl = frontendCtrl defaultProgOpts
+
+data ProgOpts =
+    ProgOpts
+    { backOpts     :: Options
+    , passFileName :: String
+    , outFileName  :: String
+    , functionName :: String
+    , frontendCtrl :: PassCtrl FrontendPass
+    , backendCtrl  :: PassCtrl BackendPass
+    , printHelp    :: Bool
+    }
+
+defaultProgOpts :: ProgOpts
+defaultProgOpts =
+    ProgOpts
+    { backOpts     = defaultOptions
+    , passFileName = ""
+    , outFileName  = ""
+    , functionName = ""
+    , frontendCtrl = defaultPassCtrl
+    , backendCtrl  = defaultPassCtrl
+    , printHelp    = False
+    }

--- a/src/Feldspar/Compiler/Error.hs
+++ b/src/Feldspar/Compiler/Error.hs
@@ -1,0 +1,40 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Error where
+
+data ErrorClass
+  = InvariantViolation
+  | InternalError
+  | Warning
+  deriving (Eq, Show)
+
+handleError :: String -> ErrorClass -> String -> a
+handleError place errorClass message =
+  error $ "[" ++ show errorClass ++ " @ " ++ place ++ "]: " ++ message

--- a/src/Feldspar/Compiler/ExternalProgram.hs
+++ b/src/Feldspar/Compiler/ExternalProgram.hs
@@ -1,0 +1,60 @@
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.ExternalProgram
+  ( icompileFile
+  , compileFile
+  ) where
+
+import qualified Data.ByteString.Char8 as B
+
+import Feldspar.Compiler.Compiler
+        (CompiledModule, SplitModule(..), compileToCCore', defaultOptions,
+         sourceCode)
+import Feldspar.Compiler.Backend.C.Options (Options(..), Platform(..))
+import Feldspar.Compiler.Frontend.Interactive.Interface (writeFiles)
+import Feldspar.Compiler.Imperative.ExternalProgram (parseFile)
+import Feldspar.Compiler.Imperative.Representation (Module(..))
+
+icompileFile :: FilePath -> IO ()
+icompileFile filename = do
+  let hfilename = filename ++ ".h"
+      cfilename = filename ++ ".c"
+  h <- B.readFile hfilename
+  c <- B.readFile cfilename
+  let comp = compileFile' defaultOptions (hfilename, h) (cfilename, c)
+  case comp of
+    (Nothing, _) -> putStrLn $ "Could not parse " ++ hfilename
+    (_, Nothing) -> putStrLn $ "Could not parse " ++ cfilename
+    (_, Just cprg) -> putStrLn $ sourceCode cprg
+
+
+compileFile :: FilePath -> FilePath -> Options -> IO ()
+compileFile fileName outFile opts = do
+  let hfilename = fileName ++ ".h"
+      cfilename = fileName ++ ".c"
+  h <- B.readFile hfilename
+  c <- B.readFile cfilename
+  let comp = compileFile' opts (hfilename, h) (cfilename, c)
+  case comp of
+    (Nothing, _) -> print $ "Could not parse " ++ hfilename
+    (_, Nothing) -> putStrLn $ "Could not parse " ++ cfilename
+    (Just hprg, Just cprg) -> writeFiles prg outFile (codeGenerator $ platform opts)
+      where prg = SplitModule cprg hprg
+
+compileFile' :: Options -> (String, B.ByteString) -> (String, B.ByteString)
+            -> (Maybe CompiledModule, Maybe CompiledModule)
+compileFile' opts (hfilename, hfile) (cfilename, cfile) =
+  case parseFile hfilename hfile [] of
+    Nothing -> (Nothing, Nothing)
+    Just hprg -> case parseFile cfilename cfile (entities hprg) of
+                   Nothing -> (Just hres, Nothing)
+                   Just cprg -> (Just hres', Just cres)
+                     where res = compileToCCore' opts cprg
+                           cres = implementation res
+                           -- Un-duplicated hres.
+                           hres' = interface res
+      where -- Will result in duplicate function declarations, but we
+            -- just failed parsing the c file and return nothing for
+            -- that so the user is probably not that picky on
+            -- potential duplicate declarations if they had succeeded.
+            hres = interface $ compileToCCore' opts hprg

--- a/src/Feldspar/Compiler/Frontend/Interactive/Interface.hs
+++ b/src/Feldspar/Compiler/Frontend/Interactive/Interface.hs
@@ -1,0 +1,220 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Frontend.Interactive.Interface where
+
+import Feldspar.Core.Frontend (Syntactic, reifyFeld)
+import Feldspar.Core.Interpretation (FeldOpts(..), Target(..))
+import Feldspar.Core.UntypedRepresentation (UntypedFeld)
+import Feldspar.Core.Middleend.PassManager
+import Feldspar.Core.Middleend.FromTyped (FrontendPass, frontend)
+import Feldspar.Compiler.Compiler
+import Feldspar.Compiler.Imperative.FromCore
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Backend.C.Library
+import Feldspar.Compiler.Backend.C.Platforms (availablePlatforms, platformFromName)
+import Feldspar.Compiler.Imperative.Representation (Module(..))
+
+import Data.Char
+import Control.Monad (when, unless)
+import System.FilePath (takeFileName)
+import System.Environment (getArgs, getProgName)
+import System.Console.GetOpt
+import System.IO
+
+-- ================================================================================================
+--  == Interactive compilation
+-- ================================================================================================
+
+compile :: (Syntactic t) => t -> FilePath -> String -> Options -> IO ()
+compile prg fileName funName opts = writeFiles compRes fileName (codeGenerator $ platform opts)
+  where compRes = compileToCCore funName opts prg
+
+compileUT :: UntypedFeld -> FilePath -> String -> Options -> IO ()
+compileUT prg fileName funName opts = writeFiles compRes fileName (codeGenerator $ platform opts)
+  where compRes = compileToCCore' opts prg'
+        prg'    = fst $ fromCoreUT opts (encodeFunctionName funName) prg
+
+writeFiles :: SplitModule -> FilePath -> String -> IO ()
+writeFiles prg fileName "c" = do
+    writeFile cfile $ unlines [ "#include \"" ++ takeFileName hfile ++ "\""
+                              , "\n"
+                              , sourceCode $ implementation prg
+                              ]
+    writeFile hfile $ withIncludeGuard $ sourceCode $ interface prg
+  where
+    hfile = makeHFileName fileName
+    cfile = makeCFileName fileName
+
+    withIncludeGuard code = unlines [ "#ifndef " ++ guardName
+                                    , "#define " ++ guardName
+                                    , ""
+                                    , code
+                                    , ""
+                                    , "#endif // " ++ guardName
+                                    ]
+
+    guardName = map ((\c -> if c `elem` toBeChanged then '_' else c) . toUpper) hfile
+      where
+        toBeChanged = "./\\"
+writeFiles prg fileName _ = writeFile fileName $ sourceCode $ implementation prg
+
+icompile :: (Syntactic t) => t -> IO ()
+icompile = icompileWith defaultOptions
+
+icompileWith :: (Syntactic t) => Options -> t -> IO ()
+icompileWith opts = icompile' opts "test"
+
+icompile' :: (Syntactic t) => Options -> String -> t -> IO ()
+icompile' opts fName prg = do
+    let res = compileToCCore fName opts prg
+    when (printHeader opts) $ do
+      putStrLn "=============== Header ================"
+      putStrLn $ sourceCode $ interface res
+      putStrLn "=============== Source ================"
+    putStrLn $ sourceCode $ implementation res
+
+-- | Get the generated core for a program.
+getCore :: (Syntactic t) => t -> Module ()
+getCore = fromCore defaultOptions "test"
+
+-- | Print the generated core for a program.
+printCore :: (Syntactic t) => t -> IO ()
+printCore prog = print $ getCore prog
+
+targetsFromPlatform :: Platform -> [Target]
+targetsFromPlatform pf = tfp $ name pf
+   where tfp "c99"       = []
+         tfp "c99OpenMp" = []
+         tfp "c99Wool"   = [Wool]
+         tfp "ba"        = [BA]
+         tfp p           = error $ "Interface.tfp: Unknown platform:" ++ p
+
+program :: Syntactic a => a -> IO ()
+program p = programOpts p defaultOptions
+
+programOpts :: Syntactic a => a -> Options -> IO ()
+programOpts p opts = do args <- getArgs
+                        programOptsArgs p defaultProgOpts{backOpts = opts} args
+
+programOptsArgs :: Syntactic a => a -> ProgOpts -> [String] -> IO ()
+programOptsArgs p = programComp (const (return p))
+
+programComp :: Syntactic a => ([String] -> IO a) -> ProgOpts -> [String] -> IO ()
+programComp pc opts args = do
+  name' <- getProgName
+  let (opts1,nonopts) = decodeOpts (optsFromName opts name') args
+  let header = "Usage: " ++ name' ++ " <option>...\n"
+                         ++ "where <option> is one of"
+  if printHelp opts1
+    then putStr $ usageInfo header optionDescs ++ passInfo ++ targetInfo
+    else do
+      p <- pc nonopts
+      let (strs,mProgs) = translate opts1 p
+      unless (null strs) $ writeFileLB (passFileName opts1) (concat strs)
+      case mProgs of
+        Nothing -> return ()
+        Just prog -> writeFiles prog (outFileName opts1)
+                      (codeGenerator $ platform $ backOpts opts1)
+
+optsFromName :: ProgOpts -> String -> ProgOpts
+optsFromName opts name' = opts{ passFileName = name' ++ ".passes"
+                              , outFileName = name'
+                              , functionName = name'}
+
+outFileNames :: ProgOpts -> [String]
+outFileNames opts = [name' ++ ".h", name' ++ ".c"]
+  where name' = outFileName opts
+
+decodeOpts :: ProgOpts -> [String] -> (ProgOpts, [String])
+decodeOpts optsIn argv
+  | null errors = (foldl (\ o f -> f o) optsIn actions, nonOptions)
+  | otherwise = error $ unlines errors
+   where (actions, nonOptions, errors) = getOpt Permute optionDescs argv
+
+passInfo :: String
+passInfo = "\nPASS is a frontend pass from\n" ++
+           unlines (map ((++) "  " . unwords) $ chunksOf 5 $ map show [minBound .. maxBound :: FrontendPass]) ++
+           "or a backend pass from\n" ++
+           unlines (map ((++) "  " . unwords) $ chunksOf 5 $ map show [minBound .. maxBound :: BackendPass])
+  where chunksOf _ [] = []
+        chunksOf n xs = take n xs:chunksOf n (drop n xs)
+
+targetInfo :: String
+targetInfo = "\nTARGET is one of " ++ unwords (map name availablePlatforms) ++ "\n\n"
+
+optionDescs :: [OptDescr (ProgOpts -> ProgOpts)]
+optionDescs = driverOpts
+
+driverOpts :: [OptDescr (ProgOpts -> ProgOpts)]
+driverOpts =
+  [ Option []  ["writeBefore"] (ReqArg (chooseEnd addWrBefore) "PASS")   "write IR before PASS"
+  , Option []  ["writeAfter"]  (ReqArg (chooseEnd addWrAfter) "PASS")    "write IR after PASS"
+  , Option []  ["stopBefore"]  (ReqArg (chooseEnd setStopBefore) "PASS") "stop processing before PASS"
+  , Option []  ["stopAfter"]   (ReqArg (chooseEnd setStopAfter) "PASS")  "stop processing after PASS"
+  , Option []  ["skip"]        (ReqArg (chooseEnd addSkip) "PASS")       "skip PASS"
+  , Option "o" ["outFile"]     (ReqArg (\ arg opts -> opts{outFileName = arg}) "FILE") "set base name of out file"
+  , Option "p" ["passFile"]    (ReqArg (\ arg opts -> opts{passFileName = arg}) "FILE") "set name of pass file"
+  , Option []  ["funcName"]    (ReqArg (\ arg opts -> opts{functionName = arg}) "IDENTIFIER") "set name of generated function"
+  , Option "t" ["target"]      (ReqArg (\ arg opts -> setTarget opts arg) "TARGET") "set target"
+  , Option "h" ["help"]        (NoArg (\ opts -> opts{printHelp = True})) "print a useage message"
+  ]
+
+setTarget :: ProgOpts -> String -> ProgOpts
+setTarget opts str = opts{backOpts = bopts{platform = pf,
+                                           frontendOpts = fopts{targets = targetsFromPlatform pf}}}
+   where bopts = backOpts opts
+         fopts = frontendOpts bopts
+         pf = platformFromName str
+
+chooseEnd :: (forall a . PassCtrl a -> a -> PassCtrl a) -> String -> ProgOpts -> ProgOpts
+chooseEnd f str opts
+  | [(p,_)] <- reads str = opts{frontendCtrl = f (frontendCtrl opts) p}
+  | [(p,_)] <- reads str = opts{backendCtrl = f (backendCtrl opts) p}
+  | otherwise = error $ "Compiler.chooseEnd: unrecognized pass " ++ str
+
+writeFileLB :: String -> String -> IO ()
+writeFileLB  "-"  str = putStr str
+writeFileLB name' str = do fh <- openFile name' WriteMode
+                           hSetBuffering fh LineBuffering
+                           hPutStr fh str
+                           hClose fh
+
+translate :: Syntactic a => ProgOpts -> a -> ([String], Maybe SplitModule)
+translate opts p = (ssf ++ ssb, as)
+  where (ssf, ut) = frontend (frontendCtrl opts) fopts $ reifyFeld p
+        (ssb, as) = maybe ([], Nothing) (backend (backendCtrl opts) bopts name') ut
+        bopts     = backOpts opts
+        fopts     = frontendOpts bopts
+        name'     = functionName opts

--- a/src/Feldspar/Compiler/Imperative/ArrayOps.hs
+++ b/src/Feldspar/Compiler/Imperative/ArrayOps.hs
@@ -1,0 +1,244 @@
+--
+-- Copyright (c) 2020, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wall #-}
+
+-- | Generation of type specific array management functions.
+module Feldspar.Compiler.Imperative.ArrayOps (arrayOps) where
+
+import Feldspar.Compiler.Backend.C.Options (Options)
+import Feldspar.Compiler.Imperative.Frontend
+        (litI32, fun, call, for, toBlock, mkIf, isShallow, variant,
+         arrayFun, freeArrayE, lowerCopy, mkSequence, elemTyAwL)
+import Feldspar.Compiler.Imperative.Representation
+        (Module(..), Entity(..), Declaration(..), Program(..), Function(..),
+         ParType(..), Block(..), ActualParameter(..), Expression(..),
+         Variable(..), Type(..), ScalarType(..), HasType(..), Size(..),
+         Signedness(..))
+import Feldspar.Range (fullRange)
+
+import Control.Monad.Writer (censor, runWriter, tell)
+import Data.List (concatMap, isPrefixOf, nub)
+
+-- | Main interface for adding needed array operations to a module.
+arrayOps :: Options -> Module () -> Module ()
+arrayOps opts (Module ents) = Module $ concatMap mkArrayOps dts ++ ents'
+  where dts = filter (not . either isShallow isShallow) lrts
+        (ents',lrts) = lower opts ents
+        mkArrayOps (Left  t) = [mkInitArray opts t, mkFreeArray opts t]
+        mkArrayOps (Right t) = [mkCopyArrayPos opts t, mkCopyArray opts t, mkInitCopyArray opts t]
+
+-- | Copying an array to a given position in the destination
+mkCopyArrayPos :: Options -> Type -> Entity ()
+mkCopyArrayPos opts t = Proc name False [dstVar, dstLVar, srcVar, srcLVar, posVar] (typeof dstVar) (Just body)
+  where name = variant "copyArrayPos" t
+        body = Block decls prog
+        decls = []
+        ixVar = Variable intT "i"
+        srcVar = Variable (ArrayType fullRange t) "src"
+        srcLVar = Variable intT "srcLen"
+        dstVar = Variable (ArrayType fullRange t) "dst"
+        dstLVar = Variable intT "dstLen"
+        posVar = Variable intT "pos"
+        prog = Sequence
+                 [ for Parallel ixVar zero (VarExpr srcLVar) one loopBody'
+                 , call "return" [ValueParameter $ VarExpr dstVar]
+                 ]
+        loopBody' = Block lbDecls (Sequence lbProg)
+        lbDecls = []
+        lbProg = lowerCopy opts t lhs' [lhs', ArrayElem (VarExpr srcVar) [VarExpr ixVar]]
+             where lhs' = ArrayElem (VarExpr dstVar) [fun intT "+" [VarExpr posVar, VarExpr ixVar]]
+
+-- FIXME: Remove unused options argument.
+-- | Copying an array to the beginning of another array
+mkCopyArray :: Options -> Type -> Entity ()
+mkCopyArray _ t = Proc name False [dstVar, dstLVar, srcVar, srcLVar] (typeof dstVar) (Just body)
+  where name = variant "copyArray" t
+        srcVar = Variable (ArrayType fullRange t) "src"
+        srcLVar = Variable intT "srcLen"
+        dstVar = Variable (ArrayType fullRange t) "dst"
+        dstLVar = Variable intT "dstLen"
+        body = Block decls prog
+        decls = []
+        prog = Sequence
+               [ Assign (VarExpr dstVar)
+                        (fun (ArrayType fullRange t)
+                             (variant "copyArrayPos" t)
+                             [VarExpr dstVar, VarExpr dstLVar, VarExpr srcVar, VarExpr srcLVar, zero])
+               , call "return" [ValueParameter $ VarExpr dstVar]
+               ]
+
+-- FIXME: Remove unused options argument.
+-- | Initializing and copying in a single operation
+mkInitCopyArray :: Options -> Type -> Entity ()
+mkInitCopyArray _ t = Proc name False [dstVar, dstLVar, srcVar, srcLVar] (typeof dstVar) (Just body)
+  where name = variant "initCopyArray" t
+        srcVar = Variable (ArrayType fullRange t) "src"
+        srcLVar = Variable intT "srcLen"
+        dstVar = Variable (ArrayType fullRange t) "dst"
+        dstLVar = Variable intT "dstLen"
+        body = Block decls prog
+        decls = []
+        prog = Sequence
+               [ Assign (VarExpr dstVar) (arrayFun "initArray" [VarExpr dstVar, VarExpr dstLVar, VarExpr srcLVar])
+               , Assign (VarExpr dstLVar) (VarExpr srcLVar)
+               , Assign (VarExpr dstVar)
+                        (fun (ArrayType fullRange t)
+                             (variant "copyArrayPos" t)
+                             [VarExpr dstVar, VarExpr dstLVar, VarExpr srcVar, VarExpr srcLVar, zero])
+               , call "return" [ValueParameter $ VarExpr dstVar]
+               ]
+
+-- FIXME: Remove unused optoins argument.
+-- | Initialize an array to a given length
+mkInitArray :: Options -> Type -> Entity ()
+mkInitArray _ t = Proc name False [dstVar, oldLen, newLen] (typeof dstVar) (Just body)
+  where name = variant "initArray" t
+        dstVar = Variable (ArrayType fullRange t) "dst"
+        oldLen = Variable lengthT "oldLen"
+        newLen = Variable lengthT "newLen"
+        body = Block [] prog
+        prog = Sequence [ mkIf (fun boolT "/=" [VarExpr oldLen, VarExpr newLen]) (toBlock setLength) Nothing
+                        , call "return" [ValueParameter $ VarExpr dstVar]
+                        ]
+        setLength = Sequence [ mkIf (fun boolT "<" [VarExpr oldLen, VarExpr newLen]) (toBlock grow) (Just $ toBlock shrink)
+                             ]
+        grow = Sequence [ Assign (VarExpr dstVar) (fun arrT "resizeArray" [VarExpr dstVar, SizeOf t, VarExpr newLen])
+                        , for Parallel ixVar (VarExpr oldLen) (VarExpr newLen) one (Block initBodyDecls initBody)
+                        ]
+        initBody = Sequence [Assign e (VarExpr $ nullVar t' i)
+                            | ((e, t'), i) <- zip arrs [0 :: Int ..]]
+        initBodyDecls = [Declaration (nullVar t' i) Nothing
+                        | ((_, t'), i) <- zip arrs [0 :: Int ..]]
+        shrink = Sequence [ for Parallel ixVar (VarExpr newLen) (VarExpr oldLen) one (toBlock freeBody)
+                          , Assign (VarExpr dstVar) (fun arrT "resizeArray" [VarExpr dstVar, SizeOf t, VarExpr newLen])
+                          ]
+        freeBody = Sequence [freeArrayE e | (e,_) <- arrs]
+
+        arrs = arrays (ArrayElem (VarExpr dstVar) [VarExpr ixVar]) t
+
+        ixVar = Variable intT "i"
+        nullVar t' n = Variable t' ("null_arr_" ++ show n)
+        arrT = ArrayType fullRange t
+
+-- FIXME: Remove unused options argument.
+-- | Free an array
+mkFreeArray :: Options -> Type -> Entity ()
+mkFreeArray _ t = Proc name False [srcVar, srcLVar] VoidType (Just body)
+  where name = variant "freeArray" t
+        srcVar = Variable (ArrayType fullRange t) "src"
+        srcLVar = Variable intT "srcLen"
+        body = Block [] $ Sequence stms
+        stms = [ for Parallel ixVar zero (VarExpr srcLVar) one loopBody'
+               , call "freeArray" [ValueParameter $ VarExpr srcVar]
+               ]
+        ixVar = Variable intT "i"
+        loopBody' = toBlock $ Sequence [freeArrayE e | (e,_) <- arrs]
+        arrs = arrays (ArrayElem (VarExpr srcVar) [VarExpr ixVar]) t
+
+-- | Type names
+lengthT, intT, boolT :: Type
+lengthT = 1 :# NumType Unsigned S32
+intT    = 1 :# NumType Signed S32
+boolT   = 1 :# BoolType
+
+-- | Extract all arrays nested in a type
+arrays :: Expression () -> Type -> [(Expression (), Type)]
+arrays e t@(StructType _ [("buffer", ArrayType _ _),_]) = [(e,t)]
+arrays e (NativeArray _ t) = [(e,t)]
+arrays e (StructType _ fs) = concat [arrays (StructField e f) t | (f,t) <- fs]
+arrays _ _                 = []
+
+-- | Add types that will also need array operations
+close :: Either Type Type -> [Either Type Type]
+close et
+  | Left  t <- et = map Left  $ t : go t
+  | Right t <- et = map Right $ t : go t
+  where go t | Just et' <- elemTyAwL t = t:go et'
+        go (StructType _ fs) = concatMap (go . snd) fs
+        go _                 = []
+
+-- | Lower copy function and collect array op variants
+lower :: Options -> [Entity ()] -> ([Entity ()], [Either Type Type])
+lower opts es' = runWriter $ censor (nub . concatMap close) $ mapM lcEnt es'
+  where lcEnt p@Proc{procBody = Just b} = do b' <- lcBlock b
+                                             return p{procBody = Just b'}
+        lcEnt e                         = return e
+
+        lcBlock block = do body <- lcProg $ blockBody block
+                           return block{blockBody = body}
+
+        lcProg (Assign lhs' e@(FunctionCall (Function "copy" _) es))
+          = do let t = typeof lhs'
+                   ts = eTypesL e t
+               tell $ map Right ts ++ map Left ts
+               return $ mkSequence $ lowerCopy opts t lhs' es
+        lcProg (Assign lhs' e@(FunctionCall (Function name _) _))
+          | "initArray" `isPrefixOf` name
+          = do tell $ map Left $ eTypes e $ typeof lhs'
+               return $ Assign lhs' e
+        lcProg (Sequence ps) = do ps' <- mapM lcProg ps
+                                  return $ Sequence ps'
+        lcProg (Switch e alts') = do alts'' <- mapM lcAlt alts'
+                                     return $ Switch e alts''
+        lcProg (SeqLoop e c b) = do c' <- lcBlock c
+                                    b' <- lcBlock b
+                                    return $ SeqLoop e c' b'
+        lcProg (ParLoop p n s e i b) = do b' <- lcBlock b
+                                          return $ ParLoop p n s e i b'
+        lcProg (ProcedureCall f args)
+               | "ivar_get_array" `isPrefixOf` f
+               , [ValueParameter e, _, _] <- args
+               = do let ts = eTypesL e $ typeof $ Deref e
+                    tell $ map Left ts ++ map Right ts
+                    return $ ProcedureCall f args
+               | "ivar_put_array" `isPrefixOf` f
+               , [_, ValueParameter e, _] <- args
+               = do let ts = eTypesL e $ typeof $ Deref e
+                    tell $ map Left ts ++ map Right ts
+                    return $ ProcedureCall f args
+        lcProg p = return p
+
+        lcAlt (p, b) = do b' <- lcBlock b
+                          return (p, b')
+
+        eTypesL _ (StructType _ [("buffer", ArrayType _ t), _]) = [t]
+        eTypesL _ (NativeArray _ t) = [t]
+        eTypesL e t = error $ "ArrayOps.eTypesL: surprising array type "
+                            ++ show t ++ " with rhs\n  " ++ show e
+
+        eTypes _ (ArrayType _ t) = [t]
+        eTypes _ (NativeArray _ t) = [t]
+        eTypes e t = error $ "ArrayOps.eTypes: surprising array type "
+                           ++ show t ++ " with rhs\n  " ++ show e
+
+-- | Utilities
+zero :: Expression ()
+zero = litI32 0
+one :: Expression ()
+one  = litI32 1

--- a/src/Feldspar/Compiler/Imperative/ExternalProgram.hs
+++ b/src/Feldspar/Compiler/Imperative/ExternalProgram.hs
@@ -1,0 +1,736 @@
+{-# OPTIONS_GHC -Wall #-}
+-- Partial functions due to the mismatch between Program and C.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module Feldspar.Compiler.Imperative.ExternalProgram (parseFile, massageInput) where
+
+import Feldspar.Lattice (universal)
+import qualified Feldspar.Compiler.Imperative.Representation as R
+import Feldspar.Compiler.Imperative.Representation hiding (
+  Block, Switch, Assign, Cast, IntConst, FloatConst, DoubleConst, Type,
+  Deref, AddrOf, Unsigned, Signed, inParams)
+import Feldspar.Compiler.Imperative.Frontend (
+    litB, litI32, toBlock, fun, call, decodeType
+  )
+
+import qualified Data.ByteString.Char8 as B
+import qualified Language.C.Parser as P
+import Language.C.Syntax
+import Data.List (intersperse, mapAccumL, isPrefixOf)
+import Data.Loc
+import Data.Maybe
+
+-- Necessary for now.
+import Debug.Trace
+
+-- The parser is quite general and handles ObjC and has support for
+-- AntiQuotations. We are interested in parsing "External Program"
+-- which grammatically is a subset of C, so most functions in this
+-- file match on some constructors and end with a general error case
+-- that tells which function it is and shows the input it got.
+--
+-- The intention is that these errors should only capture the
+-- constructors that are outside the C language, and valid "External
+-- Program" programs will never see them. The second intention is that
+-- these error messages will be unique and easy to pinpoint in the case
+-- that bugs do occur.
+
+parseFile :: FilePath -> B.ByteString -> [Entity ()] -> Maybe (Module ())
+parseFile filename s hDefs =
+  case P.parse [C99] builtin_types P.parseUnit s' (Just $ startPos filename) of
+      Left _ -> Nothing
+      Right defs -> Just (Module $ fhDefs ++ toProgram hDefs defs)
+   where s' = massageInput s
+         fhDefs = filter isStructDef hDefs
+         isStructDef StructDef{} = True
+         isStructDef _           = False
+
+-- A list of built in types. We need the regular C99 types in this list, or
+-- the parser will die with a mysterious parse error.
+builtin_types :: [String]
+builtin_types = [ "uint64_t", "uint32_t", "uint16_t", "uint8_t"
+                , "int64_t", "int32_t", "int16_t", "int8_t"
+                , "bool"]
+
+toProgram :: [Entity ()] -> [Definition] -> [Entity ()]
+toProgram [] defs = snd $ defsToProgram (emptyEnv []) defs
+toProgram hDefs defs = rest' ++ reverse funcs'
+  where funcs' = snd $ defsToProgram env' $ reverse funcs
+        (env', rest') = defsToProgram (emptyEnv (patchHdefs hDefs)) rest
+        (funcs, rest) = span isFunc defs
+        isFunc FuncDef{} = True
+        isFunc _         = False
+
+defsToProgram :: TPEnv -> [Definition] -> (TPEnv, [Entity ()])
+defsToProgram = mapAccumL defToProgram
+
+defToProgram :: TPEnv -> Definition -> (TPEnv, Entity ())
+defToProgram env (FuncDef func _) = funcToProgram env func
+defToProgram env (DecDef (InitGroup ds _ is@[Init n Array{} Nothing (Just (CompoundInitializer ins _)) _ _] _) _)
+  = valueToProgram env ds is n ins'
+   where ins' = map snd ins
+defToProgram env (DecDef ig _) = initGroupToDeclaration env ig
+defToProgram _ (EscDef s _) = error ("defToProgram: " ++ show s)
+defToProgram _ e = error ("defToProgram: Unhandled construct: " ++ show e)
+
+funcToProgram :: TPEnv -> Func -> (TPEnv, Entity ())
+funcToProgram env (Func ds name _ (Params parms _ _) bis _)
+  = (env'', Proc (unId name) False vs dsl (Just bs))
+   where (env', vs) = mapAccumL paramToVariable env parms
+         (env'', bs) = blockToBlock env' bis
+         dsl = declSpecToType env ds
+funcToProgram _ e = error ("funcToProgram: Unhandled construct: " ++ show e)
+
+valueToProgram :: TPEnv -> DeclSpec -> [Init] -> Id -> [Initializer]
+               -> (TPEnv, Entity ())
+valueToProgram env ds is n ins = (env', ValueDef (nameToVariable env' n) cs')
+  where env' = fst $ initToNames env ds is
+        cs = map (\(ExpInitializer (Const c _) _) -> constToConstant c) ins
+        cs' = ArrayConst (map (castConstant t) cs) t
+        t = declSpecToType env ds
+
+paramToVariable :: TPEnv -> Param -> (TPEnv, R.Variable ())
+paramToVariable env (Param (Just id') t p _)
+ | Just v' <- lookup (unId id') (vars env) = (env, v') -- We have recovered types.
+ | otherwise = (updateEnv env [v], v)
+  where v = Variable (declToType (declSpecToType env t) p) (unId id')
+paramToVariable _ e = error $ "paramToVariable: Unhandled construct: " ++ show e
+
+blockToBlock :: TPEnv -> [BlockItem] -> (TPEnv, R.Block ())
+blockToBlock env bis = (env'', R.Block (concat ds) (Sequence bs))
+  where (env', ds) = mapAccumL blockDeclToDecl env decls
+        (env'', bs) = blockItemsToProgram env' rest
+        (decls, rest) = span isBlockDecl bis
+        isBlockDecl BlockDecl{} = True
+        isBlockDecl _           = False
+
+blockDeclToDecl :: TPEnv -> BlockItem -> (TPEnv, [Declaration ()])
+blockDeclToDecl env (BlockDecl ig) = initGroupToProgram env ig
+
+blockItemsToProgram :: TPEnv -> [BlockItem] -> (TPEnv, [Program ()])
+-- TODO: Stop freeloading on ParLoop since we have to fake v/t at this stage.
+blockItemsToProgram env (BlockStm (Pragma "omp parallel" _):bis)
+  = (env', [ParLoop WorkParallel v t t t (toBlock $ Sequence ps)])
+    where (env', ps) = blockItemsToProgram env bis
+          t = litB True -- Fake information with the correct type.
+          v = snd $ head builtins -- Fake information with the correct type.
+blockItemsToProgram env bs = mapAccumL blockItemToProgram env bs
+
+blockItemToProgram :: TPEnv -> BlockItem -> (TPEnv, Program ())
+blockItemToProgram _ b@BlockDecl{}
+  = error ("Declaration in the middle of a block: " ++ show b)
+-- Ivar reconstruction stuff.
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "ivar_get" _) _) _ _)) _))
+  = (env, ProcedureCall "ivar_get" (tp:map ValueParameter es))
+    where (FunctionCall (Function "ivar_get" _) es) = expToExpression env e
+          tp = TypeParameter $ typeof (R.Deref (head es))
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "ivar_get_nontask" _) _) _ _)) _))
+  = (env, ProcedureCall "ivar_get_nontask" (tp:map ValueParameter es))
+    where (FunctionCall (Function "ivar_get_nontask" _) es) = expToExpression env e
+          tp = TypeParameter $ typeof (R.Deref (head es))
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "ivar_put" _) _) _ _)) _))
+  = (env, ProcedureCall s (tp:map ValueParameter es))
+   where (FunctionCall (Function s _) es) = expToExpression env e
+         tp = TypeParameter (typeof (R.Deref (last es)))
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "run2" _) _) _ _)) _))
+  = (env, ProcedureCall s (FunParameter e1:tp))
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1)]) = expToExpression env e
+         tp = map TypeParameter $ lookup3 e1 (headerDefs env)
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "run3" _) _) _ _)) _))
+  = (env, ProcedureCall s (FunParameter e1:tp))
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1)]) = expToExpression env e
+         tp = map TypeParameter $ lookup3 e1 (headerDefs env)
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "run4" _) _) _ _)) _))
+  = (env, ProcedureCall s (FunParameter e1:tp))
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1)]) = expToExpression env e
+         tp = map TypeParameter $ lookup3 e1 (headerDefs env)
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "run5" _) _) _ _)) _))
+  = (env, ProcedureCall s (FunParameter e1:tp))
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1)]) = expToExpression env e
+         tp = map TypeParameter $ lookup3 e1 (headerDefs env)
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "spawn2" _) _) _ _)) _))
+  = (env, ProcedureCall s es)
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1),e2,e3]) = expToExpression env e
+         es = [ FunParameter e1, TypeParameter (typeof e2), ValueParameter e2
+              , TypeParameter (typeof e3), ValueParameter e3]
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "spawn3" _) _) _ _)) _))
+  = (env, ProcedureCall s es)
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1),e2,e3,e4]) = expToExpression env e
+         es = [ FunParameter e1, TypeParameter (typeof e2), ValueParameter e2
+              , TypeParameter (typeof e3), ValueParameter e3
+              , TypeParameter (typeof e4), ValueParameter e4]
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "spawn4" _) _) _ _)) _))
+  = (env, ProcedureCall s es)
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1), e2, e3, e4, e5]) = expToExpression env e
+         es = [ FunParameter e1, TypeParameter (typeof e2), ValueParameter e2
+              , TypeParameter (typeof e3), ValueParameter e3
+              , TypeParameter (typeof e4), ValueParameter e4
+              , TypeParameter (typeof e5), ValueParameter e5]
+blockItemToProgram env (BlockStm (Exp (Just e@(FnCall (Var (Id "spawn5" _) _) _ _)) _))
+  = (env, ProcedureCall s es)
+   where (FunctionCall (Function s _) [VarExpr (Variable _ e1), e2, e3, e4, e5, e6]) = expToExpression env e
+         es = [ FunParameter e1, TypeParameter (typeof e2), ValueParameter e2
+              , TypeParameter (typeof e3), ValueParameter e3
+              , TypeParameter (typeof e4), ValueParameter e4
+              , TypeParameter (typeof e5), ValueParameter e5
+              , TypeParameter (typeof e6), ValueParameter e6]
+-- Probably copyArray.
+blockItemToProgram env (BlockStm (Exp (Just e@FnCall{}) _))
+  = (env, ProcedureCall s (map ValueParameter es))
+   where (FunctionCall (Function s _) es) = expToExpression env e
+blockItemToProgram env (BlockStm (Exp (Just e) _)) = impureExpToProgram env e
+blockItemToProgram env (BlockStm e) = (env, stmToProgram env e)
+blockItemToProgram _ e = error ("blockItemsToProgram: Unhandled construct: " ++ show e)
+
+initGroupToDeclaration :: TPEnv -> InitGroup -> (TPEnv, Entity ())
+-- Struct definitions and similar.
+initGroupToDeclaration env (InitGroup ds _ [] _) = (env', s)
+  where env' = updateEnv2 env [] t
+        t = declSpecToType env ds
+        [s] = mkDef t
+initGroupToDeclaration env (TypedefGroup ds _ (h:_) _) = (env', s)
+  where env'                  = updateEnv2 env [] t
+        (StructType _ fields) = declSpecToType env ds
+        t                     = StructType (typeDefToName h) fields
+        [s]                   = mkDef t
+-- Function declarations
+initGroupToDeclaration env (InitGroup ds _ [is@(Init _ (Proto _ (Params ps _ _) _) _ _ _ _)] _)
+  = initToFunDecl env ds is ps
+initGroupToDeclaration _ e = error $ "initGroupToDeclaration: " ++ show e
+
+initGroupToProgram :: TPEnv -> InitGroup -> (TPEnv, [Declaration ()])
+-- Variable declarations
+initGroupToProgram env (InitGroup ds _ is _) = initToNames env ds is
+initGroupToProgram _ (TypedefGroup _ds _attr _ts _)
+  = error "initGroupToProgram: hit TypedefGroup."
+initGroupToProgram _ e
+  = error $ "initGroupToProgram: Unhandled construct: " ++ show e
+
+-- Contrived type to swallow break statements silently.
+switchAltToProgram :: TPEnv -> BlockItem -> [(Pattern (), R.Block ())]
+switchAltToProgram _ (BlockStm Break{}) = []
+switchAltToProgram env (BlockStm (Case e s _))
+  = [(Pat (expToExpression env e), toBlock (stmToProgram env s))]
+switchAltToProgram env (BlockStm (Default stm _))
+  = [(PatDefault, toBlock (stmToProgram env stm))]
+switchAltToProgram _ e = error $ "switchAltToProgram: " ++ show e
+
+stmToProgram :: TPEnv -> Stm -> Program ()
+stmToProgram _ l@Label{} = error $ "stmToProgram: Unexpected label: " ++ show l
+stmToProgram _ (Exp Nothing _) = error "Exp: Nothing?"
+stmToProgram env (Exp (Just e) _) = snd $ impureExpToProgram env e
+stmToProgram env (Block bis _) = R.BlockProgram $ snd $ blockToBlock env bis
+stmToProgram env (If e b1 (Just b2) _)
+  = R.Switch cond [ (Pat $ litB True, toBlock $ stmToProgram env b1)
+                  , (Pat $ litB False, toBlock $ stmToProgram env b2)]
+    where cond = expToExpression env e
+stmToProgram env (Switch e (Block alts' _) _)
+  = R.Switch (expToExpression env e) $ concatMap (switchAltToProgram env) alts'
+stmToProgram env (While e s _) = SeqLoop cond (toBlock Empty) (toBlock p)
+  where cond = expToExpression env e
+        p = stmToProgram env s
+stmToProgram _ (DoWhile _s _e _) = error "stmToProgram: No support for Do."
+stmToProgram env (For eit
+                      (Just (BinOp Lt Var{} v2 _))
+                      (Just ass) s _)
+  = ParLoop Sequential v' e0' (expToExpression env' v2) rhs' body
+    where body = toBlock $ stmToProgram env' s
+          (v', env', e0') = case eit of
+             Right (Just (Assign name JustAssign e0 _)) -> (v, env, expToExpression env e0)
+               where v = varToVariable env name
+             Left es@InitGroup{} -> (v, env0, e0)
+               where (env0, es') = initGroupToProgram env es
+                     [Declaration v (Just e0)] = es'
+             _ -> error $ "stmToProgram: Unknown first for block: " ++ show eit
+          rhs' = case ass of
+                   Assign _ AddAssign rhs'' _ -> expToExpression env' rhs''
+                   PostInc v _              -> plusOne $ expToExpression env' v
+                   _ -> error $ "stmToProgram: Unknown second for block: " ++ show ass
+stmToProgram _ Goto{} = error "stmToProgram: No support for goto."
+stmToProgram _ Continue{} = error "stmToProgram: No support for continue."
+stmToProgram _ Break{} = error "stmToProgram: Unexpected break."
+stmToProgram env (Return (Just e) _)
+  = call "return" [ValueParameter $ expToExpression env e]
+stmToProgram _ (Pragma _ _) = error "Pragma not supported yet."
+stmToProgram _ a@Asm{} = error $ "stmToProgram: unexpected asm: " ++ show a
+stmToProgram _ e = error $ "stmToProgram: Unhandled construct: " ++ show e
+
+impureExpToProgram :: TPEnv -> Exp -> (TPEnv, Program ())
+-- Hook for padding incomplete struct array * type info.
+impureExpToProgram env (Assign e JustAssign
+                               f@(FnCall (Var (Id "initArray" _) _)
+                                         [_, e2', _] _) _)
+  = (env', R.Assign (expToExpression env' e) (expToExpression env' f))
+   where env' = fixupEnv env e $ typToType env (getTyp e2')
+         getTyp (SizeofType e' _) = e'
+         getTyp (BinOp Sub _ e' _) = getTyp e'
+         getTyp e' = error $ "Unexpected parameter to initArray:" ++ show e'
+impureExpToProgram env (Assign e@Var{} JustAssign
+                               f@(FnCall (Var (Id "at" _) _) [e1, _] _) _)
+  = (env', R.Assign (expToExpression env e) (expToExpression env' f))
+   where env' = fixupEnv env e1 $ varType (varToVariable env e)
+impureExpToProgram env (Assign e@(FnCall (Var (Id "at" _) _) [e1, _] _) JustAssign
+                               f@(FnCall (Var (Id "at" _) _) [e1', _] _) _)
+  = (env'', R.Assign (expToExpression env'' e) (expToExpression env'' f))
+   -- Hope LHS or RHS has proper types. Propagate to the other side.
+   where env'' = fixupEnv env' e1 $ typeof (expToExpression env' f)
+         env'  = fixupEnv env e1' $ typeof (expToExpression env e)
+impureExpToProgram env (Assign e@(FnCall (Var (Id "at" _) _) [e1, _] _) JustAssign
+                               f _)
+  = (env', R.Assign (expToExpression env' e) f')
+   -- Propagate type of RHS to LHS.
+   where env' | VoidType <- typeof e' = fixupEnv env e1 $ typeof f'
+              | otherwise = env
+         e'   = expToExpression env e
+         f' | VoidType <- typeof e' = expToExpression env f
+            | otherwise = expToExpression' env' (Just $ typeof e') f
+impureExpToProgram env (Assign e JustAssign
+                               f@(FnCall (Var (Id "at" _) _) [e1', _] _) _)
+  = (env', R.Assign e' (expToExpression env' f))
+   -- Propagate type of LHS to RHS.
+   where env' | VoidType <- typeof f' = fixupEnv env e1' $ typeof e'
+              | otherwise = env
+         e' | VoidType <- typeof f' = expToExpression env e
+            | otherwise = expToExpression' env' (Just $ typeof f') e
+         f' = expToExpression env f
+impureExpToProgram env (Assign e1 JustAssign e2 _)
+  = (env, R.Assign (expToExpression env e1) (expToExpression env e2))
+impureExpToProgram _ e = error $ "impureExpToProgram: " ++ show e
+
+varToVariable :: TPEnv -> Exp -> Variable ()
+varToVariable env (Var name _) = nameToVariable env name
+
+nameToVariable :: TPEnv -> Id -> Variable ()
+nameToVariable env name
+ | Just v <- lookup (unId name) (vars env) = v
+ | take 4 (unId name) == "task" = Variable fakeType (unId name) -- fake tasks
+ | otherwise = error $ "varToVariable: Could not find: " ++ show name
+
+expToExpression :: TPEnv -> Exp -> Expression ()
+expToExpression env = expToExpression' env Nothing
+
+-- No concept of Bool constants in the C parser. They appear at expresion
+-- positions in our context.
+expToExpression' :: TPEnv -> Maybe R.Type -> Exp -> Expression ()
+expToExpression' _ _ (Var n _)
+  | unId n == "true" = litB True
+  | unId n == "false" = litB False
+  | unId n == "NULL"  = litI32 0 -- Only representation for NULL in Program.
+expToExpression' env _ v@Var{} = VarExpr $ varToVariable env v
+expToExpression' _ _ (Const c _) = ConstExpr (constToConstant c)
+expToExpression' env t (BinOp op e1 e2 _) = opToFunctionCall parms op
+  where parms = map (expToExpression' env t) [e1, e2]
+expToExpression' env t (UnOp op e _) = unOpToExp (expToExpression' env t e) op
+expToExpression' _ _ (Assign e1 JustAssign e2 _) = error $ "Assign unimplemented" ++ show e1 ++ " = " ++ show e2
+expToExpression' _ _ a@Assign{} = error ("AssignOp unhandled: " ++ show a)
+expToExpression' _ _ PreInc{} = error "expToExpression: No support for preinc."
+expToExpression' _ _ PostInc{} = error "expToExpression: No support for postinc."
+expToExpression' _ _ PreDec{} = error "expToExpression: No support for predec."
+expToExpression' _ _ PostDec{} = error "expToExpression: No support for postdec."
+expToExpression' _ _ SizeofExp{} = error "expToExpression: No support for sizeof exp"
+expToExpression' env _ (SizeofType t _) = R.SizeOf $ typToType env t
+expToExpression' env _ (Cast t e _)
+  = R.Cast (typToType env t) (expToExpression env e)
+expToExpression' _ _ (Cond _c _e1 _e2 _) = error "expToExpression: No support for conditional statements."
+expToExpression' env _ (Member e name _)
+  = StructField (expToExpression env e) (unId name)
+expToExpression' _ _ PtrMember{} = error "expToExpression: No support for ptrmember."
+expToExpression' env _ (Index e1 e2 _)
+  = ArrayElem (expToExpression env e1) [expToExpression env e2]
+expToExpression' env tcontext (FnCall (Var (Id "at" _) _) [e1, e2] _)
+  = ArrayElem (expToExpression env' e1) [expToExpression env' e2]
+   where env' | (Var name _) <- e1
+              , Just t <- tcontext
+              , Just (Variable (ArrayType _ VoidType) _) <- lookup (unId name) (vars env)
+              = fixupEnv env e1 t
+              | otherwise = env
+expToExpression' env _ (FnCall e es _)
+  = expToFunctionCall env (map (expToExpression env) es) e
+expToExpression' _ _ CudaCall{} = error "expToExpression: No support for CUDA."
+expToExpression' _ _ Seq{} = error "expToExpression: No support for seq."
+expToExpression' env _ (CompoundLit t ls _) = ConstExpr $ ArrayConst cs' $ typToType env t
+  where cs = map (\(_, ExpInitializer (Const c _) _) -> constToConstant c) ls
+        cs' = map (castConstant (typToType env t)) cs
+expToExpression' _ _ StmExpr{} = error "expToExpression: No support for Stmexpr."
+expToExpression' _ _ BuiltinVaArg{} = error "expToExpression: varargs not supported."
+expToExpression' _ _ BlockLit{} = error "expToExpression: No support for blocklit."
+expToExpression' _ _ e = error $ "expToExpression: Unhandled construct: " ++ show e
+
+opToFunctionCall :: [Expression ()] -> BinOp -> Expression ()
+opToFunctionCall es op = case opToString op of
+                      Right s -> fun t s es
+                      Left s -> fun (1 :# BoolType) s es
+  where t = typeof (head es)
+
+opToString :: BinOp -> Either String String
+opToString Add = Right "+"
+opToString Sub = Right "-"
+opToString Mul = Right "*"
+opToString Div = Right "/"
+opToString Mod = Right "%"
+opToString Eq = Left "=="
+opToString Ne = Left "!="
+opToString Lt = Left "<"
+opToString Gt = Left ">"
+opToString Le = Left "<="
+opToString Ge = Left ">="
+opToString Land = Left "&&"
+opToString Lor = Left "||"
+opToString And = Right "&"
+opToString Or = Right "|"
+opToString Xor = Right "^"
+opToString Lsh = Right "<<"
+opToString Rsh = Right ">>"
+
+expToFunctionCall :: TPEnv -> [Expression ()] -> Exp -> Expression ()
+expToFunctionCall _ es (Var name _)
+  | Just v <- lookup (unId name) builtins
+  = fun (varType v) (varName v) es
+  | otherwise = fun fakeType (unId name) es
+
+-- Signed integers are the default for literals, but that is not always
+-- convenient. Fix things up afterwards instead.
+castConstant :: R.Type -> R.Constant () -> R.Constant ()
+castConstant (1 :# t) (R.IntConst i _) = R.IntConst i t
+castConstant _ c = error ("castConstant: Unexpected argument: " ++ show c)
+
+constToConstant :: Const -> Constant ()
+constToConstant (IntConst _ sgn i _)
+  = R.IntConst i (NumType (signToSign sgn) S32)
+constToConstant (LongIntConst _ sgn i _)
+  = R.IntConst i (NumType (signToSign sgn) S64)
+constToConstant (LongLongIntConst _ sgn i _)
+  = R.IntConst i (NumType (signToSign sgn) S64)
+constToConstant (FloatConst _ r _) = R.FloatConst r
+constToConstant (DoubleConst _ r _) = R.DoubleConst r
+constToConstant (LongDoubleConst _ r _) = R.DoubleConst r
+constToConstant (CharConst _ _c _)
+  = error "constToConstant: No support for character constants."
+constToConstant (StringConst _ss _s _)
+  = error "constToConstant: No support for string constants."
+constToConstant e = error ("constToConstant: Unhandled construct: " ++ show e)
+
+declSpecToType :: TPEnv -> DeclSpec -> R.Type
+declSpecToType env (DeclSpec _ _ ts _) = typSpecToType env ts
+declSpecToType _ e = error ("declSpecToType: Unhandled construct: " ++ show e)
+
+initToFunDecl :: TPEnv -> DeclSpec -> Init -> [Param] -> (TPEnv, Entity ())
+initToFunDecl env ds is ps = (env', Proc iv False ps' VoidType Nothing)
+ where (iv, _, _)  = initToName env (declSpecToType env' ds) is
+       (env', ps') = mapAccumL paramToVariable env ps
+
+initToNames :: TPEnv -> DeclSpec -> [Init] -> (TPEnv, [Declaration ()])
+initToNames env ds is = (updateEnv env vs, dv)
+ where ivs = map (initToName env (declSpecToType env ds)) is
+       vs  = map (\(name, t, _) -> Variable t name) ivs
+       dv  = zipWith (\v (_, _, start) -> Declaration v start) vs ivs
+
+initToName :: TPEnv -> R.Type -> Init -> (String, R.Type, Maybe (Expression ()))
+initToName env tp (Init name dcl _ ints _ _)
+  = (unId name, t, maybe Nothing (initializerToExp env t) ints)
+    where t = declToType tp dcl
+
+initializerToExp :: TPEnv -> R.Type -> Initializer -> Maybe (Expression ())
+initializerToExp env _ (ExpInitializer e _)
+  = Just $ expToExpression env e
+initializerToExp env t@(StructType _ ts) (CompoundInitializer es _)
+  | isCompoundZero es
+  = Nothing
+  | otherwise
+  = Just (ConstExpr (StructConst (zipWith (structInit env) ts es) t))
+initializerToExp _ t e
+  = error $ "initializerToExp: Unexpected argument: " ++ show e ++ " of type " ++ show t
+
+structInit :: TPEnv -> (String, R.Type)
+           -> (Maybe Designation, Initializer) -> (Maybe String, Constant ())
+structInit env (_, t) (d, e)
+  | Just (ConstExpr c) <- e'
+  = (maybe Nothing (\(Designation ((MemberDesignator i _):_) _) -> Just $ unId i) d, c)
+  | otherwise
+  = error $ "structInit: Unexpected pattern : " ++ show (d, e)
+   where e' = initializerToExp env t e
+
+isCompoundZero :: [(Maybe Designation, Initializer)] -> Bool
+isCompoundZero [(_, ExpInitializer (Const (IntConst _ _ 0 _) _) _)] = True
+isCompoundZero _ = False
+
+unOpToExp :: Expression () -> UnOp -> Expression ()
+unOpToExp e AddrOf = R.AddrOf e
+unOpToExp e Deref  = R.Deref e
+unOpToExp (ConstExpr (R.IntConst n t)) Negate
+  = ConstExpr (R.IntConst (-1*n) t)
+unOpToExp (ConstExpr (R.FloatConst  n)) Negate
+  = ConstExpr (R.FloatConst (-1*n))
+unOpToExp (ConstExpr (R.DoubleConst n)) Negate
+  = ConstExpr (R.DoubleConst (-1*n))
+unOpToExp e Negate = fun (typeof e) "-" [e]
+unOpToExp e Positive = e
+unOpToExp _ Not = error "Not"
+unOpToExp e Lnot = fun (1 :# BoolType) "!" [e]
+
+typToType :: TPEnv -> Type -> R.Type
+typToType env (Type ds _ _) = declSpecToType env ds
+typToType _ t = error $ "typToType: Unhandled construct: " ++ show t
+
+typSpecToType :: TPEnv -> TypeSpec -> R.Type
+typSpecToType _ Tvoid{} = VoidType
+typSpecToType _ Tchar{} = error "Tchar"
+typSpecToType _ Tshort{} = error "TShort"
+typSpecToType _ (Tint Nothing _) = 1 :# (NumType R.Unsigned S32)
+typSpecToType _ (Tint _ _)       = 1 :# (NumType R.Signed S32)
+typSpecToType _ Tlong{} = error "Tlong"
+typSpecToType _ Tlong_long{} = error "longlong"
+typSpecToType _ Tfloat{}         = 1 :# FloatType
+typSpecToType _ Tdouble{}        = 1 :# DoubleType
+typSpecToType _ Tlong_double{} = error "long double"
+-- Anonymous typedefs.
+typSpecToType env (Tstruct Nothing mfg _ _)
+  = StructType fakeName (concatMap (fieldGroupToType env) (fromJust mfg))
+-- Array types are incomplete so fake one. We recover the type elsewhere.
+typSpecToType _ (Tstruct (Just (Id "array" _)) _ _ _)
+  = ArrayType universal fakeType
+typSpecToType _ (Tstruct (Just (Id s _)) _ _ _)
+  | "awl" `isPrefixOf` s
+  , [t] <- decodeType s
+  = t
+-- Ivars are declared externally so just fake a type.
+typSpecToType _ (Tstruct (Just (Id "ivar" _)) Nothing _ _)
+  = IVarType fakeType
+-- Called for both declaration and use-sites.
+typSpecToType env t'@(Tstruct (Just (Id s _)) mfg _ _)
+  | Just t <- findBuiltinDeclaration env s = t
+  | Just t <- findLocalDeclaration env s = t
+  | Nothing <- mfg = error ("typSpecToType: Internal error: " ++ show t'
+                           ++ " not found in:\n" ++ show (headerDefs env)
+                           ++ " and not in " ++ show (typedefs env))
+  | otherwise = StructType s (concatMap (fieldGroupToType env) (fromJust mfg))
+typSpecToType _ Tunion{} = error "typSpecToType: No support for union."
+typSpecToType _ Tenum{} = error "typSpecToType: No support for enum."
+typSpecToType env (Tnamed i@Id{} _ _) = namedToType env (unId i)
+typSpecToType _ TtypeofExp{} = error "typSpecToType: No support for typeofExp"
+typSpecToType _ TtypeofType{} = error "typSpecToType: No support for typeofType"
+typSpecToType _ Tva_list{} = error "typSpecToType: No support for valist."
+typSpecToType _ t = error $ "typSpecToType: Unknown type " ++ show t
+
+namedToType :: TPEnv -> String -> R.Type
+namedToType _ "uint64_t" = 1 :# (NumType R.Unsigned S64)
+namedToType _ "uint40_t" = 1 :# (NumType R.Unsigned S40)
+namedToType _ "uint32_t" = 1 :# (NumType R.Unsigned S32)
+namedToType _ "uint16_t" = 1 :# (NumType R.Unsigned S16)
+namedToType _ "uint8_t"  = 1 :# (NumType R.Unsigned S8)
+namedToType _ "int64_t"  = 1 :# (NumType R.Signed S64)
+namedToType _ "int40_t"  = 1 :# (NumType R.Signed S40)
+namedToType _ "int32_t"  = 1 :# (NumType R.Signed S32)
+namedToType _ "int16_t"  = 1 :# (NumType R.Signed S16)
+namedToType _ "int8_t"   = 1 :# (NumType R.Signed S8)
+namedToType _ "bool"     = 1 :# BoolType
+namedToType env s | Just t <- findLocalDeclaration env s = t
+namedToType _ s          = error $ "namedToType: Unrecognized type: " ++ s
+
+declToType :: R.Type -> Decl -> R.Type
+declToType t DeclRoot{} = t
+-- Truncate one level of pointers on array types.
+declToType t (Ptr _ DeclRoot{} _) | pointedArray t = t
+declToType t (Ptr _ dcl _)  = declToType (1 :# (Pointer t)) dcl
+declToType _ BlockPtr{} = error "Blocks?"
+declToType t (Array _ (NoArraySize _) _ _) = NativeArray Nothing t
+declToType _ (Array _tqs _sz _dcl _)
+  = error "declToType: No support for sized native arrays yet."
+declToType t (Proto _ params _)
+  = trace ("DEBUG: Proto: " ++ show params) t
+declToType _ (OldProto _dcl _ids _) = error "OldProto"
+declToType _ d = error $ "declToType: Unhandled construct: " ++ show d
+
+pointedArray :: R.Type -> Bool
+pointedArray (ArrayType{})                 = True
+pointedArray (_ :# (Pointer t))            = pointedArray t
+pointedArray _                             = False
+
+fieldGroupToType :: TPEnv -> FieldGroup -> [(String, R.Type)]
+fieldGroupToType env (FieldGroup dss fs _)
+  = zip (map fieldToName fs) $ replicate (length fs) $ declSpecToType env dss
+fieldGroupToType _ g
+  = error $ "fieldGroupToType: Unhandled construct: " ++ show g
+
+signToSign :: Signed -> Signedness
+signToSign Signed   = R.Signed
+signToSign Unsigned = R.Unsigned
+
+fieldToName :: Field -> String
+fieldToName (Field (Just s) _ _ _) = unId s
+
+typeDefToName :: Typedef -> String
+typeDefToName (Typedef s _ _ _) = unId s
+
+unId :: Id -> String
+unId (Id n _) = n
+unId i = error ("unId: Unhandled construct: " ++ show i)
+
+-- Some place holders.
+fakeType :: R.Type
+fakeType = VoidType
+
+fakeName :: String
+fakeName = "fakeName"
+
+-- Feldspar "builtins".
+builtins :: [(String, R.Variable ())]
+builtins =
+  [ ("getLength", Variable (1 :# (NumType R.Unsigned S32)) "getLength")
+  ]
+
+findBuiltinDeclaration :: TPEnv -> String -> Maybe R.Type
+findBuiltinDeclaration env = go (headerDefs env)
+  where go [] _ = Nothing
+        go ((_, _, StructDef n fs):t) s
+         | n == s = Just (StructType n (map toType fs))
+         | otherwise = go t s
+        go e _ = error $ "findBuiltinDeclaration: Non-Struct found: " ++ show e
+        toType (StructMember n t) = (n, t)
+
+findLocalDeclaration :: TPEnv -> String -> Maybe R.Type
+findLocalDeclaration env = go (typedefs env)
+  where go [] _ = Nothing
+        go (tp@(StructType n _):t) s | n == s = Just tp
+                                     | otherwise = go t s
+        go e _ = error $ "findLocalDeclaration: Non-Struct found: " ++ show e
+
+-- | Environments.
+data TPEnv = TPEnv
+    { vars :: [(String, Variable ())]
+    , typedefs :: [R.Type]
+    , headerDefs :: [(String, [R.Type], Entity ())]
+    } deriving Show
+
+emptyEnv :: [(String, [R.Type], Entity ())] -> TPEnv
+emptyEnv = TPEnv [] []
+
+updateEnv :: TPEnv -> [R.Variable ()] -> TPEnv
+updateEnv env ns = env { vars = nt ++ vars env }
+     where nt = map (\v@(Variable _ name) -> (name, v)) ns
+
+updateEnv2 :: TPEnv -> [R.Variable ()] -> R.Type -> TPEnv
+updateEnv2 (TPEnv vs tdefs hdefs) ns t
+ = TPEnv (nt ++ vs) (t:tdefs) hdefs
+     where nt = map (\v@(Variable _ name) -> (name, v)) ns
+
+-- Patch the type information in the environment when we learn more.
+fixupEnv :: TPEnv -> Exp -> R.Type -> TPEnv
+fixupEnv env _ VoidType = env -- No new type information.
+fixupEnv env (UnOp Deref (Var (Id s _) _) _) tp = env { vars = goVar (vars env) }
+  where goVar [] = []
+        goVar ((n, Variable (l :# (Pointer (ArrayType r _))) n'):t)
+         | s == n = (n, Variable (l :# (Pointer (ArrayType r tp))) n'):goVar t
+        goVar (p:t) = p:goVar t
+fixupEnv _ (UnOp Deref e _) _ = error $ "fixupEnv: No support for " ++ show e
+fixupEnv env (Var (Id s _) _) tp = env { vars = goVar (vars env) }
+  where goVar [] = []
+        goVar ((n, Variable (ArrayType r _) n'):t)
+         | s == n = (n, Variable (ArrayType r tp) n'):goVar t
+        goVar (p:t) = p:goVar t
+fixupEnv env (FnCall (Var (Id "at" _) _) [(UnOp Deref (Var (Id s _) _) _), _] _) tp = env { vars = goVar (vars env) }
+  where goVar [] = []
+        goVar ((n, Variable (k :# (Pointer (ArrayType r1 (ArrayType r2 _)))) n'):t)
+         | s == n = let nt = (k :# (Pointer (ArrayType r1 (ArrayType r2 tp))))
+                    in (n, Variable nt n'):goVar t
+        goVar (p:t) = p:goVar t
+fixupEnv env (Member (Var (Id s _) _) (Id name _) _) tp = env { vars = goStruct (vars env) }
+  where goStruct [] = []
+        goStruct ((n, Variable (StructType s' ns) n'):t)
+         | s == n
+         , Just _ <- lookup name ns
+         = (n, Variable (StructType s' ns') n'):goStruct t
+           where ns' = map structFixup ns
+                 structFixup (mem, ArrayType r _)
+                  | mem == name = (mem, ArrayType r tp)
+                 structFixup (mem, _)
+                  | mem == name = (mem, tp)
+                 structFixup e = e
+        goStruct (p:t) = p:goStruct t
+fixupEnv env (Member (FnCall (Var (Id "at" _) _) [Var (Id s _) _, _] _) (Id name _) _) tp = env { vars = goStructAt (vars env) }
+  where goStructAt [] = []
+        goStructAt ((n, Variable (StructType s' ns) n'):t)
+         | s == n
+         , Just _ <- lookup name ns
+         = (n, Variable (StructType s' ns') n'):goStructAt t
+           where ns' = map structFixup ns
+                 structFixup (mem, ArrayType r _)
+                  | mem == name = (mem, ArrayType r tp)
+                 structFixup e = e
+        goStructAt (p:t) = p:goStructAt t
+fixupEnv env _ _ = env
+
+-- Expression builders.
+
+plusOne :: Expression () -> Expression ()
+plusOne e = opToFunctionCall [e, litI32 1] Add
+
+-- Misc helpers
+
+patchHdefs :: [Entity ()] -> [(String, [R.Type], Entity ())]
+patchHdefs [] = []
+patchHdefs (StructDef s _:t)
+  = (s, map snd ts, StructDef s $ map toDef ts):patchHdefs t
+  where [StructType _ ts] = decodeType s
+        toDef (n,t') = StructMember n t'
+patchHdefs (p@(Proc n _ ins _ Nothing):t)
+  = (n, map typeof ins, p):patchHdefs t
+patchHdefs (_:t) = patchHdefs t
+
+mkDef :: R.Type -> [Entity ()]
+mkDef (StructType n fields)
+  = [StructDef n (map (\(n', t) -> StructMember n' t) fields)]
+-- Only interested in struct definitions so discard everything else.
+mkDef _ = []
+
+lookup3 :: String -> [(String, [R.Type], Entity ())] -> [R.Type]
+lookup3 s xs = ts
+  where (_, ts, _) = head $ filter (\(s1,_,_) -> s1 == s) xs
+
+-- Input helpers.
+
+-- FIXME: We have removed the at macro, clean this up.
+
+-- The C parser chokes when parsing a function call that has a type
+-- parameter as first argument. This is precisely what we have with our
+-- "at" macro. We can reconstruct the first argument by other means, so
+-- just change all calls on the form "at(type,p1,p2)" to "at(p1, p2)".
+massageInput:: B.ByteString -> B.ByteString
+massageInput xs' = foldr (\w xs -> dropBitMask xs w) tmp otherWords'
+ where -- Drop first parameter for these functions.
+       prefixWords = map B.pack ["at(", "ivar_put(","ivar_get(", "ivar_get_nontask("]
+       -- Drop some parameters according to mask for these.
+       otherWords = [ ("spawn2(", [True, False, True, False, True])
+                    , ("run2(", [True, False, False])
+                    , ("spawn3(", [True, False, True, False, True
+                                       , False, True])
+                    , ("run3(", [True, False, False, False])
+                    , ("spawn4(", [True, False, True, False, True
+                                       , False, True, False, True])
+                    , ("run4(", [True, False, False, False, False])
+                    , ("spawn5(", [True, False, True, False, True
+                                       , False, True, False, True
+                                       , False, True])
+                    , ("run5(", [True, False, False, False, False,False])]
+       otherWords' = map (\(p1, b) -> (B.pack p1, b)) otherWords
+       tmp = foldr (\w xs -> dropFirstArg xs w) xs' prefixWords
+
+dropFirstArg:: B.ByteString -> B.ByteString -> B.ByteString
+dropFirstArg xs wrd = go (B.breakSubstring wrd xs) []
+  where go (h, t) acc
+          | B.null t = B.append (B.concat $ reverse acc) h
+          | otherwise = go (B.breakSubstring wrd $ fixArg t) (wrd:h:acc)
+        -- Drops the prefix "<word>.*,".
+        fixArg = B.drop 1 . B.dropWhile (/= ',') . B.drop (B.length wrd)
+
+dropBitMask :: B.ByteString -> (B.ByteString, [Bool]) -> B.ByteString
+dropBitMask xs (wrd, bs) = go (B.breakSubstring wrd xs) []
+  where comma = B.pack ","
+        rparen = B.pack ")"
+        go (h, t) acc
+          | B.null t = B.append (B.concat $ reverse acc) h
+          | otherwise = go (B.breakSubstring wrd rest) (rparen:as:wrd:h:acc)
+             where (as, rest) = fixArg (B.span (/= ';') $ B.drop (B.length wrd) t)
+        -- Drops the types.
+        fixArg (as, rest) = (flt $ zip bs (B.split ',' $ B.init as), rest)
+          where flt = B.concat  . intersperse comma . map snd . filter fst

--- a/src/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore.hs
@@ -1,0 +1,926 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -Wall #-}
+-- FIXME: Partial functions, eliminate.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+-- | This module provides functions for translating from the 'UntypedFeld'
+-- representation (\"Feldspar core\") to imperative code (from
+-- "Feldspar.Compiler.Imperative.Representation").
+--
+-- Compilation is done as follows:
+--
+-- * The user calls one of the @fromCoreX@ functions
+--
+-- * @fromCoreX@ calls 'compileProgTop' which recurively deals with top-level
+--   lambdas and let bindings.
+--
+-- * When 'compileProgTop' gets to the body (the first non-lambda, non-let
+--   node), it calls 'compileProg' to generate code that writes the result to
+--   the variable \"out\".
+--
+-- * The body of the code is generated using mutual recursion between
+--   'compileProg' and 'compileExpr'. The former handles constructs whose
+--   result cannot be represented as a non-variable 'Expression' (e.g. a
+--   conditional), and the latter handles all other constructs (e.g. primitive
+--   functions).
+
+module Feldspar.Compiler.Imperative.FromCore
+  ( fromCoreUT
+  , fromCoreExp
+  ) where
+
+import Data.Char (toLower)
+import Data.List (find, isPrefixOf, nub)
+import qualified Data.Map as Map
+import Data.Maybe (fromJust, isJust, mapMaybe)
+
+import Control.Monad.RWS
+
+import Feldspar.Core.Frontend (reifyFeld, Syntactic)
+import Feldspar.Core.UntypedRepresentation
+         ( VarId(..), UntypedFeld, Term(..), Lit(..)
+         , UntypedFeldF(App, LetFun), Fork(..)
+         )
+import qualified Feldspar.Core.UntypedRepresentation as Ut
+import Feldspar.Core.Middleend.FromTyped
+import Feldspar.Range (fullRange, upperBound)
+
+import Feldspar.Compiler.Backend.C.MachineLowering
+import Feldspar.Compiler.Backend.C.Options (Options(..))
+import Feldspar.Compiler.Backend.C.Platforms (c99, extend)
+import Feldspar.Compiler.Imperative.FromCore.Interpretation
+import Feldspar.Compiler.Imperative.Frontend
+import Feldspar.Compiler.Imperative.Representation
+
+--------------------------------------------------------------------------------
+-- * Top-level translation functions
+--------------------------------------------------------------------------------
+
+{-
+
+Fast returns
+------------
+
+Fast returns really means single return value and that value fits in a
+register--thus they are platform dependent. This is why we have to use
+compileType since that can make configuration specific choices about
+data layout.
+
+The user is free to ask for fast returns (by setting 'useNativeReturns' to True),
+but we might not be able to comply.
+
+-}
+
+-- | Get the generated core for an 'UntypedFeld' expression. The result is the
+-- generated code and the next available variable identifier.
+fromCoreUT
+    :: Options
+    -> String       -- ^ Name of the generated function
+    -> UntypedFeld  -- ^ Expression to generate code for
+    -> (Module (), VarId)
+fromCoreUT opt funname uast = (Module defs, maxVar')
+  where
+    maxVar  = succ $ maximum $ map Ut.varNum $ Ut.allVars uast
+    fastRet = useNativeReturns opt && canFastReturn (compileType opt (typeof uast))
+
+    (outParam,maxVar',results) = runRWS (compileProgTop uast) (initEnv opt) maxVar
+
+    decls      = decl results
+    formals    = params results ++ outs
+    post       = epilogue results ++ returns
+    Block ds p = block results
+    outDecl    = Declaration outParam Nothing
+    paramTypes = getTypeDefs $ map (`Declaration` Nothing) formals
+    defs       = nub (def results ++ paramTypes) ++ topProc
+
+    (rtype, outs, ds', returns)
+     | fastRet   = ( typeof outParam, [],  outDecl:ds ++ decls
+                   , [call "return" [ValueParameter $ varToExpr outParam]])
+     | otherwise = ( VoidType, [outParam],         ds ++ decls, [])
+
+    topProc    = [Proc funname False formals rtype $ Just (Block ds' (Sequence mainProg))]
+
+    mainProg
+     | Just _ <- find isTask $ def results
+     = call "taskpool_init" [four,four,four] : p : call "taskpool_shutdown" [] : post
+     | otherwise = p:post
+      where
+        four = ValueParameter $ ConstExpr $ IntConst 4 $ NumType Ut.Unsigned Ut.S32
+
+    isTask Proc{..}   = "task_core" `isPrefixOf` procName
+    isTask _          = False
+
+-- | Get the generated core for a program and an expression that contains the output. The components
+-- of the result are as follows, in order:
+--
+-- * A list of extra entities needed by the program
+-- * A list of declarations needed by the program
+-- * The actual program
+-- * An expression that contains the result
+-- * A list of epilogue programs, for freeing memory, etc.
+fromCoreExp :: MonadState VarId m
+            => Syntactic a
+            => Options
+            -> Map.Map VarId String
+            -> a
+            -> m ([Entity ()], [Declaration ()], Program (), Expression (), [Program ()])
+fromCoreExp opt aliases prog = do
+    let uast = untype (frontendOpts opt) $ reifyFeld prog
+        mkAlias (Ut.Var i t _) = do
+          n <- Map.lookup i aliases
+          return (i, varToExpr $ Variable (compileType opt t) n)
+        as = mapMaybe mkAlias $ Ut.fv uast
+    s <- get
+    let (exp', s', results) = runRWS (compileExpr uast) (CodeEnv as False opt) s
+    put s'
+    unless (null $ params results) $ error "fromCoreExp: unexpected params"
+    let x = getPlatformRenames opt
+        Block ls p = block results
+    return ( renameEnt  opt x <$> def results
+           , renameDecl     x <$> (ls ++ decl results)
+           , renameProg opt x p
+           , renameExp x exp'
+           , renameProg opt x <$> epilogue results
+           )
+
+-- | Generate code for an expression that may have top-level lambdas and let
+-- bindings. The returned variable holds the result of the generated code.
+compileProgTop :: Ut.UntypedFeld -> CodeWriter (Variable ())
+compileProgTop (In (Ut.Lambda (Ut.Var v ta _) body)) = do
+  opt <- asks backendOpts
+  let typ = compileType opt ta
+      (arg,arge) | StructType{} <- typ = (mkPointer typ v, Deref $ varToExpr arg)
+                 | otherwise           = (mkVariable typ v, varToExpr arg)
+  tell $ mempty {params=[arg]}
+  withAlias v arge $
+     compileProgTop body
+compileProgTop (In (Ut.App Ut.Let _ [In (Ut.Literal l), In (Ut.Lambda (Ut.Var v _ _) body)]))
+  | representableType l
+  = do opt <- asks backendOpts
+       let var = mkVariable (typeof c) v -- Note [Precise size information]
+           c   = literalConst opt l
+       tellDef [ValueDef var c]
+       withAlias v (varToExpr var) $
+         compileProgTop body
+compileProgTop a = do
+  opt <- asks backendOpts
+  let outType' = compileType opt (typeof a)
+      fastRet  = useNativeReturns opt && canFastReturn outType'
+      (outType, outLoc)
+       | fastRet   = (outType', varToExpr outParam)
+       | otherwise = (1 :# Pointer outType', Deref $ varToExpr outParam)
+      outParam   = Variable outType "out"
+  compileProg (Just outLoc) a
+  return outParam
+
+
+
+--------------------------------------------------------------------------------
+-- * compileType
+--------------------------------------------------------------------------------
+
+-- | Compile a type representation. The conversion is platform-dependent, which
+-- is why the function takes and 'Options' argument.
+compileType :: Options -> Ut.Type -> Type
+compileType _   (n Ut.:# Ut.BoolType)      = n :# BoolType
+compileType _   (n Ut.:# Ut.BitType)       = n :# BitType
+compileType _   (n Ut.:# Ut.IntType s sz)  = n :# NumType s sz
+compileType _   (n Ut.:# Ut.FloatType)     = n :# FloatType
+compileType _   (n Ut.:# Ut.DoubleType)    = n :# DoubleType
+compileType opt (n Ut.:# Ut.ComplexType t) = n :# ComplexType (compileType opt t)
+compileType _   (Ut.TupType [])        = VoidType
+compileType opt (Ut.TupType ts)        = mkStructType
+    [("member" ++ show n, compileType opt t) | (n,t) <- zip [1 :: Int ..] ts]
+compileType opt (Ut.MutType a)         = compileType opt a
+compileType opt (Ut.RefType a)         = compileType opt a
+compileType opt (Ut.ArrayType rs a)
+ | useNativeArrays opt = NativeArray (Just $ upperBound rs) $ compileType opt a
+ | otherwise           = mkAwLType rs $ compileType opt a
+compileType opt (Ut.MArrType rs a)
+ | useNativeArrays opt = NativeArray (Just $ upperBound rs) $ compileType opt a
+ | otherwise           = mkAwLType rs $ compileType opt a
+compileType opt (Ut.ParType a)         = compileType opt a
+compileType opt (Ut.ElementsType a)
+ | useNativeArrays opt = NativeArray Nothing $ compileType opt a
+ | otherwise           = mkAwLType fullRange $ compileType opt a
+compileType opt (Ut.IVarType a)        = IVarType $ compileType opt a
+compileType opt (Ut.FunType _ b)       = compileType opt b
+compileType opt (Ut.FValType a)        = IVarType $ compileType opt a
+
+--------------------------------------------------------------------------------
+-- * compileProg
+--------------------------------------------------------------------------------
+
+-- 'compileProg' should handle constructs whose result cannot be represented as
+-- a non-variable 'Expression' (e.g. a conditional), and delegate all other
+-- constructs to 'compileExpr'. Delegation is done by calling 'compileExprLoc'.
+
+-- | Compile an expression and put the result in the given location
+compileProg :: Location -> Ut.UntypedFeld -> CodeWriter ()
+-- Array
+compileProg (Just loc) (In (App Ut.Parallel _ [len, In (Ut.Lambda (Ut.Var v ta _) ixf)])) = do
+   opts <- asks backendOpts
+   let ix = mkVar (compileType opts ta) v
+   len' <- mkLength len ta
+   (ptyp, b) <- case ixf of
+          In (App (Ut.Call Loop n) _ vs) -> do
+            vs' <- mapM compileExpr vs
+            let args  = map (ValueParameter . varToExpr) $ nub $ map varExpr vs' ++ fv loc
+            return (TaskParallel, toBlock $ ProcedureCall n args)
+          _                              -> do
+            b' <- confiscateBlock $ compileProg (Just $ mkArrayElem loc [ix]) ixf
+            return (Parallel, snd b')
+   tellProg [initArray (Just loc) len']
+   tellProg [for ptyp (varExpr ix) (litI32 0) len' (litI32 1) b]
+compileProg loc (In (App Ut.Sequential _ [len, init', In (Ut.Lambda (Ut.Var v tix _) ixf1)]))
+   | In (Ut.Lambda (Ut.Var s tst _) l) <- ixf1
+   , (bs, In (Ut.App Ut.Tup _ [In (Ut.Variable t1), In (Ut.Variable t2)])) <- collectLetBinders l
+   , not $ null bs
+   , (e, step) <- last bs
+   , t1 == e
+   , t2 == e
+   = do
+        opts <- asks backendOpts
+        blocks <- mapM (confiscateBlock . compileBind) (init bs)
+        let (dss, lets) = unzip $ map (\(_, Block ds (Sequence body)) -> (ds, body)) blocks
+        let ix = mkVar (compileType opts tix) v
+        len' <- mkLength len tix
+        st1 <- freshVar opts "st" tst
+        let st = mkPointer (compileType opts tst) s
+            st_val = Deref $ varToExpr st
+        declareAlias st
+        (_, Block ds (Sequence body)) <- confiscateBlock $ withAlias s st_val $ compileProg (mkArrayElem <$> loc <*> pure [ix]) step
+        withAlias s st_val $ compileProg (Just st1) init'
+        tellProg [ Assign (varToExpr st) (AddrOf st1)
+                 , initArray loc len']
+        tellProg [toProg $ Block (concat dss ++ ds) $
+                  for Sequential (varExpr ix) (litI32 0) len' (litI32 1) $
+                               toBlock $ Sequence (concat lets ++ body ++ maybe [] (\arr -> [Assign (varToExpr st) $ AddrOf (mkArrayElem arr [ix])]) loc)]
+compileProg loc (In (App Ut.Sequential _ [len, st, In (Ut.Lambda (Ut.Var v t _) (In (Ut.Lambda (Ut.Var s _ _) step)))]))
+  = do
+       opts <- asks backendOpts
+       let tr' = typeof step
+       let ix = mkVar (compileType opts t) v
+       len' <- mkLength len t
+       tmp  <- freshVar opts "seq" tr'
+       (_, Block ds (Sequence body)) <- confiscateBlock $ withAlias s (StructField tmp "member2") $ compileProg (Just tmp) step
+       tellProg [initArray loc len']
+       compileProg (Just $ StructField tmp "member2") st
+       tellProg [toProg $ Block ds $
+                 for Sequential (varExpr ix) (litI32 0) len' (litI32 1) $ toBlock $
+                   Sequence $ body ++
+                     [copyProg (mkArrayElem <$> loc <*> pure [ix]) [StructField tmp "member1"]
+                     ]]
+compileProg loc (In (App Ut.Append _ [a, b])) = do
+   a' <- compileExpr a
+   b' <- compileExpr b
+   tellProg [copyProg loc [a', b']]
+compileProg loc (In (App Ut.SetIx _ [arr, i, a])) = do
+   compileProg loc arr
+   i' <- compileExpr i
+   compileProg (mkArrayElem <$> loc <*> pure [i']) a
+compileProg loc (In (App Ut.GetIx _ [arr, i])) = do
+   a' <- compileExpr arr
+   i' <- compileExpr i
+   let el = mkArrayElem a' [i']
+   if isAwLType $ typeof el
+      then shallowAssign loc el
+      else assign loc el
+compileProg loc (In (App Ut.SetLength _ [len, arr])) = do
+   len' <- compileExpr len
+   compileProg loc arr
+   tellProg [initArray loc len']
+-- Binding
+compileProg _ e@(In Ut.Lambda{})
+  = error ("Can only compile top-level lambda: " ++ show e)
+compileProg loc (In (Ut.App Ut.Let _ [a, In (Ut.Lambda (Ut.Var v ta _) body)])) = do
+   e <- compileLet a ta v
+   withAlias v e $ compileProg loc body
+-- Bits
+-- Complex
+-- Condition
+compileProg loc (In (App Ut.Condition _ [cond, tHEN, eLSE])) =
+   mkBranch loc cond tHEN $ Just eLSE
+compileProg loc (In (App Ut.ConditionM _ [cond, tHEN, eLSE])) =
+   mkBranch loc cond tHEN $ Just eLSE
+-- Conversion
+-- Elements
+compileProg loc (In (App Ut.EMaterialize _ [len, arr])) = do
+   len' <- mkLength len (Ut.typeof len)
+   tellProg [initArray loc len']
+   compileProg loc arr
+compileProg (Just loc) (In (App Ut.EWrite _ [ix, e])) = do
+   dst <- compileExpr ix
+   compileProg (Just $ mkArrayElem loc [dst]) e
+compileProg _ (In (App Ut.ESkip _ _)) = return ()
+compileProg loc (In (App Ut.EPar _ [p1, p2])) = do
+   (_, Block ds1 b1) <- confiscateBlock $ compileProg loc p1
+   (_, Block ds2 b2) <- confiscateBlock $ compileProg loc p2
+   tellProg [toProg $ Block (ds1 ++ ds2) (Sequence [b1,b2])]
+compileProg (Just loc) (In (App Ut.EparFor _ [len, In (Ut.Lambda (Ut.Var v ta _) ixf)])) = do
+   opts <- asks backendOpts
+   let ix = mkVar (compileType opts ta) v
+   len' <- mkLength len ta
+   (ptyp, b) <- case ixf of
+          In (App (Ut.Call Loop n) _ vs) -> do
+            vs' <- mapM compileExpr vs
+            let args  = map (ValueParameter . varToExpr) $ nub $ map varExpr vs' ++ fv loc
+            return (TaskParallel, toBlock $ ProcedureCall n args)
+          _                              -> do
+            b' <- confiscateBlock $ compileProg (Just loc) ixf
+            return (Parallel, snd b')
+   tellProg [for ptyp (varExpr ix) (litI32 0) len' (litI32 1) b]
+-- Error
+compileProg _ (In (App Ut.Undefined _ _)) = return ()
+compileProg loc (In (App (Ut.Assert msg) _ [cond, a])) = do
+   compileAssert cond msg
+   compileProg loc a
+-- Future
+compileProg _ e@(In (App Ut.MkFuture _ _))
+  = error ("Unexpected MkFuture:" ++ show e)
+compileProg (Just loc) (In (LetFun f e)) = do
+   compileFunction loc f
+   compileProg (Just loc) e
+compileProg loc (In (App Ut.Await _ [a])) = do
+   env <- ask
+   fut <- compileExprVar a
+   tellProg [iVarGet (inTask env) l fut | Just l <- [loc]]
+-- Literal
+compileProg loc (In (Ut.Literal a)) =
+   case loc of
+     Just l -> literalLoc l a
+     Nothing -> return ()
+-- Logic
+-- Loop
+compileProg (Just loc) (In (App Ut.ForLoop _ [len, init', In (Ut.Lambda (Ut.Var ix ta _) (In (Ut.Lambda (Ut.Var st _ _) ixf)))]))
+  = do
+      opts <- asks backendOpts
+      let ix' = mkVar (compileType opts ta) ix
+      len' <- mkLength len ta
+      (lstate, stvar) <- mkDoubleBufferState loc st
+      compileProg (Just lstate) init'
+      (_, Block ds body) <- withAlias st lstate $ confiscateBlock
+                          $ compileProg (Just stvar) ixf
+                          >> shallowCopyWithRefSwap lstate stvar
+      tellProg [toProg $ Block ds (for Sequential (varExpr ix') (litI32 0) len' (litI32 1) (toBlock body))]
+      shallowAssign (Just loc) lstate
+compileProg (Just loc) (In (App Ut.WhileLoop _ [init', In (Ut.Lambda (Ut.Var cv _ _) cond), In (Ut.Lambda (Ut.Var bv _ _) body)])) = do
+    opts <- asks backendOpts
+    let condv  = mkVariable (compileType opts (typeof cond)) cv
+        condvE = varToExpr condv
+    (lstate,stvar) <- mkDoubleBufferState loc bv
+    compileProg (Just lstate) init'
+    (_, cond') <- confiscateBlock $ withAlias cv lstate $ compileProg (Just condvE) cond
+    (_, body') <- withAlias bv lstate $ confiscateBlock $ compileProg (Just stvar) body >> shallowCopyWithRefSwap lstate stvar
+    declare condv
+    tellProg [while cond' condvE body']
+    shallowAssign (Just loc) lstate
+-- LoopM
+compileProg loc (In (App Ut.While _ [cond,step])) = do
+   opts <- asks backendOpts
+   condv <- freshVar opts "cond" (typeof cond)
+   (_, cond') <- confiscateBlock $ compileProg (Just condv) cond
+   (_, step') <- confiscateBlock $ compileProg loc step
+   tellProg [while cond' condv step']
+compileProg loc (In (App Ut.For _ [len, In (Ut.Lambda (Ut.Var v ta _) ixf)])) = do
+   opts <- asks backendOpts
+   let ix = mkVar (compileType opts ta) v
+   len' <- mkLength len ta
+   (_, Block ds body) <- confiscateBlock $ compileProg loc ixf
+   tellProg [toProg $ Block ds (for Sequential (varExpr ix) (litI32 0) len' (litI32 1) (toBlock body))]
+-- Mutable
+compileProg loc (In (App Ut.Run _ [ma])) = compileProg loc ma
+compileProg loc (In (App Ut.Return t [a]))
+  | Ut.MutType (Ut.TupType []) <- t = return ()
+  | Ut.ParType (Ut.TupType []) <- t = return ()
+  | otherwise = compileProg loc a
+compileProg loc (In (App Ut.Bind _ [ma, In (Ut.Lambda (Ut.Var v ta _) body)]))
+  | (In (App Ut.ParNew _ _)) <- ma = do
+   opts <- asks backendOpts
+   let var = mkVariable (compileType opts ta) v
+   declare var
+   tellProg [iVarInit $ AddrOf $ varToExpr var]
+   compileProg loc body
+  | otherwise = do
+   opts <- asks backendOpts
+   let var = mkVariable (compileType opts ta) v
+   declare var
+   compileProg (Just (varToExpr var)) ma
+   compileProg loc body
+compileProg loc (In (App Ut.Then _ [ma, mb])) = do
+   compileProg Nothing ma
+   compileProg loc mb
+compileProg loc (In (App Ut.When _ [c, action])) =
+   mkBranch loc c action Nothing
+-- MutableArray
+compileProg loc (In (App Ut.NewArr _ [len, a])) = do
+   nId <- freshId
+   let var = mkNamedVar "i" (1 :# NumType Ut.Unsigned Ut.S32) nId
+       ix  = varToExpr var
+   a' <- compileExpr a
+   l  <- compileExpr len
+   tellProg [initArray loc l]
+   tellProg [for Sequential var (litI32 0) l (litI32 1) $ toBlock (Sequence [copyProg (mkArrayElem <$> loc <*> pure [ix]) [a']])]
+compileProg loc (In (App Ut.NewArr_ _ [len])) = do
+   l <- compileExpr len
+   tellProg [initArray loc l]
+compileProg loc (In (App Ut.GetArr _ [arr, i])) = do
+   arr' <- compileExpr arr
+   i'   <- compileExpr i
+   assign loc (mkArrayElem arr' [i'])
+compileProg _ (In (App Ut.SetArr _ [arr, i, a])) = do
+   arr' <- compileExpr arr
+   i'   <- compileExpr i
+   a'   <- compileExpr a
+   assign (Just $ mkArrayElem arr' [i']) a'
+-- MutableReference
+compileProg loc (In (App Ut.NewRef _ [a])) = compileProg loc a
+compileProg loc (In (App Ut.GetRef _ [r])) = compileProg loc r
+compileProg _ (In (App Ut.SetRef _ [r, a])) = do
+   var  <- compileExpr r
+   compileProg (Just var) a
+compileProg _ (In (App Ut.ModRef _ [r, In (Ut.Lambda (Ut.Var v _ _) body)])) = do
+   var <- compileExpr r
+   withAlias v var $ compileProg (Just var) body
+       -- Since the modifier function is pure it is safe to alias
+       -- v with var here
+-- MutableToPure
+compileProg (Just loc) (In (App Ut.RunMutableArray _ [marr]))
+ | (In (App Ut.Bind _ [In (App Ut.NewArr_ _ [l]), In (Ut.Lambda (Ut.Var v _ _) body)])) <- marr
+ , (In (App Ut.Return _ [In (Ut.Variable (Ut.Var r _ _))])) <- chaseBind body
+ , v == r
+ = do
+     len <- compileExpr l
+     tellProg [initArray (Just loc) len]
+     withAlias v loc $ compileProg (Just loc) body
+compileProg loc (In (App Ut.RunMutableArray _ [marr])) = compileProg loc marr
+compileProg loc (In (App Ut.WithArray _ [marr@(In Ut.Variable{}), In (Ut.Lambda (Ut.Var v _ _) body)])) = do
+    e <- compileExpr marr
+    withAlias v e $ do
+      b <- compileExpr body
+      tellProg [copyProg loc [b]]
+compileProg loc (In (App Ut.WithArray _ [marr, In (Ut.Lambda (Ut.Var v ta _) body)])) = do
+    opts <- asks backendOpts
+    let var = mkVariable (compileType opts ta) v
+    declare var
+    compileProg (Just $ varToExpr var) marr
+    e <- compileExpr body
+    tellProg [copyProg loc [e]]
+-- Noinline
+compileProg (Just _) (In (App Ut.NoInline _ [e]))
+  = error ("Unexpected NoInline:" ++ show e)
+-- Par
+compileProg loc (In (App Ut.ParRun _ [p])) = compileProg loc p
+compileProg _ (In (App Ut.ParNew _ _)) = return ()
+compileProg loc (In (App Ut.ParGet _ [r])) = do
+    env <- ask
+    iv <- compileExpr r
+    tellProg [iVarGet (inTask env) l iv | Just l <- [loc]]
+compileProg _ (In (App Ut.ParPut _ [r, a])) = do
+    iv  <- compileExpr r
+    val <- compileExpr a
+    i   <- freshId
+    let var  = mkNamedVar "msg" (typeof val) i
+        varE = varToExpr var
+    declare var
+    assign (Just varE) val
+    tellProg [iVarPut iv varE]
+compileProg _ (In (App Ut.ParFork _ [e]))
+  = error ("Unexpected ParFork:" ++ show e)
+compileProg _ (In (App Ut.ParYield _ _)) = return ()
+-- SizeProp
+compileProg loc (In (App Ut.PropSize _ [e])) = compileProg loc e
+-- SourceInfo
+compileProg loc (In (App (Ut.SourceInfo info) _ [a])) = do
+    tellProg [Comment True info]
+    compileProg loc a
+-- Switch
+compileProg loc (In (App Ut.Switch _ [tree@(In (App Ut.Condition _ [In (App Ut.Equal _ [_, s]), _, _]))])) = do
+    scrutinee <- compileExpr s
+    alts      <- chaseTree loc s tree
+    tellProg [Switch{..}]
+compileProg loc (In (App Ut.Switch _ [tree])) = compileProg loc tree
+-- Tuple
+compileProg loc (In (App Ut.Tup _ ms)) = sequence_
+    [ compileProg (StructField <$> loc <*> pure ("member" ++ show n)) m
+      | (n,m) <- zip [1 :: Int ..] ms
+    ]
+-- Special case foreign imports since they can be of void type and just have effects.
+compileProg loc@(Just _) (In (App p@Ut.ForeignImport{} t es)) = do
+    opts <- asks backendOpts
+    es' <- mapM compileExpr es
+    shallowAssign loc $ fun (compileType opts t) (compileOp p) es'
+compileProg Nothing (In (App p@Ut.ForeignImport{} _ es)) = do
+    es' <- mapM compileExpr es
+    tellProg [ProcedureCall (compileOp p) $ map ValueParameter es']
+-- Common nodes
+compileProg (Just loc) (In (App (Ut.Call f name) _ es)) = do
+  es' <- mapM compileExpr es
+  let args = nub $ map exprToVar es' ++ fv loc
+  tellProg [iVarInitCond f (AddrOf loc)]
+  tellProg [spawn f name args]
+compileProg loc e = compileExprLoc loc e
+
+--------------------------------------------------------------------------------
+-- * compileExpr
+--------------------------------------------------------------------------------
+
+-- 'compileExpr' should handle constructs whose can be represented as a
+-- non-variable 'Expression' (e.g. a conditional), and delegate all other
+-- constructs to 'compileProg'. Delegation is done by calling
+-- 'compileProgFresh'.
+
+-- | Compile an expression
+compileExpr :: Ut.UntypedFeld -> CodeWriter (Expression ())
+-- Array
+compileExpr (In (App Ut.GetLength _ [a])) = do
+   aExpr <- compileExpr a
+   return $ arrayLength aExpr
+compileExpr (In (App Ut.GetIx _ [arr, i])) = do
+   a' <- compileExpr arr
+   i' <- compileExpr i
+   return $ mkArrayElem a' [i']
+-- Bits
+compileExpr (In (App Ut.Bit t [arr])) = do
+   opts <- asks backendOpts
+   a' <- compileExpr arr
+   let t' = compileType opts t
+   return $ binop t' "<<" (litI t' 1) a'
+-- Binding
+compileExpr (In (Ut.Variable (Ut.Var v t _))) = do
+        env <- ask
+        case lookup v (aliases env) of
+          Nothing -> return $ mkVar (compileType (backendOpts env) t) v
+          Just e  -> return e
+compileExpr (In (Ut.App Ut.Let _ [a, In (Ut.Lambda (Ut.Var v ta _) body)])) = do
+    e <- compileLet a ta v
+    withAlias v e $ compileExpr body
+-- Bits
+-- Condition
+-- Conversion
+compileExpr (In (App Ut.F2I t es)) = do
+    opts <- asks backendOpts
+    es' <- mapM compileExpr es
+    let f' = fun (1 :# FloatType) "truncf" es'
+    return $ Cast (compileType opts t) f'
+compileExpr (In (App Ut.I2N t1 [e])) = do
+    opts <- asks backendOpts
+    let t' = compileType opts t1
+    case t' of
+      1 :# (ComplexType t) -> do
+        e' <- compileExpr e
+        let args = [Cast t e', litF 0]
+        return $ fun t' (extend c99 "complex" t) args
+      _ -> do
+        e' <- compileExpr e
+        return $ Cast t' e'
+compileExpr (In (App Ut.B2I t [e])) = do
+    opts <- asks backendOpts
+    e' <- compileExpr e
+    return $ Cast (compileType opts t) e'
+compileExpr (In (App Ut.Round t es)) = do
+    opts <- asks backendOpts
+    es' <- mapM compileExpr es
+    let f' = fun (1 :# FloatType) "roundf" es'
+    return $ Cast (compileType opts t) f'
+compileExpr (In (App Ut.Ceiling t es)) = do
+    opts <- asks backendOpts
+    es' <- mapM compileExpr es
+    let f' = fun (1 :# FloatType) "ceilf" es'
+    return $ Cast (compileType opts t) f'
+compileExpr (In (App Ut.Floor t es)) = do
+    opts <- asks backendOpts
+    es' <- mapM compileExpr es
+    let f' = fun (1 :# FloatType) "floorf" es'
+    return $ Cast (compileType opts t) f'
+-- Error
+compileExpr (In (App (Ut.Assert msg) _ [cond, a])) = do
+    compileAssert cond msg
+    compileExpr a
+-- Eq
+-- FFI
+-- Floating
+compileExpr (In (App Ut.Pi _ [])) = error "No pi ready"
+-- Fractional
+-- Future
+-- Literal
+compileExpr (In (Ut.Literal l)) = literal l
+-- Loop
+-- Logic
+-- Mutable
+compileExpr (In (App Ut.Run _ [ma])) = compileExpr ma
+-- MutableArray
+compileExpr (In (App Ut.ArrLength _ [arr])) = do
+    a' <- compileExpr arr
+    return $ arrayLength a'
+-- MutableReference
+compileExpr (In (App Ut.GetRef _ [r])) = compileExpr r
+-- NoInline
+-- Num
+-- Ord
+-- SizeProp
+compileExpr (In (App Ut.PropSize _ [e])) = compileExpr e
+-- SourceInfo
+compileExpr (In (App (Ut.SourceInfo info) _ [a])) = do
+    tellProg [Comment True info]
+    compileExpr a
+-- Tuple
+compileExpr (In (App (Ut.Sel n) _ [tup])) = do
+    tupExpr <- compileExpr tup
+    return $ StructField tupExpr ("member" ++ show (n + 1))
+compileExpr e@(In (App p _ _))
+ | p `elem` [ Ut.Parallel, Ut.SetLength, Ut.Sequential, Ut.Condition, Ut.ConditionM
+            , Ut.MkFuture, Ut.Await, Ut.Bind, Ut.Then, Ut.Return, Ut.While, Ut.For, Ut.SetArr, Ut.EMaterialize
+            , Ut.WhileLoop, Ut.ForLoop, Ut.RunMutableArray, Ut.NoInline
+            , Ut.Switch, Ut.WithArray, Ut.Tup]
+ = compileProgFresh e
+compileExpr (In (App p t es)) = do
+    opts <- asks backendOpts
+    es' <- mapM compileExpr es
+    return $ fun (compileType opts t) (compileOp p) es'
+compileExpr e = compileProgFresh e
+
+
+
+--------------------------------------------------------------------------------
+-- * Compilation helper functions
+--------------------------------------------------------------------------------
+
+{-
+
+Precise size information
+------------------------
+
+Tight size bounds for a given literal is easy to compute. Precise
+bounds are particularly important for array literals since they are
+often copied in the deepCopy function near the CodeGen in the
+backend. Deepcopy will appear to hang when generating the copy code
+for insanely large array literals, so don't do that.
+
+-}
+
+-- | Call 'compileExpr' and assign the result to the given location.
+compileExprLoc :: Location  -> Ut.UntypedFeld  -> CodeWriter ()
+compileExprLoc loc e = do
+    expr <- compileExpr e
+    assign loc expr
+
+-- | Generate and declare a fresh variable expression
+freshVar :: Options -> String -> Ut.Type -> CodeWriter (Expression ())
+freshVar opt base t = do
+  v <- mkNamedVar base (compileType opt t) <$> freshId
+  declare v
+  return $ varToExpr v
+
+-- | Compiles code into a fresh variable.
+compileProgFresh :: Ut.UntypedFeld -> CodeWriter (Expression ())
+compileProgFresh e = do
+    opts <- asks backendOpts
+    loc <- freshVar opts "e" (typeof e)
+    compileProg (Just loc) e
+    return loc
+
+-- | Compile an expression and make sure that the result is stored in a variable
+compileExprVar :: Ut.UntypedFeld -> CodeWriter (Expression ())
+compileExprVar e = do
+    e' <- compileExpr e
+    case e' of
+        _ | isNearlyVar e' -> return e'
+          | otherwise -> do
+              varId <- freshId
+              let loc  = mkNamedVar "e" (typeof e') varId
+                  locE = varToExpr loc
+              declare loc
+              assign (Just locE) e'
+              return locE
+  where isNearlyVar VarExpr{}   = True
+        isNearlyVar (Deref e')  = isNearlyVar e'
+        isNearlyVar (AddrOf e') = isNearlyVar e'
+        isNearlyVar _           = False
+
+-- | Compile a function bound by a LetFun.
+compileFunction :: Expression () -> (String, Fork, Ut.UntypedFeld) -> CodeWriter ()
+compileFunction loc (coreName, kind, e) | (bs, e') <- collectBinders e = do
+  es' <- mapM (compileExpr . In . Ut.Variable) bs
+  let args = nub $ map exprToVar es' ++ fv loc
+  -- Task core:
+  (_, (Block ds bl, decls, _)) <- confiscateBigBlock $
+    case kind of
+      Future -> do
+        p' <- local (\env -> env {inTask = True }) $ compileExprVar e'
+        tellProg [iVarPut loc p']
+      Par -> local (\env -> env {inTask = True }) $ compileProg (Just loc) e'
+      Loop | (_:_) <- es'
+           , Ut.ElementsType{} <- typeof e' -> compileProg (Just loc) e'
+           | (ix:_) <- es' -> compileProg (Just $ mkArrayElem loc [ix]) e'
+      None -> compileProg (Just loc) e'
+  tellDef [Proc coreName (kind == Loop) args VoidType $ Just $ Block (decls ++ ds) bl]
+  -- Task:
+  let taskName = "task" ++ drop 9 coreName
+      runTask  = Just $ toBlock $ run coreName args
+      formals  = [mkNamedRef "params" VoidType (-1)]
+  case kind of
+   _ | kind `elem` [None, Loop] -> return ()
+   _    -> tellDef [Proc taskName False formals VoidType runTask]
+
+-- | Check if an expression is a variable or a literal
+isVariableOrLiteral :: Ut.UntypedFeld -> Bool
+isVariableOrLiteral (Ut.In Ut.Literal{})  = True
+isVariableOrLiteral (Ut.In Ut.Variable{}) = True
+isVariableOrLiteral _                     = False
+
+-- | Create a variable of the right type for storing a length.
+mkLength :: Ut.UntypedFeld -> Ut.Type -> CodeWriter (Expression ())
+mkLength a t
+  | isVariableOrLiteral a = compileExpr a
+  | otherwise             = do
+      opts <- asks backendOpts
+      lenvar <- freshVar opts "len" t
+      compileProg (Just lenvar) a
+      return lenvar
+
+mkBranch :: Location -> Ut.UntypedFeld -> Ut.UntypedFeld -> Maybe Ut.UntypedFeld -> CodeWriter ()
+mkBranch loc c th el = do
+    ce <- compileExpr c
+    (_, tb) <- confiscateBlock $ compileProg loc th
+    (_, eb) <- if isJust el
+                  then confiscateBlock $ compileProg loc (fromJust el)
+                  else return (undefined, toBlock Empty)
+    tellProg [Switch ce [(Pat (litB True), tb), (Pat (litB False), eb)]]
+
+compileLet :: Ut.UntypedFeld -> Ut.Type -> VarId -> CodeWriter (Expression ())
+compileLet a ta v = do
+   opts <- asks backendOpts
+   let var  = mkVariable (compileType opts ta) v
+       varE = varToExpr var
+   declare var
+   compileProg (Just varE) a
+   return varE
+
+compileAssert :: Ut.UntypedFeld -> String -> CodeWriter ()
+compileAssert cond msg = do
+    condExpr <- compileExpr cond
+    tellProg [call "assert" [ValueParameter condExpr]]
+    unless (null msg) $ tellProg [Comment False $ "{" ++ msg ++ "}"]
+
+literal :: Ut.Lit -> CodeWriter (Expression ())
+literal lit = do
+    opts <- asks backendOpts
+    let litConst = return $ ConstExpr $ literalConst opts lit
+    case lit of
+      LTup []     -> litConst
+      LBool{}     -> litConst
+      LInt{}      -> litConst
+      LFloat{}    -> litConst
+      LDouble{}   -> litConst
+      LComplex{}  -> litConst
+      LArray{}    -> litConst
+      _           -> do loc <- freshVar opts "x" (typeof lit)
+                        literalLoc loc lit
+                        return loc
+
+-- | Returns true if we can represent the literal in Program.
+representableType :: Ut.Lit -> Bool
+representableType l
+  | Ut.ArrayType{} <- t = True
+  -- Simple types.
+  | _ Ut.:# Ut.IntType{} <- t     = True
+  | _ Ut.:# Ut.ComplexType{} <- t = True
+  | _ Ut.:# st <- t
+  = st `elem` [Ut.DoubleType, Ut.FloatType, Ut.BoolType]
+  | otherwise
+  = t == Ut.TupType []
+      where t = typeof l
+
+literalConst :: Options -> Ut.Lit -> Constant ()
+literalConst _   (LTup [])      = IntConst 0 (NumType Ut.Unsigned Ut.S32)
+literalConst _   (LBool a)      = BoolConst a
+literalConst _   (LInt s sz a)  = IntConst (toInteger a) (NumType s sz)
+literalConst _   (LFloat a)     = FloatConst a
+literalConst _   (LDouble a)    = DoubleConst a
+literalConst opt (LArray t es)  = ArrayConst (map (literalConst opt) es) $ compileType opt t
+literalConst opt (LComplex r i) = ComplexConst (literalConst opt r) (literalConst opt i)
+
+literalLoc :: Expression () -> Ut.Lit -> CodeWriter ()
+literalLoc loc arr@Ut.LArray{} = do
+    opts <- asks backendOpts
+    tellProg [copyProg (Just loc) [ConstExpr $ literalConst opts arr]]
+literalLoc loc (Ut.LTup ls) = sequence_
+    [literalLoc (StructField loc ("member" ++ show n)) l | (n,l) <- zip [1 :: Int ..] ls]
+literalLoc loc t =
+    do rhs <- literal t
+       assign (Just loc) rhs
+
+chaseTree :: Location -> Ut.UntypedFeld -> Ut.UntypedFeld -> CodeWriter [(Pattern (), Block ())]
+chaseTree loc _s (In (App Ut.Condition _ [In (App Ut.Equal _ [c, _]), t, f]))
+    -- , alphaEq s a -- TODO check that the scrutinees are equal
+    = do
+         e <- compileExpr c
+         (_,body) <- confiscateBlock $ compileProg loc t
+         cases <- chaseTree loc _s f
+         return $ (Pat e, body) : cases
+
+chaseTree loc _ a = do
+    (_,body) <- confiscateBlock $ compileProg loc a
+    return [(PatDefault, body)]
+
+-- | Chase down the right-spine of `Bind` and `Then` constructs and return
+-- the last term
+chaseBind :: Ut.UntypedFeld -> Ut.UntypedFeld
+chaseBind (In (App Ut.Let  _ [_, In (Ut.Lambda _  body)])) = chaseBind body
+chaseBind (In (App Ut.Bind _ [_, In (Ut.Lambda _  body)])) = chaseBind body
+chaseBind (In (App Ut.Then _ [_, body]))                   = chaseBind body
+chaseBind a                                                = a
+
+{- NOTES:
+
+The trick of doing a copy at the end, i.e. `tellProg [copyProg loc
+e]`, when compiling WithArray is important. It allows us to safely
+return the pure array that is passed in as input. This is nice because
+it allows us to implement `freezeArray` in terms of `withArray`.
+In most cases I expect `withArray` to return a scalar as its final
+result and then the copyProg is harmless.
+-}
+
+compileBind :: (Ut.Var, Ut.UntypedFeld) -> CodeWriter ()
+compileBind (Ut.Var v t _, e) = do
+   opts <- asks backendOpts
+   let var = mkVariable (compileType opts t) v
+   declare var
+   compileProg (Just $ varToExpr var) e
+
+-- | Translates Op names to strings.
+compileOp :: Ut.Op -> String
+-- Bits
+compileOp Ut.BAnd              = "&"
+compileOp Ut.BOr               = "|"
+compileOp Ut.BXor              = "^"
+-- Complex
+compileOp Ut.RealPart          = "creal"
+compileOp Ut.ImagPart          = "cimag"
+compileOp Ut.Sign              = "signum"
+  -- Eq
+compileOp Ut.Equal             = "=="
+compileOp Ut.NotEqual          = "/="
+  -- FFI
+compileOp (Ut.ForeignImport s) = s
+  -- Floating
+compileOp Ut.Exp               = "exp"
+  -- Fractional
+compileOp Ut.DivFrac           = "/"
+  -- Integral
+compileOp Ut.IExp              = "pow"
+  -- Logic
+compileOp Ut.And               = "&&"
+compileOp Ut.Or                = "||"
+  -- Num
+compileOp Ut.Add               = "+"
+compileOp Ut.Sub               = "-"
+compileOp Ut.Mul               = "*"
+  -- Ord
+compileOp Ut.LTH               = "<"
+compileOp Ut.GTH               = ">"
+compileOp Ut.LTE               = "<="
+compileOp Ut.GTE               = ">="
+compileOp p                    = toLower h:t
+    where (h:t) = show p
+
+-- FIXME: Remove this definition of collectLetBinders.
+collectLetBinders :: UntypedFeld -> ([(Ut.Var, UntypedFeld)], UntypedFeld)
+collectLetBinders = go []
+  where go acc (In (App Ut.Let _ [e, In (Ut.Lambda v b)])) = go ((v, e):acc) b
+        go acc e                                           = (reverse acc, e)
+
+-- FIXME: Remove this definition of collectLetBinders.
+collectBinders :: UntypedFeld -> ([Ut.Var], UntypedFeld)
+collectBinders = go []
+  where go acc (In (Ut.Lambda v e)) = go (v:acc) e
+        go acc e                    = (reverse acc, e)

--- a/src/Feldspar/Compiler/Imperative/FromCore/Interpretation.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore/Interpretation.hs
@@ -1,0 +1,316 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# OPTIONS_GHC -Wall #-}
+
+module Feldspar.Compiler.Imperative.FromCore.Interpretation where
+
+import Control.Arrow hiding (arr)
+import Control.Monad.RWS hiding ((<>))
+
+import Data.List (intercalate, nub)
+import Data.Semigroup (Semigroup(..))
+
+import Feldspar.Core.UntypedRepresentation (VarId (..))
+
+import Feldspar.Compiler.Imperative.Frontend
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Compiler.Backend.C.Options (Options(..), Platform(..))
+
+-- | Code generation monad
+type CodeWriter = RWS CodeEnv CodeParts VarId
+
+data CodeEnv = CodeEnv
+  { aliases     :: [(VarId, Expression ())] -- ^ Variable aliasing
+  , inTask      :: Bool                     -- ^ Are we currently in a concurrent task?
+  , backendOpts :: Options                  -- ^ Options for the backend
+  }
+
+initEnv :: Options -> CodeEnv
+initEnv = CodeEnv [] False
+
+data CodeParts = CodeParts
+  { block    :: Block ()         -- ^ collects code within one block
+  , def      :: [Entity ()]      -- ^ collects top level definitions
+  , decl     :: [Declaration ()] -- ^ collects top level variable declarations
+  , params   :: [Variable ()]    -- ^ collects top level parameters
+  , epilogue :: [Program ()]     -- ^ collects postlude code (freeing memory, etc)
+  }
+
+instance Semigroup CodeParts where
+  a <> b = CodeParts { block    = block a <> block b
+                     , def      = def a <> def b
+                     , decl     = decl a <> decl b
+                     , params   = params a <> params b
+                     , epilogue = epilogue a <> epilogue b
+                      }
+
+instance Monoid CodeParts where
+  mappend     = (<>)
+  mempty      = CodeParts { block    = mempty
+                          , def      = mempty
+                          , decl     = mempty
+                          , params   = mempty
+                          , epilogue = mempty
+                          }
+
+--------------------------------------------------------------------------------
+-- * Utility functions
+--------------------------------------------------------------------------------
+
+-- | Make a struct type from a list of field names and their types
+mkStructType :: [(String, Type)] -> Type
+mkStructType trs = StructType n trs
+  where
+    n = "s_" ++ intercalate "_" (show (length trs):map (encodeType . snd) trs)
+
+-- | Construct an array indexing expression
+mkArrayElem :: Expression () -> [Expression ()] -> Expression ()
+mkArrayElem arr ixs
+  | StructType _ [("buffer", ArrayType{}), _] <- typeof arr
+  = ArrayElem (StructField arr "buffer") ixs
+  | NativeArray{}                             <- typeof arr
+  = ArrayElem arr ixs
+  | otherwise = error $ "Interpretation.mkArrayElem: funny array type "
+                      ++ show (typeof arr)
+
+-- | Construct a named variable. The 'VarId' is appended to the base name to
+-- allow different variables to have the same base name. Use a negative 'VarId'
+-- to just get the base name without the appendix.
+mkNamedVar
+    :: String   -- ^ Base name
+    -> Type     -- ^ Variable type
+    -> VarId    -- ^ Identifier (appended to the base name)
+    -> Variable ()
+mkNamedVar base t i = Variable t $ base ++ if i < 0 then "" else show i
+
+-- | Construct a named variable. The 'VarId' is appended to the base name to
+-- allow different variables to have the same base name. Use a negative 'VarId'
+-- to just get the base name without the appendix.
+mkNamedRef
+    :: String   -- ^ Base name
+    -> Type     -- ^ Target type
+    -> VarId    -- ^ Identifier (appended to the base name)
+    -> Variable ()
+mkNamedRef base t = mkNamedVar base (1 :# Pointer t)
+
+-- | Construct a variable.
+mkVariable :: Type -> VarId -> Variable ()
+mkVariable t i | i >= 0 = mkNamedVar "v" t i
+               | otherwise = error "mkVariable: negative index"
+
+-- | Construct a pointer variable.
+mkPointer :: Type -> VarId -> Variable ()
+mkPointer t i | i >= 0 = mkNamedRef "v" t i
+              | otherwise = error "mkPointer: negative index"
+
+-- | Construct a variable expression.
+mkVar :: Type -> VarId -> Expression ()
+mkVar t = varToExpr . mkVariable t
+
+-- | Generate a fresh identifier
+freshId :: CodeWriter VarId
+freshId = do
+  v <- get
+  put $ v + 1
+  return v
+
+-- | Generate and declare a fresh uninitialized variable that will not be freed
+-- in the postlude
+freshAlias :: Type -> CodeWriter (Expression ())
+freshAlias t = do i <- freshId
+                  let v = mkNamedVar "e" t i
+                  declareAlias v
+                  return $ varToExpr v
+
+-- | Generate and declare a fresh variable initialized to the given expression.
+-- The variable will not be freed in the postlude.
+freshAliasInit :: Expression () -> CodeWriter (Expression ())
+freshAliasInit e = do vexp <- freshAlias (typeof e)
+                      tellProg [Assign vexp e]
+                      return vexp
+
+-- | Declare an uninitialized variable that will be freed in the postlude (if
+-- applicable)
+declare :: Variable () -> CodeWriter ()
+declare v = tellDeclWith True [Declaration v Nothing]
+
+-- | Declare an uninitialized variable that will not be freed in the postlude
+declareAlias :: Variable () -> CodeWriter ()
+declareAlias v = tellDeclWith False [Declaration v Nothing]
+
+-- | Declare and initialize a variable that will be freed in the postlude (if
+-- applicable)
+initialize :: Variable () -> Expression () -> CodeWriter ()
+initialize v e = tellDeclWith True [Declaration v (Just e)]
+
+-- | Add a definition to the generated program
+tellDef :: [Entity ()] -> CodeWriter ()
+tellDef es = tell $ mempty {def = es}
+
+-- | Add a list of sub-programs to the generated program
+tellProg :: [Program ()] -> CodeWriter ()
+tellProg [BlockProgram b@(Block [] _)] = tell $ mempty {block = b}
+tellProg ps = tell $ mempty {block = toBlock $ Sequence ps}
+
+-- | Add a list of declarations to the generated program
+tellDeclWith
+    :: Bool  -- ^ Should arrays and IVars in the declarations be freed in the epilogue?
+    -> [Declaration ()]
+    -> CodeWriter ()
+tellDeclWith free ds = do
+    rs <- ask
+    let frees | free = freeArrays ds ++ freeIVars ds
+              | otherwise = []
+        opts = backendOpts rs
+        defs = getTypeDefs ds
+        code | varFloating $ platform opts = mempty {decl = ds, epilogue = frees, def = defs}
+             | otherwise = mempty {block = Block ds Empty,
+                                   epilogue = frees, def = defs}
+    tell code
+
+-- | Find declarations that require top-level type definitions, and return those
+-- definitions
+getTypeDefs :: [Declaration ()] -> [Entity ()]
+getTypeDefs defs = nub $ concatMap mkDef comps
+  where
+    comps = filter isComposite' $ map (typeof . declVar) defs
+    -- There are other composite types that are not flagged as such by this
+    -- version of isComposite, so keep it private.
+    isComposite' :: Type -> Bool
+    isComposite' StructType {}                 = True
+    isComposite' (_ :# (Pointer t))            = isComposite' t
+    isComposite' e                             = isArray e
+    mkDef (StructType n members)
+      =  concatMap (mkDef . snd) members
+      ++ [StructDef n (map (uncurry StructMember) members)]
+    mkDef (ArrayType _ typ)               = mkDef typ
+    mkDef (_ :# (Pointer typ))            = mkDef typ
+    mkDef _                               = []
+
+-- | Copy an 'Expression' to a 'Location'. See 'copyProg' for more details.
+assign :: Location -> Expression () -> CodeWriter ()
+assign dst src = tellProg [copyProg dst [src]]
+
+-- | Shallow assignment from an 'Expression' to a 'Location' (or nothing, if the
+-- destination and source are identical)
+--
+-- Shallow assignment means that it becomes a plain assignment operation in the
+-- generated code; i.e. no deep copying of structures.
+shallowAssign :: Location -> Expression () -> CodeWriter ()
+shallowAssign (Just dst) src | dst /= src = tellProg [Assign dst src]
+shallowAssign _          _                = return ()
+
+shallowCopyWithRefSwap :: Expression () -> Expression () -> CodeWriter ()
+shallowCopyWithRefSwap dst src
+  | dst /= src
+  = case filter (hasReference . snd) $ flattenStructs $ typeof dst of
+      [] -> tellProg [Assign dst src]
+      arrs -> do
+        temps <- sequence [freshAliasInit $ accF dst | (accF, _) <- arrs]
+        tellProg [Assign dst src]
+        tellProg [Assign (accF src) tmp | (tmp, (accF, _)) <- zip temps arrs]
+  | otherwise = return ()
+
+shallowCopyReferences :: Expression () -> Expression () -> CodeWriter ()
+shallowCopyReferences dst src
+  = tellProg [Assign (accF dst) (accF src)
+                 | (accF, t) <- flattenStructs $ typeof dst, hasReference t]
+
+{-
+This function implements double buffering of state for imnmutable
+seqential loops (forLoop and whileLoop).  The intention is to generate
+the minimal amount of copying (especially deep array copies) while
+also avoiding frequent references to data that can not be allocated in
+registers.
+
+The state of the loop is implemented by two variables so that the
+loop body reads from one and writes to the other. At the end of the
+body, the contents of the second (write) variable is shallow copied to
+the first (read) variable. In order to avoid inadvertent sharing of
+data referenced by pointers in the variables (array buffers, for
+instance), the pointers in the state are swapped rather than just
+copied so that the end up in the variable written to. Finally the read
+variable is shallow copied to the result location.
+
+There are some simplifying cases:
+    - When the target lvalue loc is a variable, and thus cheap to
+      access, it is reused as the read state variable
+    - When the type of the state is scalar, so that assignment is
+      atomic, only one state variable is used and it is both read and
+      written to in the loop body, eliminating the shallow copy in the
+      loop body.
+The strategy implemented a compromise between different design constraints:
+    - Avoid deep copying of arrays (that is what the double buffering is for)
+    - Avoid shallow copying if possible
+    - Avoid memory leaks of arrays and ivars
+-}
+
+mkDoubleBufferState :: Expression () -> VarId -> CodeWriter (Expression (), Expression ())
+mkDoubleBufferState loc stvar
+   = do stvar1 <- if isVarExpr loc || containsNativeArray (typeof loc)
+                     then return loc
+                     else do vexp <- freshAlias (typeof loc)
+                             shallowCopyReferences vexp loc
+                             return vexp
+        stvar2 <- if isComposite $ typeof loc
+                     then do let vexp2 = mkVariable (typeof loc) stvar
+                             declare vexp2
+                             return $ varToExpr vexp2
+                     else return stvar1
+        return (stvar1, stvar2)
+
+-- | Move the generated code block from the 'CodeWriter' effect to the result
+-- value. Top-level declarations etc. remain in the 'CodeWriter' effect.
+confiscateBlock :: CodeWriter a -> CodeWriter (a, Block ())
+confiscateBlock m
+    = liftM (second block)
+    $ censor (\rec -> rec {block = mempty})
+    $ listen m
+
+-- | Move the generated code block, declarations and postlude code from the
+-- 'CodeWriter' effect to the result value. The other fields of 'CodeParts' remain
+-- in the 'CodeWriter' effect.
+--
+-- Note that the resulting declarations and postlude code most probably need to
+-- be re-emitted in the 'CodeWriter'. Otherwise there is a risk that the
+-- generated code will be incorrect.
+confiscateBigBlock ::
+    CodeWriter a -> CodeWriter (a, (Block (), [Declaration ()], [Program ()]))
+confiscateBigBlock m
+    = liftM (\(a,ws) -> (a, (block ws, decl ws, epilogue ws)))
+    $ censor (\rec -> rec {block = mempty, decl = mempty, epilogue = mempty})
+    $ listen m
+
+-- | Add an alias to the environment of a local code generator
+withAlias
+    :: VarId          -- ^ Variable to alias
+    -> Expression ()  -- ^ Expression to substitute for the variable
+    -> CodeWriter a   -- ^ Local code generator
+    -> CodeWriter a
+withAlias v0 expr = local (\e -> e {aliases = (v0,expr) : aliases e})

--- a/src/Feldspar/Compiler/Imperative/Frontend.hs
+++ b/src/Feldspar/Compiler/Imperative/Frontend.hs
@@ -1,0 +1,510 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wall #-}
+-- Some questionable partial patterns and pattern matches on strings
+-- in the decoding function.
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module Feldspar.Compiler.Imperative.Frontend where
+
+import Feldspar.Compiler.Backend.C.Options
+import Feldspar.Compiler.Imperative.Representation
+import Feldspar.Core.Types (Length)
+import Feldspar.Core.UntypedRepresentation (Fork(..))
+import Feldspar.Range
+
+import Data.Char (toLower)
+import Data.List (stripPrefix)
+
+toBlock :: Program () -> Block ()
+toBlock (BlockProgram b) = b
+toBlock p                = Block [] p
+
+toProg :: Block () -> Program ()
+toProg (Block [] p) = p
+toProg e = BlockProgram e
+
+-- | Where to place the program result
+type Location = Maybe (Expression ())
+
+-- | Copies expressions into a destination. If the destination is
+-- an array the arguments are appended into the destination.
+copyProg :: Location -> [Expression ()] -> Program ()
+copyProg _ []      = error "copyProg: missing source parameter."
+copyProg Nothing _ = Empty
+copyProg (Just outExp) inExp =
+  case inExp of
+    [x] | outExp == x -> Empty
+    _                 -> deepCopy outExp inExp
+
+-- | Expand copying of aggregate data to copying of components
+deepCopy :: Expression () -> [Expression ()] -> Program ()
+deepCopy arg1 [arg2]
+  | arg1 == arg2
+  = Empty
+
+deepCopy arg1 args
+  | isAwLType (typeof arg1) || isNativeArray (typeof arg1)
+  = Assign arg1 $ fun (typeof arg1) "copy" (arg1 : args)
+
+deepCopy arg1 [arg2]
+  | StructType _ fts <- typeof arg2
+  = Sequence $ map (deepCopyField . fst) fts
+
+  | otherwise
+  = Assign arg1 arg2
+    where deepCopyField fld = deepCopy (StructField arg1 fld) [StructField arg2 fld]
+
+deepCopy _ _ = error "Multiple non-array arguments to copy"
+
+flattenCopy :: Expression () -> [Expression ()] -> [Expression ()] ->
+               Expression () -> [Program ()]
+flattenCopy _ [] [] _ = []
+flattenCopy dst (t:ts) (l:ls) cLen
+  = Assign dst (arrayFun "copyArrayPos" $ arrayBufLen dst ++ arrayBufLen t ++ [cLen])
+    : flattenCopy dst ts ls (ePlus cLen l)
+
+ePlus :: Expression () -> Expression () -> Expression ()
+ePlus (ConstExpr (IntConst 0 _)) e = e
+ePlus e (ConstExpr (IntConst 0 _)) = e
+ePlus e1 e2                        = binop (1 :# NumType Signed S32) "+" e1 e2
+
+-- | Lower array copy
+lowerCopy :: Options -> Type -> Expression () -> [Expression ()] -> [Program ()]
+lowerCopy opts t dst ins
+  | isAwLType t = lowerArrayCopy opts t dst ins
+lowerCopy opts NativeArray{} dst [arg1,arg2]
+  | l@(ConstExpr (IntConst n _)) <- arrayLength arg2
+  = if n < safetyLimit opts
+      then initArray (Just dst) l:map (\i -> Assign (ArrayElem dst [litI32 i]) (ArrayElem arg2 [litI32 i])) [0..(n-1)]
+      else error $ unlines ["Frontend.lowerCopy: array size (" ++ show n ++ ") too large", show arg1, show arg2]
+lowerCopy _ t e es = error $ "Frontend.lowerCopy: funny type (" ++ show t ++ ") or destination\n"
+                                ++ show e ++ "\nor arguments\n"
+                                ++ unlines (map show es)
+
+-- | Lower general array copy
+lowerArrayCopy :: Options -> Type -> Expression () -> [Expression ()] -> [Program ()]
+lowerArrayCopy _ _ dst ins'@(arg1:in1:ins) -- FIXME: Remove the unused Options argument.
+  | [ConstExpr ArrayConst{..}] <- ins'
+  = initArray (Just dst) (litI32 $ toInteger $ length arrayValues)
+    : zipWith (\i c -> Assign (ArrayElem dst [litI32 i]) (ConstExpr c)) [0..] arrayValues
+  | [] <- ins
+  = [ Assign (arrayBuffer   dst) (arrayFun "initCopyArray" $ concatMap arrayBufLen [arg1, in1])
+    , Assign (arrayLengthLV dst) (arrayLength in1)
+    ]
+  | otherwise
+  = [ initArray (Just dst) expDstLen, copyFirstSegment ] ++
+      flattenCopy arg1 ins argnLens arg1len
+    where expDstLen = foldr ePlus (litI32 0) aLens
+          copyFirstSegment
+            | dst == in1 = Empty
+            | otherwise
+            = Assign (arrayBuffer dst)
+                     (arrayFun "copyArray" $ concatMap arrayBufLen [arg1, in1])
+          aLens@(arg1len:argnLens) = map arrayLength (in1:ins)
+
+
+-- | Initialize an array using \"initArray\"
+initArray
+    :: Location       -- ^ Array location
+    -> Expression ()  -- ^ Array length
+    -> Program ()
+initArray Nothing _ = Empty
+initArray (Just arr) len
+  | isNativeArray $ typeof arr
+  = Empty
+  | otherwise
+  = Sequence [ Assign (arrayBuffer arr) $ arrayFun "initArray" $ arrayBufLen arr ++ [len]
+             , Assign (arrayLengthLV arr) len
+             ]
+
+-- | Generate a call to free an array represented as a variable
+freeArray :: Variable () -> Program ()
+freeArray = freeArrayE . VarExpr
+
+-- | Generate a call to free an array represented as an expression
+freeArrayE :: Expression () -> Program ()
+freeArrayE arr
+  = call (variant "freeArray" t) $ map ValueParameter $ take n $ arrayBufLen arr
+   where StructType _ [("buffer", ArrayType _ t), _] = typeof arr
+         n = if isShallow t then 1 else 2
+
+-- | Generate 'freeArray' calls for all arrays in a list of declarations
+freeArrays :: [Declaration ()] -> [Program ()]
+freeArrays defs = map freeArrayE arrays
+  where
+    arrays = [f $ varToExpr v | v <- map declVar defs,
+                                (f, t) <- flattenStructs $ typeof v,
+                                isAwLType t]
+
+-- | Get the length of an array
+arrayLength :: Expression () -> Expression ()
+arrayLength arr
+  | Just l <- staticArrayLength arr = litI32 $ fromIntegral l
+  | otherwise = StructField arr "length"
+
+-- | Get the length of an array as an lval
+arrayLengthLV :: Expression () -> Expression ()
+arrayLengthLV arr = StructField arr "length"
+
+arrayBuffer :: Expression () -> Expression ()
+arrayBuffer arr = StructField arr "buffer"
+
+arrayBufLen :: Expression () -> [Expression ()]
+arrayBufLen arr = [arrayBuffer arr, arrayLength arr]
+
+-- | If possible, return the static length of an array
+staticArrayLength :: Expression t -> Maybe Length
+staticArrayLength = go []  -- TODO: Extend to handle x.member1.member2
+  where go :: [String] -> Expression t -> Maybe Length
+        go []    (ConstExpr (ArrayConst l _)) = Just (fromIntegral $ length l)
+        go []    (VarExpr (Variable (ArrayType r _) _)) | isSingleton r = Just (upperBound r)
+        go []    (VarExpr (Variable (NativeArray (Just l) _) _)) = Just l
+        go []    (Deref e) = go [] e -- TODO: this is questionable; we now look at an expression for the address of the array
+        go ss    (StructField e s) = go (s:ss) e
+        go ss    (AddrOf e) = go ss e
+        go (s:_) (VarExpr (Variable (StructType _ fields) _))
+          | Just (ArrayType r _) <- lookup s fields
+          , isSingleton r = Just (upperBound r)
+          | Just (NativeArray (Just l) _) <- lookup s fields
+          = Just l
+        go _ _ = Nothing
+
+iVarInitCond :: Fork -> Expression () -> Program ()
+iVarInitCond Future var = iVarInit var
+iVarInitCond _      _   = Empty
+
+iVarInit :: Expression () -> Program ()
+iVarInit var = call "ivar_init" [ValueParameter var]
+
+iVarGet :: Bool -> Expression () -> Expression () -> Program ()
+iVarGet inTask loc ivar
+    | Just eTy <- elemTyAwL typ
+    = if isShallow eTy
+          then call (mangle inTask "ivar_get_array_shallow") $ map ValueParameter [ AddrOf loc, ivar, size eTy ]
+          else call (mangle inTask "ivar_get_array") $ map ValueParameter [ AddrOf loc, ivar, copyFun eTy ]
+    | otherwise  = call (mangle inTask "ivar_get") [ TypeParameter typ
+                                                   , ValueParameter (AddrOf loc)
+                                                   , ValueParameter ivar]
+      where
+        typ = typeof loc
+        mangle True  s = s
+        mangle False s = s ++ "_nontask"
+        size t = SizeOf t
+        copyFun t = VarExpr $ Variable (1 :# Pointer VoidType) (variant "initCopyArray" t)
+
+iVarPut :: Expression () -> Expression () -> Program ()
+iVarPut ivar msg
+    | Just eTy <- elemTyAwL typ
+    = if isShallow eTy
+          then call "ivar_put_array_shallow" [ValueParameter ivar, ValueParameter $ AddrOf msg, sizePar eTy]
+          else call "ivar_put_array" [ValueParameter ivar, ValueParameter $ AddrOf msg, copyPar eTy]
+    | otherwise              = call "ivar_put" [TypeParameter typ, ValueParameter ivar, ValueParameter (AddrOf msg)]
+      where
+        typ = typeof msg
+        copyPar t = ValueParameter $ VarExpr $ Variable (1 :# Pointer VoidType) (variant "initCopyArray" t)
+        sizePar t = ValueParameter $ SizeOf t
+
+-- | Generate a call to free an IVar represented as a variable
+iVarDestroy :: Variable () -> Program ()
+iVarDestroy v = call "ivar_destroy" [ValueParameter $ AddrOf $ varToExpr v]
+
+-- | Generate 'iVarDestroy' calls for all IVars in a list of declarations
+freeIVars :: [Declaration ()] -> [Program ()]
+freeIVars defs = map iVarDestroy ivars
+  where
+    ivars = filter (isIVar . typeof) $ map declVar defs
+
+spawn :: Fork -> String -> [Variable ()] -> Program ()
+spawn f taskName vs
+ | f `elem` [None, Loop] = call taskName $ map mkV vs
+ | otherwise = call spawnName allParams
+  where
+    mkV v = ValueParameter . varToExpr $ Variable (typeof v) (varName v)
+    spawnName = "spawn" ++ show (length vs)
+    taskParam = FunParameter taskName
+    typeParams = map (TypeParameter . typeof) vs
+    varParams = map (ValueParameter . mkv) vs
+      where mkv v = VarExpr $ Variable (typeof v) (varName v)
+    allParams = taskParam : concat (zipWith (\a b -> [a,b]) typeParams varParams)
+
+run :: String -> [Variable ()] -> Program ()
+run taskName vs = call runName allParams
+  where
+    runName = "run" ++ show (length vs)
+    typeParams = map (TypeParameter . typeof) vs
+    taskParam = FunParameter taskName
+    allParams = taskParam : typeParams
+
+intWidth :: Type -> Maybe Integer
+intWidth (1 :# (NumType _ S8))             = Just 8
+intWidth (1 :# (NumType _ S16))            = Just 16
+intWidth (1 :# (NumType _ S32))            = Just 32
+intWidth (1 :# (NumType _ S40))            = Just 40
+intWidth (1 :# (NumType _ S64))            = Just 64
+intWidth _                                 = Nothing
+
+intSigned :: Type -> Maybe Bool
+intSigned (1 :# (NumType Unsigned _))            = Just False
+intSigned (1 :# (NumType Signed _))              = Just True
+intSigned _                                      = Nothing
+
+litF :: Float -> Expression t
+litF n = ConstExpr (FloatConst n)
+
+litD :: Double -> Expression t
+litD n = ConstExpr (DoubleConst n)
+
+litB :: Bool -> Expression ()
+litB b = ConstExpr (BoolConst b)
+
+litC :: Constant () -> Constant () -> Expression ()
+litC r i = ConstExpr (ComplexConst r i)
+
+litI :: Type -> Integer -> Expression ()
+litI (_ :# t) n = ConstExpr (IntConst n t)
+
+litI32 :: Integer -> Expression ()
+litI32 = litI (1 :# NumType Unsigned S32)
+
+int32, uint32 :: Type
+int32 = 1 :# NumType Signed S32
+uint32 = 1 :# NumType Unsigned S32
+
+isComplex :: Type -> Bool
+isComplex (_ :# ComplexType{})            = True
+isComplex _                               = False
+
+isFloat :: Type -> Bool
+isFloat (_ :# FloatType{})            = True
+isFloat _                             = False
+
+isAwLType :: Type -> Bool
+isAwLType (StructType _ [("buffer", ArrayType{}), ("length",_)])
+            = True
+isAwLType _ = False
+
+elemTyAwL :: Type -> Maybe Type
+elemTyAwL (StructType _ [("buffer", ArrayType _ t), ("length",_)]) = Just t
+elemTyAwL _ = Nothing
+
+isArray :: Type -> Bool
+isArray ArrayType{}                   = True
+isArray _                             = False
+
+isNativeArray :: Type -> Bool
+isNativeArray NativeArray{}                   = True
+isNativeArray _                               = False
+
+isIVar :: Type -> Bool
+isIVar IVarType{} = True
+isIVar _              = False
+
+isPointer :: Type -> Bool
+isPointer (_ :# Pointer{})            = True
+isPointer _                           = False
+
+isVarExpr :: Expression () -> Bool
+isVarExpr VarExpr{} = True
+isVarExpr _         = False
+
+isComposite :: Type -> Bool
+isComposite ArrayType{}   = True
+isComposite NativeArray{} = True
+isComposite StructType{}  = True
+isComposite _             = False
+
+isShallow :: Type -> Bool
+isShallow ArrayType{} = False
+isShallow NativeArray{} = False
+isShallow (StructType _ fs) = all (isShallow . snd) fs
+isShallow _ = True
+
+variant :: String -> Type -> String
+variant str t | isShallow t = str
+              | otherwise = str ++ "_" ++ encodeType t
+
+arrayFun :: String -> [Expression ()] -> Expression ()
+arrayFun name (dst : dLen : es)
+  = fun arrTy (variant name eTy) (dst : dLen : addSize es eTy)
+   where arrTy = typeof dst
+         eTy   = elemType arrTy
+         elemType (ArrayType _ t) = t
+         elemType (StructType _ [("buffer", ArrayType _ t), _]) = t
+         elemType t = error $ "Frontend.elemType: not an array " ++ show t
+         addSize es' t | isShallow t = SizeOf t:es'
+                       | otherwise   = es'
+
+-- | The type of an array paired with its length
+mkAwLType :: Range Length -> Type -> Type
+mkAwLType r t = StructType n [("buffer", ArrayType r t), ("length", uint32)]
+  where n = "awl_" ++ encodeType t
+
+-- | Does the parameters allow a fast/cheap (in register) return.
+canFastReturn :: Type -> Bool
+canFastReturn t
+  | not $ isComposite t
+  , not $ isPointer t -- Conservative, pointers are handled the regular way.
+  , not $ isIVar t      = True
+canFastReturn _         = False
+
+containsNativeArray :: Type -> Bool
+containsNativeArray t = any (isNativeArray . snd) $ flattenStructs t
+
+-- | Returns a list of access functions and types for the leaves of the struct tree of the type
+flattenStructs :: Type -> [(Expression () -> Expression (), Type)]
+flattenStructs t'@(StructType _ fts)
+  | not $ isAwLType t' = [(\e -> af $ StructField e fname, t'')
+                          | (fname, t) <- fts, (af, t'') <- flattenStructs t]
+flattenStructs t' = [(id, t')]
+
+hasReference :: Type -> Bool
+hasReference ArrayType{}                 = True
+hasReference NativeArray{}               = True -- TODO: Reconsider this safe approximation if we start using native arrays for performance
+hasReference (_ :# Pointer{})            = True
+hasReference IVarType{}                  = True
+hasReference (StructType _ fs)           = any (hasReference . snd) fs
+hasReference _                           = False
+
+varToExpr :: Variable t -> Expression t
+varToExpr = VarExpr
+
+exprToVar :: Expression () -> Variable ()
+exprToVar (VarExpr v) = v
+exprToVar (Deref e)   = exprToVar e
+exprToVar e           = error $ "Frontend.exprToVar: Unexpected variable:" ++ show e
+
+binop :: Type -> String -> Expression () -> Expression () -> Expression ()
+binop t n e1 e2 = fun t n [e1, e2]
+
+fun :: Type -> String -> [Expression ()] -> Expression ()
+fun t n = FunctionCall (Function n t)
+
+mkIf :: Expression () -> Block () -> Maybe (Block ()) -> Program ()
+mkIf ce tb Nothing   = Switch ce [(Pat (litB True), tb)]
+mkIf ce tb (Just eb) = Switch ce [(Pat (litB True), tb), (Pat (litB False), eb)]
+
+call :: String -> [ActualParameter ()] -> Program ()
+call = ProcedureCall
+
+for :: ParType -> Variable () -> Expression () -> Expression () -> Expression () -> Block () -> Program ()
+for _ _ _ _ _ (Block [] (Sequence ps)) | all (== Empty) ps = Empty
+for p n s e i b = ParLoop p n s e i b
+
+while :: Block () -> Expression () -> Block () -> Program ()
+while p e = SeqLoop e p
+
+-- | Wrap a list of statements in Sequence unless there is only one statement in the list
+mkSequence :: [Program ()] -> Program ()
+mkSequence [p] = p
+mkSequence ps  = Sequence ps
+
+{-
+Encoded format is:
+
+<type tag>_<inner_type_tag(s)>
+
+Where the type tag is some unique prefix except for the scalar
+types. The tag for StructTypes include the number of elements in the
+struct to simplify the job for decodeType.
+
+-}
+
+encodeType :: Type -> String
+encodeType = go
+  where
+    go VoidType              = "void"
+    -- Machine vectors do not change memory layout, so keep internal.
+    go (_ :# t)              = goScalar t
+    go (IVarType t)          = "i_" ++ go t
+    go (NativeArray _ t)     = "narr_" ++ go t
+    go (StructType n _)      = n
+    go (ArrayType _ t)       = "arr_" ++ go t
+    goScalar BoolType        = "bool"
+    goScalar BitType         = "bit"
+    goScalar FloatType       = "float"
+    goScalar DoubleType      = "double"
+    goScalar (NumType s w)   = map toLower (show s) ++ show w
+    goScalar (ComplexType t) = "complex_" ++ go t
+    goScalar (Pointer t)     = "ptr_" ++ go t
+
+-- Almost the inverse of encodeType. Some type encodings are lossy so
+-- they are impossible to recover.
+decodeType :: String -> [Type]
+decodeType = goL []
+  where
+    goL acc [] = reverse acc
+    goL acc s  = goL (out:acc) rest'
+       where (out, rest) = go s
+             rest' = case rest of
+                      '_':t -> t
+                      _     -> rest
+
+    go (stripPrefix "void"     -> Just t) = (VoidType, t)
+    go (stripPrefix "bool"     -> Just t) = (1 :# BoolType, t)
+    go (stripPrefix "bit"      -> Just t) = (1 :# BitType, t)
+    go (stripPrefix "float"    -> Just t) = (1 :# FloatType, t)
+    go (stripPrefix "double"   -> Just t) = (1 :# DoubleType, t)
+    go (stripPrefix "unsigned" -> Just t) = (1 :# NumType Unsigned w, t')
+     where (w, t') = decodeSize t
+    go (stripPrefix "signed"   -> Just t) = (1 :# NumType Signed w, t')
+     where (w, t') = decodeSize t
+    go (stripPrefix "complex"  -> Just t) = (1 :# ComplexType tn, t')
+     where (tn, t') = go t
+    go (stripPrefix "ptr_"     -> Just t) = (1 :# Pointer tt, t')
+     where (tt, t') = go t
+    go (stripPrefix "i_"       -> Just t) = (IVarType tt, t')
+     where (tt, t') = go t
+    go (stripPrefix "narr_"    -> Just t) = (NativeArray Nothing tt, t')
+     where (tt, t') = go t
+    go h@('s':'_':t) = (StructType h' $ zipWith mkMember [1 :: Int ..] ts, t'')
+       where mkMember n' tmem = ("member" ++ show n', tmem)
+             Just (n, t') = decodeLen t
+             (ts, t'') = structGo n t' []
+             structGo 0 s acc = (reverse acc, s)
+             structGo n' ('_':s) acc = structGo (n' - 1) s' (ts':acc)
+                      where (ts', s') = go s
+             h' = take (length h - length t'') h
+    go (stripPrefix "arr_"     -> Just t) = (ArrayType fullRange tt, t')
+      where (tt, t') = go t
+    go (stripPrefix "awl_"     -> Just t) = (mkAwLType fullRange tt, t')
+      where (tt, t') = go t
+    go s = error ("decodeType: " ++ s)
+
+    decodeSize (stripPrefix "S32" -> Just t) = (S32, t)
+    decodeSize (stripPrefix "S8"  -> Just t) = (S8, t)
+    decodeSize (stripPrefix "S16" -> Just t) = (S16, t)
+    decodeSize (stripPrefix "S40" -> Just t) = (S40, t)
+    decodeSize (stripPrefix "S64" -> Just t) = (S64, t)
+
+    decodeLen e
+      | [p@(_,_)] <- reads e :: [(Int,String)]
+      = Just p
+      | otherwise = Nothing

--- a/src/Feldspar/Compiler/Imperative/Representation.hs
+++ b/src/Feldspar/Compiler/Imperative/Representation.hs
@@ -1,0 +1,376 @@
+--
+-- Copyright (c) 2009-2011, ERICSSON AB
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--
+--     * Redistributions of source code must retain the above copyright notice,
+--       this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * Neither the name of the ERICSSON AB nor the names of its contributors
+--       may be used to endorse or promote products derived from this software
+--       without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+-- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+-- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+-- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+-- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+-- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wall #-}
+
+-- | Abstract syntax representation for imperative programs
+module Feldspar.Compiler.Imperative.Representation (
+    -- * Representation of imperative programs
+    Module(..)
+  , Entity(..)
+  , Declaration(..)
+  , Block(..)
+  , Program(..)
+  , Expression(..)
+  , ActualParameter(..)
+  , Function(..)
+  , Variable(..)
+  , StructMember(..)
+  , Pattern(..)
+  , ParType(..)
+  , Type(..)
+    -- * Types
+  , ScalarType(..)
+  , Constant(..)
+  , module Feldspar.Core.UntypedRepresentation
+  , fv
+  )
+  where
+
+import Data.List (nub)
+import Data.Maybe (fromMaybe)
+import Data.Semigroup (Semigroup(..))
+import Language.Haskell.TH.Syntax (Lift(..))
+
+import Feldspar.Compiler.Error
+
+import Feldspar.Range (Range)
+import Feldspar.Core.Types (Length)
+import Feldspar.Core.UntypedRepresentation
+        (Signedness(..), Size(..), HasType(..))
+
+--------------------------------------------------------------------------------
+-- * Representation of imperative programs
+--------------------------------------------------------------------------------
+
+data Module t = Module
+    { entities                      :: [Entity t]
+    }
+    deriving (Eq, Show)
+
+data Entity t
+    = StructDef
+        { structName                :: String
+        , structMembers             :: [StructMember t]
+        }
+    | TypeDef
+        { actualType                :: Type
+        , typeName                  :: String
+        }
+    | Proc
+        { procName                  :: String
+        , loopBody                  :: Bool
+        -- Is this a loopbody in disguise?
+        , inParams                  :: [Variable t]
+        , procType                  :: Type
+        , procBody                  :: Maybe (Block t)
+        }
+    | ValueDef
+        { valVar                    :: Variable t
+        , valValue                  :: Constant t
+        }
+    deriving (Eq, Show)
+
+data StructMember t = StructMember
+    { structMemberName              :: String
+    , structMemberType              :: Type
+    }
+    deriving (Eq, Show)
+
+data Block t = Block
+    { locals                        :: [Declaration t]
+    , blockBody                     :: Program t
+    }
+    deriving (Eq, Show)
+
+data Program t
+    = Empty
+        {
+        }
+    | Comment
+        { isBlockComment            :: Bool
+        , commentValue              :: String
+        }
+    | Assign
+        { lhs                       :: Expression t
+        , rhs                       :: Expression t
+        }
+    | ProcedureCall
+        { procCallName              :: String
+        , procCallParams            :: [ActualParameter t]
+        }
+    | Sequence
+        { sequenceProgs             :: [Program t]
+        }
+    | Switch
+        { scrutinee                 :: Expression t
+        , alts                      :: [(Pattern t, Block t)]
+        }
+    | SeqLoop
+        { sLoopCond                 :: Expression t
+        , sLoopCondCalc             :: Block t
+        , sLoopBlock                :: Block t
+        }
+    | ParLoop
+        { pParallelType             :: ParType
+        , pLoopCounter              :: Variable t
+        , pLoopStart                :: Expression t
+        , pLoopEnd                  :: Expression t
+        , pLoopStep                 :: Expression t
+        , pLoopBlock                :: Block t
+        }
+    | BlockProgram
+        { blockProgram              :: Block t
+        }
+    deriving (Eq, Show)
+
+data Pattern t
+   = PatDefault
+   | Pat (Expression t)
+     deriving (Eq, Show)
+
+data ParType
+   = Sequential
+   | Parallel
+   | TaskParallel
+   | WorkParallel -- Generated from ExternalProgram.
+     deriving (Eq, Show)
+
+data ActualParameter t
+    = ValueParameter
+        { valueParam                :: Expression t
+        }
+    | TypeParameter
+        { typeParam                 :: Type
+        }
+    | FunParameter
+        { funParamName              :: String
+        }
+    deriving (Eq, Show)
+
+data Declaration t = Declaration
+    { declVar                       :: Variable t
+    , initVal                       :: Maybe (Expression t)
+    }
+    deriving (Eq, Show)
+
+data Expression t
+    = VarExpr
+        { varExpr                   :: Variable t
+        }
+    | ArrayElem
+        { array                     :: Expression t
+        , arrayIndex                :: [Expression t]
+        }
+    | StructField
+        { struct                    :: Expression t
+        , fieldName                 :: String
+        }
+    | ConstExpr
+        { constExpr                 :: Constant t
+        }
+    | FunctionCall
+        { function                  :: Function
+        , funCallParams             :: [Expression t]
+        }
+    | Cast
+        { castType                  :: Type
+        , castExpr                  :: Expression t
+        }
+    | AddrOf
+        { addrExpr                  :: Expression t
+        }
+    | SizeOf
+        { sizeOf                    :: Type
+        }
+    | Deref
+        { ptrExpr                   :: Expression t
+        }
+    deriving (Eq, Show)
+
+data Function
+    = Function
+        { funName                   :: String
+        , returnType                :: Type
+        }
+    deriving (Eq, Show)
+
+data Constant t
+    = IntConst
+        { intValue                  :: Integer
+        , intType                   :: ScalarType
+        }
+    | DoubleConst
+        { doubleValue               :: Double
+        }
+    | FloatConst
+        { floatValue                :: Float
+        }
+    | BoolConst
+        { boolValue                 :: Bool
+        }
+    | ComplexConst
+        { realPartComplexValue      :: Constant t
+        , imagPartComplexValue      :: Constant t
+        }
+    | ArrayConst
+        { arrayValues               :: [Constant t]
+        , arrayType                 :: Type
+        }
+    -- The maybe allows us to represent both x = { .field = 0 } and x = { 0 }.
+    | StructConst
+        { memberValues              :: [(Maybe String, Constant t)]
+        , structType                :: Type
+        }
+    deriving (Eq, Lift, Show)
+
+data Variable t
+    = Variable
+        { varType                   :: Type
+        , varName                   :: String
+        }
+    deriving (Eq, Show)
+
+instance Semigroup (Program t) where
+  Empty         <> p              = p
+  p             <> Empty          = p
+  (Sequence pa) <> (Sequence pb)  = Sequence (pa <> pb)
+  pa            <> pb             = Sequence [pa <> pb]
+
+instance Semigroup (Block t) where
+  (Block da pa) <> (Block db pb)  = Block (da <> db) (pa <> pb)
+
+instance Monoid (Block t) where
+  mempty                          = Block [] Empty
+  mappend                         = (<>)
+
+--------------------------------------------------------------------------------
+-- * Types
+--------------------------------------------------------------------------------
+
+data ScalarType =
+      BoolType
+    | BitType
+    | FloatType
+    | DoubleType
+    | NumType Signedness Size
+    | ComplexType Type
+    | Pointer Type -- Used for scatter/gather.
+    deriving (Eq, Lift, Show)
+
+data Type =
+      VoidType
+    | Length :# ScalarType -- Machine SIMD vectors; xmm registers in x86.
+    | ArrayType (Range Length) Type
+    | NativeArray (Maybe Length) Type
+    | StructType String [(String, Type)]
+    | IVarType Type
+    deriving (Lift, Show)
+
+-- | Type equality is just structural equality, except for arrays
+-- where size info is ignored and struct types where the tag is ignored.
+instance Eq Type where
+   VoidType              == VoidType              = True
+   (l1 :# t1)            == (l2 :# t2)            = l1 == l2 && t1 == t2
+   (ArrayType _ t1)      == (ArrayType _ t2)      = t1 == t2
+   (NativeArray l1 t1)   == (NativeArray l2 t2)   = l1 == l2 && t1 == t2
+   (StructType _ l1)     == (StructType _ l2)     = l1 == l2
+   (IVarType t1)         == (IVarType t2)         = t1 == t2
+   _                     == _                     = False
+
+----------------------
+--   Type inference --
+----------------------
+
+instance HasType (Variable t) where
+    type TypeOf (Variable t) = Type
+    typeof Variable{..}      = varType
+
+instance HasType (Constant t) where
+    type TypeOf (Constant t) = Type
+    typeof IntConst{..}      = 1 :# intType
+    typeof DoubleConst{}     = 1 :# DoubleType
+    typeof FloatConst{}      = 1 :# FloatType
+    typeof BoolConst{}       = 1 :# BoolType
+    typeof ArrayConst{..}    = NativeArray (Just (fromIntegral $ length arrayValues)) arrayType
+    typeof StructConst{..}   = structType
+    typeof ComplexConst{..}  = 1 :# ComplexType (typeof realPartComplexValue)
+
+instance HasType (Expression t) where
+    type TypeOf (Expression t) = Type
+    typeof VarExpr{..}   = typeof varExpr
+    typeof ArrayElem{..} = decrArrayDepth $ typeof array
+      where
+        decrArrayDepth :: Type -> Type
+        decrArrayDepth (ArrayType _ t)               = t
+        decrArrayDepth (NativeArray _ t)             = t
+        -- Allow indexing of int* with [].
+        decrArrayDepth (1 :# Pointer t)              = t
+        decrArrayDepth t                             = reprError InternalError $ "Non-array variable is indexed! " ++ show array ++ " :: " ++ show t
+    typeof StructField{..} = getStructFieldType fieldName $ typeof struct
+      where
+        getStructFieldType :: String -> Type -> Type
+        getStructFieldType f (StructType _ l) = fromMaybe (structFieldNotFound f) $ lookup f l
+        getStructFieldType f t                = reprError InternalError $
+            "Trying to get a struct field from not a struct typed expression\n" ++ "Field: " ++ f ++ "\nType:  " ++ show t
+        structFieldNotFound f = reprError InternalError $ "Not found struct field with this name: " ++ f
+    typeof ConstExpr{..}    = typeof constExpr
+    typeof FunctionCall{..} = returnType function
+    typeof Cast{..}         = castType
+    typeof AddrOf{..}       = 1 :# Pointer (typeof addrExpr)
+    typeof SizeOf{..}       = 1 :# NumType Signed S32
+    typeof Deref{..}        = case typeof ptrExpr of
+                                1 :# (Pointer btype) -> btype
+                                wtype         -> reprError InternalError $ "Type of dereferenced expression " ++ show ptrExpr ++ " has type " ++ show wtype
+
+instance HasType (ActualParameter t) where
+    type TypeOf (ActualParameter t) = Type
+    typeof ValueParameter{..}= typeof valueParam
+    typeof TypeParameter{..} = typeParam
+    typeof FunParameter{}    = VoidType
+
+
+reprError :: ErrorClass -> String -> a
+reprError = handleError "Feldspar.Compiler.Imperative.Representation"
+
+-- | Free variables of an expression.
+fv :: Expression t -> [Variable t]
+fv = nub . fv'
+
+fv' :: Expression t -> [Variable t]
+fv' (VarExpr v)         = [v]
+fv' (ArrayElem e i)     = fv' e ++ concatMap fv' i
+fv' (StructField e _)   = fv' e
+fv' (FunctionCall _ ps) = concatMap fv' ps
+fv' (Cast _ e)          = fv' e
+fv' (AddrOf e)          = fv' e
+fv' (Deref e)           = fv' e
+fv' _                   = []

--- a/src/Feldspar/Compiler/Marshal.hs
+++ b/src/Feldspar/Compiler/Marshal.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wall #-}
+-- FIXME: Move instances to the right place.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+
+-- | Marshaling between Feldspar and C99 types
+--
+module Feldspar.Compiler.Marshal
+  ( SA(..)
+  , allocSA
+  , Marshal(..)
+  ) where
+
+import Feldspar.Core.NestedTuples (npair)
+import Feldspar.Core.Types (IntN(..), Tuple(..), (:*), TNil, WordN(..))
+import System.Plugins.MultiStage
+
+import Data.Complex (Complex(..))
+import Data.Default
+import Data.Int (Int32)
+
+import Foreign.Marshal (free, mallocBytes, new, newArray, peekArray)
+import Foreign.Ptr
+import Foreign.Storable (Storable(..))
+import qualified Foreign.Storable.Record as Store
+import Foreign.Storable.Tuple ()
+
+instance Reference IntN        where type Ref IntN        = IntN
+instance Reference WordN       where type Ref WordN       = WordN
+instance Reference (Complex a) where type Ref (Complex a) = Complex a
+
+instance Marshal IntN        where type Rep IntN        = IntN
+instance Marshal WordN       where type Rep WordN       = WordN
+instance Marshal (Complex a) where type Rep (Complex a) = Complex a
+
+instance Default (Ptr a) where def = nullPtr
+
+instance (Storable (Rep a), Marshal a) => Marshal [a]
+  where
+    type Rep [a] = SA (Rep a)
+    to xs = do
+        let len  = fromIntegral $ length xs
+        ys <- mapM to xs
+        buffer <- newArray ys
+        return $ SA buffer len
+    from p | elems p == 0 = return []
+    from p = go p
+      where
+        go SA{..} = do
+          res <- mapM from =<< peekArray (fromIntegral elems) buf
+          free buf
+          return res
+
+
+-- | Buffer descriptor for Feldspar arrays
+data SA a = SA { buf   :: Ptr a
+               , elems :: Int32
+               }
+  deriving (Eq, Show)
+
+instance Default (SA a) where
+    def = SA nullPtr def
+
+allocSA :: forall a. Storable a => Int -> IO (Ptr (SA a))
+allocSA len = do
+    let size  = fromIntegral $ sizeOf (undefined :: a)
+    let bytes = len * size
+    buffer <- mallocBytes bytes
+    new $ SA buffer (fromIntegral len)
+
+storeSA :: Storable a => Store.Dictionary (SA a)
+storeSA = Store.run $ SA
+    <$> Store.element buf
+    <*> Store.element elems
+
+instance Storable a => Storable (SA a)
+  where
+    sizeOf    = Store.sizeOf    storeSA
+    alignment = Store.alignment storeSA
+    peek      = Store.peek      storeSA
+    poke      = Store.poke      storeSA
+
+instance Reference (Ptr a)
+  where
+    type Ref (Ptr a) = Ptr a
+    ref   = return
+    deref = return
+
+instance Storable a => Reference (SA a)
+  where
+    type Ref (SA a) = Ptr (SA a)
+    ref   = new
+    deref = peek
+
+instance Storable (a,b) => Reference (a,b)
+  where
+    type Ref (a,b) = Ptr (a,b)
+    ref   = new
+    deref = peek
+
+instance Storable (a,b,c) => Reference (a,b,c)
+  where
+    type Ref (a,b,c) = Ptr (a,b,c)
+    ref   = new
+    deref = peek
+
+instance Storable (a,b,c,d) => Reference (a,b,c,d)
+  where
+    type Ref (a,b,c,d) = Ptr (a,b,c,d)
+    ref   = new
+    deref = peek
+
+instance Storable (a,b,c,d,e) => Reference (a,b,c,d,e)
+  where
+    type Ref (a,b,c,d,e) = Ptr (a,b,c,d,e)
+    ref   = new
+    deref = peek
+
+instance Storable (a,b,c,d,e,f) => Reference (a,b,c,d,e,f)
+  where
+    type Ref (a,b,c,d,e,f) = Ptr (a,b,c,d,e,f)
+    ref   = new
+    deref = peek
+
+instance Storable (a,b,c,d,e,f,g) => Reference (a,b,c,d,e,f,g)
+  where
+    type Ref (a,b,c,d,e,f,g) = Ptr (a,b,c,d,e,f,g)
+    ref   = new
+    deref = peek
+
+instance ( Marshal a
+         , Marshal b
+         ) => Marshal (a,b)
+  where
+    type Rep (a,b) = (Rep a,Rep b)
+    to (a,b)   = (,) <$> to a <*> to b
+    from (a,b) = (,) <$> from a <*> from b
+
+instance ( Marshal a
+         , Marshal b
+         , Marshal c
+         ) => Marshal (a,b,c)
+  where
+    type Rep (a,b,c) = (Rep a,Rep b,Rep c)
+    to (a,b,c)   = (,,) <$> to a <*> to b <*> to c
+    from (a,b,c) = (,,) <$> from a <*> from b <*> from c
+
+instance ( Marshal a
+         , Marshal b
+         , Marshal c
+         , Marshal d
+         ) => Marshal (a,b,c,d)
+  where
+    type Rep (a,b,c,d) = (Rep a,Rep b,Rep c,Rep d)
+    to (a,b,c,d) =
+      (,,,) <$> to a <*> to b <*> to c <*> to d
+    from (a,b,c,d) =
+      (,,,) <$> from a <*> from b <*> from c <*> from d
+
+instance ( Marshal a
+         , Marshal b
+         , Marshal c
+         , Marshal d
+         , Marshal e
+         ) => Marshal (a,b,c,d,e)
+  where
+    type Rep (a,b,c,d,e) = (Rep a,Rep b,Rep c,Rep d,Rep e)
+    to (a,b,c,d,e) =
+      (,,,,) <$> to a <*> to b <*> to c <*> to d <*> to e
+    from (a,b,c,d,e) =
+      (,,,,) <$> from a <*> from b <*> from c <*> from d <*> from e
+
+instance ( Marshal a
+         , Marshal b
+         , Marshal c
+         , Marshal d
+         , Marshal e
+         , Marshal f
+         ) => Marshal (a,b,c,d,e,f)
+  where
+    type Rep (a,b,c,d,e,f) = (Rep a,Rep b,Rep c,Rep d,Rep e,Rep f)
+    to (a,b,c,d,e,f) =
+      (,,,,,) <$> to a <*> to b <*> to c <*> to d <*> to e <*> to f
+    from (a,b,c,d,e,f) =
+      (,,,,,) <$> from a <*> from b <*> from c <*> from d <*> from e <*> from f
+
+instance ( Marshal a
+         , Marshal b
+         , Marshal c
+         , Marshal d
+         , Marshal e
+         , Marshal f
+         , Marshal g
+         ) => Marshal (a,b,c,d,e,f,g)
+  where
+    type Rep (a,b,c,d,e,f,g) = (Rep a,Rep b,Rep c,Rep d,Rep e,Rep f,Rep g)
+    to (a,b,c,d,e,f,g) =
+      (,,,,,,) <$> to a <*> to b <*> to c <*> to d <*> to e <*> to f <*> to g
+    from (a,b,c,d,e,f,g) =
+      (,,,,,,) <$> from a <*> from b <*> from c <*> from d <*> from e <*> from f <*> from g
+
+instance (Marshal a, Marshal b) => Marshal (Tuple (a :* b :* TNil)) where
+  type Rep (Tuple (a :* b :* TNil)) = (Rep a, Rep b)
+  to (a :* b :* TNil) = (,) <$> to a <*> to b
+  from (a, b) = npair <$> from a <*> from b

--- a/src/Feldspar/Compiler/Plugin.hs
+++ b/src/Feldspar/Compiler/Plugin.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# OPTIONS_GHC -Wall #-}
+-- FIXME: Remove this when removing the Lift instances.
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Dynamically load a compiled Feldspar function as a Haskell function
+module Feldspar.Compiler.Plugin
+  ( loadFun
+  , loadFunWith
+  , loadFunOpts
+  , loadFunOptsWith
+  , loadFunWithConfig
+  , defaultConfig
+  , pack   -- from MultiStage
+  , unpack -- from MultiStage
+  )
+  where
+
+import GHCi.ObjLink (initObjLinker, loadObj, resolveObjs)
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 802
+import GHCi.ObjLink (ShouldRetainCAFs(..))
+#endif
+import GHC.Paths (ghc)
+import System.Plugins.MultiStage
+import Distribution.Verbosity (verbose)
+import Distribution.Simple.Utils (defaultPackageDesc)
+import Distribution.PackageDescription
+#if defined(MIN_VERSION_Cabal) && MIN_VERSION_Cabal(2,2,0)
+import Distribution.PackageDescription.Parsec (readGenericPackageDescription)
+#else
+import Distribution.PackageDescription.Parse (readPackageDescription)
+#endif
+import Distribution.PackageDescription.Configuration (flattenPackageDescription)
+
+import Feldspar.Compiler.CallConv (rewriteType, buildCType, buildHaskellType)
+
+import Data.Default -- FIXME: Not required any longer?
+import Foreign.Ptr
+import Foreign.Marshal (with)
+import Foreign.Marshal.Unsafe (unsafeLocalState)
+import Foreign.Storable (Storable(..))
+import Foreign.C.String (CString, withCString)
+
+import Control.Exception (handle)
+import Control.Monad (join, (>=>), when, unless)
+
+import Language.Haskell.TH hiding (Type, Range)
+import Language.Haskell.TH.Syntax (Lift(..))
+
+import System.Directory (doesFileExist, removeFile, createDirectoryIfMissing)
+import System.Exit (ExitCode(..))
+import System.Process (readProcessWithExitCode)
+import System.Info (os)
+import System.IO.Error (IOError)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- Feldspar specific
+import Feldspar.Runtime
+import Feldspar.Compiler (compile, defaultOptions)
+import Feldspar.Compiler.Imperative.Representation (Constant)
+import Feldspar.Compiler.Backend.C.Options (Options(..), Platform(..))
+import Feldspar.Compiler.Backend.C.Library (encodeFunctionName)
+import Feldspar.Compiler.Marshal ()
+
+-- | Configurable configuration for the loader.
+feldsparPluginConfigWith :: String -> Options -> Config
+feldsparPluginConfigWith suff fopts =
+    feldsparPluginConfig { builder = feldsparBuilder fopts
+                         , suffix  = suff
+                         }
+
+-- | Default configuration for the loader
+feldsparPluginConfig :: Config
+feldsparPluginConfig =
+    defaultConfig { builder      = feldsparBuilder defaultOptions
+                  , worker       = feldsparWorker
+                  , typeFromName = loadFunType >=> rewriteType
+                  , mkHSig       = buildHaskellType
+                  , mkCSig       = buildCType
+                  }
+
+-- | Compile and load a Feldspar function into the current GHC session.
+--
+-- > prog1 :: Data Index -> Vector1 Index
+-- > prog1 c = indexed c (const c)
+-- >
+-- > $(loadFun 'prog1)
+--
+-- The call to @loadFun@ above will splice code into the current module
+-- to compile, load and wrap a Feldspar function as a Haskell function:
+--
+-- > c_prog1 :: Index -> [Index]
+--
+loadFun :: [Name] -> Q [Dec]
+loadFun = loadFunWithConfig feldsparPluginConfig
+
+-- | @loadFun@ with a function suffix to avoid collisions and different
+--  feldspar-compiler options.
+loadFunWith :: String -> Options -> [Name] -> Q [Dec]
+loadFunWith s o = loadFunWithConfig (feldsparPluginConfigWith s o)
+
+-- | Call @loadFun@ with C compiler options
+loadFunOpts :: [String] -> [Name] -> Q [Dec]
+loadFunOpts o = loadFunWithConfig feldsparPluginConfig {opts = o}
+
+-- | Call @loadFunWith@ with C compiler options
+loadFunOptsWith :: String -> Options -> [String] -> [Name] -> Q [Dec]
+loadFunOptsWith pref fopt o =
+    loadFunWithConfig (feldsparPluginConfigWith pref fopt){opts = o}
+
+feldsparWorker :: Name -> [Name] -> Q Body
+feldsparWorker fun as = normalB
+    [|with def $ \outPtr -> do
+        join $(infixApp (apply ([|pure $(varE fun)|] : map toRef as)) [|(<*>)|] [|pure outPtr|])
+        peek outPtr >>= from
+    |]
+  where
+    toRef name = [| pack $(varE name) |]
+
+    apply :: [ExpQ] -> ExpQ
+    apply [] = error "apply []"
+    apply [x] = x
+    apply (x:y:zs) = apply (infixApp x [|(<*>)|] y : zs)
+
+feldsparBuilder :: Options -> Config -> Name -> Q Body
+feldsparBuilder fopts Config{..} fun = do
+    let db    = getDB
+        opts' = opts ++ map ("-I"++) db
+    normalB [|unsafeLocalState $ do
+                createDirectoryIfMissing True wdir
+                $(varE 'compile) $(varE fun) basename base fopts
+                compileAndLoad basename opts'
+                lookupSymbol symbol
+            |]
+  where
+    base     = nameBase fun ++ suffix
+    basename = wdir ++ "/" ++ base
+    symbol   = ldprefix ++ encodeFunctionName base
+    ldprefix = case os of
+                 "darwin" -> "_"
+                 _        -> ""
+
+getDB :: [String]
+getDB = unsafePerformIO $ do
+    dirs <- sequence [ sandbox, user, local ]
+    putStrLn $ unwords $ "Using feldspar runtime in" : concat dirs
+    return $ concat dirs
+  where
+    sandbox = handle (\(_ :: IOError) -> return []) $ do
+      (c,d,_) <- readProcessWithExitCode "cabal" ["sandbox", "hc-pkg","field","feldspar-language","include-dirs"] ""
+      case c of
+        ExitSuccess -> return $ drop 1 $ words d
+        _           -> return []
+    user = handle (\(_ :: IOError) -> return []) $ do
+      (c,d,_) <- readProcessWithExitCode "ghc-pkg" ["field","feldspar-language","include-dirs"] ""
+      case c of
+        ExitSuccess -> return $ drop 1 $ words d
+        _           -> return []
+    local   = do
+#if defined(MIN_VERSION_Cabal) && MIN_VERSION_Cabal(2,2,0)
+      pd <- readGenericPackageDescription verbose =<< defaultPackageDesc verbose
+#else
+      pd <- readPackageDescription verbose =<< defaultPackageDesc verbose
+#endif
+      let f a = return $ includeDirs $ libBuildInfo a
+      maybe (return []) f (maybeHasLibs $ flattenPackageDescription pd)
+{-# NOINLINE getDB #-}
+
+maybeHasLibs :: PackageDescription -> Maybe Library
+maybeHasLibs p =
+   library p >>= \lib -> if buildable (libBuildInfo lib)
+                           then Just lib
+                           else Nothing
+
+compileAndLoad :: String -> [String] -> IO ()
+compileAndLoad name opts = do
+    let cname = name ++ ".c"
+        oname = name ++ ".o"
+    exists <- doesFileExist oname
+    when exists $ removeFile oname
+    compileC cname oname opts
+#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 802
+    initObjLinker RetainCAFs
+#else
+    initObjLinker
+#endif
+    _ <- loadObj oname
+    res <- resolveObjs
+    unless res $ error $ "Symbols in " ++ oname ++ " could not be resolved"
+
+compileC :: String -> String -> [String] -> IO ()
+compileC srcfile objfile opts = do
+    let args = [ "-optc -std=c99"
+               , "-optc -Wall"
+               , "-w"
+               , "-c"
+               ]
+    (_,stdout,stderr) <- readProcessWithExitCode ghc (args ++ opts ++ ["-o",objfile,srcfile]) ""
+    let output = stdout ++ stderr
+    unless (null output) $ putStrLn output
+
+lookupSymbol :: String -> IO (Ptr a)
+lookupSymbol symbol = do
+    when (0 /= feldspar_compiler_hook) $ error "lookupSymbol: Runtime library missing"
+    mptr <- withCString symbol _lookupSymbol
+    when (mptr == nullPtr) $ error $ "Symbol " ++ symbol ++ " not found"
+    return mptr
+
+foreign import ccall safe "lookupSymbol"
+    _lookupSymbol :: CString -> IO (Ptr a)
+
+
+--- Boring TH instances for Lifting Options -------
+-- TODO: Derive Lift for these.
+
+instance Lift Options where
+    lift (Options platform ph una unr frontopts sl ns) =
+        [| Options platform ph una unr frontopts sl ns |]
+
+instance Lift Platform where
+    lift (Platform n t vs is vf be) = [| Platform n t vs is vf be |]
+
+instance Lift (Constant () -> String) where
+    lift _ = [| error "No TH instance for ShowValue" |]

--- a/src/Feldspar/Runtime.hs
+++ b/src/Feldspar/Runtime.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE CPP #-}
+{-# OPTIONS_GHC -Wall #-}
+
+-- | A module provinding a linker hook that can be referenced to ensure
+-- that the runtime support files are linked.
+
+module Feldspar.Runtime
+    ( feldspar_compiler_hook
+    )
+  where
+
+feldspar_compiler_hook :: Int
+
+#ifdef CABAL_IS_USED
+
+feldspar_compiler_hook = sum [ feldspar_c99_hook
+                             , feldspar_ivar_hook
+                             , feldspar_taskpool_hook
+                             ]
+
+foreign import ccall safe "feldspar_c99_hook"
+  feldspar_c99_hook :: Int
+
+foreign import ccall safe "feldspar_ivar_hook"
+  feldspar_ivar_hook :: Int
+
+foreign import ccall safe "feldspar_taskpool_hook"
+  feldspar_taskpool_hook :: Int
+
+#else
+
+feldspar_compiler_hook = 0
+
+#endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,6 +46,7 @@ extra-deps:
   ,prelude-edsl-0.3.1
   ,data-hash-0.2.0.1
   ,tree-view-0.5
+  ,plugins-multistage-0.6.3
   ]
 
 # Override default flag values for local packages and extra-deps

--- a/tests/CallingConvention.hs
+++ b/tests/CallingConvention.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Test that the compiler respects the calling conventions of Feldspar
+
+module Main where
+
+import qualified Prelude
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+import Test.QuickCheck
+
+import Feldspar hiding (assert)
+import Feldspar.Vector
+import Feldspar.Compiler
+import Feldspar.Compiler.Plugin
+import Feldspar.Core.NestedTuples
+
+import Control.Applicative
+
+-- | Arbitrary instances for nested tuples
+instance Arbitrary (Tuple TNil) where
+  arbitrary = return TNil
+
+instance (Arbitrary a, Arbitrary (Tuple b)) => Arbitrary (Tuple (a :* b)) where
+  arbitrary = do a <- arbitrary
+                 b <- arbitrary
+                 return (a :* b)
+
+vector1D :: Length -> Gen a -> Gen [a]
+vector1D l = vectorOf (Prelude.fromIntegral l)
+
+pairArg :: (Data Word8,Data IntN) -> Data IntN
+pairArg (a,b) = i2n a + b
+
+pairRes :: Data Word16 -> (Data WordN, Data IntN)
+pairRes a = (i2n a, i2n a)
+
+vecId :: Pull1 Word32 -> Pull1 Word32
+vecId = id
+
+vectorInPair :: (Pull1 WordN, Data WordN) -> (Data WordN, Pull1 WordN)
+vectorInPair (v,a) = (a,v)
+
+vectorInVector :: Pull DIM1 (Pull1 WordN) -> Data WordN
+vectorInVector v = fromZero $ sum $ map (fromZero . sum) v
+
+vectorInPairInVector :: Data WordN -> Pull DIM1 (Data WordN, Pull1 WordN)
+vectorInPairInVector l = indexed1 l $ \i -> (i, indexed1 i id)
+
+shTest :: Data Length -> Data Length
+shTest n = runMutable $ do
+             a <- newArr n 1
+             c <- newArr n 2
+             let d = n<5 ? a $ c
+             setArr d 0 n
+             b <- getArr a $ 0
+             return b
+
+arrayInStructR :: Data [Length] -> Data [Length]
+arrayInStructR a = snd $ whileLoop (getLength a, a) (\(n,_) -> (n>0)) (\(n,a) -> (n-1, parallel (getLength a) (\ i -> a!i + 5)))
+
+pairParamR :: (Data Index, Data Index) -> Data Index
+pairParamR (x, _) = x
+
+pairParam2R :: (Data Int16, Data Int16) ->
+              ((Data Int16, Data Int16), (Data Int16, Data Int16))
+pairParam2R c = (c, c)
+
+copyPushR :: Pull1 Index -> DPush DIM1 Index
+copyPushR v = let pv = toPush v in pv ++ pv
+
+complexWhileCondR :: Data Int32 -> (Data Int32, Data Int32)
+complexWhileCondR y = whileLoop (0,y) (\(a,b) -> ((\a b -> a * a < b * b) a (b-a))) (\(a,b) -> (a+1,b))
+
+deepArrayCopyTest :: Data [[[Length]]] -> (Data [[[Length]]], Data [[[Length]]])
+deepArrayCopyTest xs = (xs, xs)
+
+loadFun ['pairArg]
+loadFun ['pairRes]
+loadFun ['vecId]
+loadFun ['vectorInPair]
+loadFun ['vectorInVector]
+loadFun ['vectorInPairInVector]
+loadFun ['shTest]
+loadFun ['arrayInStructR]
+loadFun ['pairParamR]
+loadFun ['pairParam2R]
+loadFun ['copyPushR]
+loadFun ['complexWhileCondR]
+loadFun ['deepArrayCopyTest]
+
+prop_pairArg = eval pairArg ==== c_pairArg
+prop_pairRes = eval pairRes ==== c_pairRes
+prop_vecId (Small l) =
+    forAll (vector1D l arbitrary) $ \xs ->
+      eval vecId xs ==== c_vecId xs
+prop_vectorInPair (Small l) =
+    forAll (npair <$> vector1D l arbitrary <*> arbitrary) $ \p ->
+      eval vectorInPair p ==== c_vectorInPair p
+prop_vectorInVector (Small l1) (Small l2) =
+    forAll (vector1D l1 (vector1D l2 arbitrary)) $ \v ->
+      eval vectorInVector v ==== c_vectorInVector v
+prop_vectorInPairInVector (Small l) = eval vectorInPairInVector l ==== c_vectorInPairInVector l
+prop_shTest (Positive n) = eval shTest n ==== c_shTest n
+prop_deepArrayCopyTest = eval deepArrayCopyTest ==== c_deepArrayCopyTest
+
+prop_arrayInStruct = eval arrayInStructR ==== c_arrayInStructR
+prop_pairParam = eval pairParamR ==== c_pairParamR
+prop_pairParam2 = eval pairParam2R ==== c_pairParam2R
+prop_copyPush = eval copyPushR ==== c_copyPushR
+prop_complexWhileCond (Small n) = eval complexWhileCondR n ==== c_complexWhileCondR n
+
+tests :: TestTree
+tests = testGroup "CallingConvention"
+    [ testProperty "pairArg" prop_pairArg
+    , testProperty "pairRes" prop_pairRes
+    , testProperty "vecId"   prop_vecId
+    , testProperty "vectorInPair" prop_vectorInPair
+    , testProperty "vectorInVector" prop_vectorInVector
+    -- TODO: This test case will cause a segmentation fault due to issue #145
+    -- , testProperty "vectorInPairInVector" prop_vectorInPairInVector
+    , testProperty "arrayInStruct" prop_arrayInStruct
+    , testProperty "pairParam" prop_pairParam
+    , testProperty "pairParam2" prop_pairParam2
+    , testProperty "copyPush" prop_copyPush
+    , testProperty "complexWhileCond" prop_complexWhileCond
+    , testProperty "deepArrayCopy" prop_deepArrayCopyTest
+    ]
+
+main :: IO ()
+main = defaultMain tests

--- a/tests/RegressionTests.hs
+++ b/tests/RegressionTests.hs
@@ -1,0 +1,372 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main where
+
+-- To generate the golden files use a script similiar to this one
+-- > ghc -ilib -isrc -itests tests/RegressionTests.hs -e 'writeGoldFile example9 "example9" defaultOptions'
+-- > ghc -ilib -isrc -itests tests/RegressionTests.hs -e 'writeGoldFile example9 "example9_native" nativeOpts'
+
+import Test.Tasty
+import Test.Tasty.Golden.Advanced
+import Test.Tasty.QuickCheck
+
+import qualified Prelude
+import Feldspar
+import qualified Feldspar.Core.UntypedRepresentation as UT
+import Feldspar.Mutable
+import Feldspar.Vector
+import qualified Feldspar.SimpleVector.Push as SP
+import qualified Feldspar.SimpleVector as S
+import Feldspar.Compiler
+import Feldspar.Compiler.Plugin
+import Feldspar.Compiler.ExternalProgram (compileFile)
+
+import Control.Applicative hiding (empty)
+import Control.Monad
+import Control.Monad.Except (liftIO)
+import Data.Monoid ((<>))
+import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Lazy as LB
+import qualified Data.ByteString.Lazy.Search as LB
+import System.Exit (ExitCode (..))
+import System.Process
+import Text.Printf
+
+vgReadFiles :: String -> IO LB.ByteString
+vgReadFiles base = liftM LB.concat $ mapM (LB.readFile . (base<>)) [".h",".c"]
+
+example9 :: Data Int32 -> Data Int32
+example9 a = condition (a<5) (3*(a+20)) (30*(a+20))
+
+-- Compile and load example9 as c_example9 (using plugins)
+loadFun ['example9]
+
+topLevelConsts :: Data Index -> Data Index -> Data Index
+topLevelConsts a b = condition (a<5) (d ! (b+5)) (c ! (b+5))
+  where
+    c = value [1,2,3,4,5] :: Data [Index]
+    d = value [2,3,4,5,6] :: Data [Index]
+
+pairParam :: (Data Index, Data Index) -> Data Index
+pairParam (x, _) = x
+
+pairParam2 :: (Data Int16, Data Int16) ->
+              ((Data Int16, Data Int16), (Data Int16, Data Int16))
+pairParam2 c = (c, c)
+
+-- One test starting.
+metrics :: Pull1 IntN -> Pull1 IntN
+            -> Pull DIM1 (Pull DIM1 (Data Index, Data Index)) -> Pull DIM1 (Pull1 IntN)
+metrics s _ = scan (columnMetrics s) initialMetrics
+
+initialMetrics :: Pull1 IntN
+initialMetrics = replicate1 8 (-32678)
+
+columnMetrics :: Pull1 IntN -> Pull1 IntN -> Pull DIM1 (Data Index, Data Index)
+                  -> Pull1 IntN
+columnMetrics s prev zf  = zipWith (metricFast prev) zf s
+
+metricFast :: Pull1 IntN -> (Data Index, Data Index) -> Data IntN -> Data IntN
+metricFast prev (z, _) _ = prev !! z
+-- End one test.
+
+copyPush :: Pull1 Index -> DPush DIM1 Index
+copyPush v = let pv = toPush v in pv ++ pv
+
+scanlPush :: SP.PushVector1 WordN -> S.Vector1 WordN -> SP.PushVector (SP.PushVector1 WordN)
+scanlPush = SP.scanl const
+
+concatV :: Pull DIM1 (Pull1 IntN) -> DPush DIM1 IntN
+concatV xs = fromZero $ fold (++) empty xs
+
+loadFun ['concatV]
+
+concatVM :: Pull DIM1 (Pull1 IntN) -> Manifest DIM1 (Data IntN)
+concatVM xs = fromZero $ fold (\ l r -> store $ l ++ r) (store empty) xs
+
+loadFun ['concatVM]
+
+complexWhileCond :: Data Int32 -> (Data Int32, Data Int32)
+complexWhileCond y = whileLoop (0,y) (\(a,b) -> ((\a b -> a * a /= b * b) a (b-a))) (\(a,b) -> (a+1,b))
+
+-- One test starting
+divConq3 :: Pull DIM1 (Data IntN) -> DPush DIM1 IntN
+divConq3 xs = concatV $ pmap (map (+1)) (segment 1024 xs)
+
+pmap :: (Syntax a, Syntax b) => (a -> b) -> Pull DIM1 a -> Pull DIM1 b
+pmap f = map await . force . map (future . f)
+
+-- Note. @segment@ expects the length of @xs@ to be a multiple of @l@
+segment :: Syntax a => Data Length -> Pull DIM1 a -> Pull DIM1 (Pull DIM1 a)
+segment l xs = indexed1 clen (\ix -> take l $ drop (ix*l) xs)
+  where clen = length xs `div` l
+
+loadFun ['divConq3]
+
+-- End one test.
+
+-- | We rewrite `return x >>= \_ -> return y` into `return x >> return y`
+--   This test ensures that we can still `return x` in the first action.
+bindToThen :: Data Index -> Data Index
+bindToThen y = runMutable $ do
+    ref <- newRef y
+    _ <- getRef ref
+    getRef ref
+
+switcher :: Data Word8 -> Data Bool -> Data Word8
+switcher i = switch (value 0) [(True,i), (False,2)]
+
+ivartest :: Data Index -> Data Index
+ivartest a = share (future (a+1)) $ \a' -> await a' * 2
+
+ivartest2 :: (Data Index, Data Index) -> (Data Index, Data Index)
+ivartest2 a = share (future a) $ \a' -> await a'
+
+arrayInStruct :: Data [Length] -> Data [Length]
+arrayInStruct a = snd $ whileLoop (getLength a, a) (\(n,_) -> (n>0)) (\(n,a) -> (n-1, parallel (getLength a) (\ i -> a!i + 5)))
+
+arrayInStructInStruct :: Data (Length, (Length, [Length])) -> Data (Length, (Length, [Length]))
+arrayInStructInStruct x = x
+
+fut1 :: Future (Data IntN) -> Future (Data IntN)
+fut1 x  = forLoop 20 x (\_ e -> future $ force $ await e)
+
+not1 :: Data Bool -> Data Bool
+not1 x = not x
+
+issue128_ex1 :: Data WordN -> Data WordN
+issue128_ex1 a = share (switch 45 [(1,10)] a) $ \b -> (1==a ? b $ a)
+
+issue128_ex2 :: Data WordN -> Data WordN
+issue128_ex2 a = share (switch 45 [(1,20)] a) $ \b -> (2==a ? b $ a)
+
+issue128_ex3 :: Data WordN -> Data WordN
+issue128_ex3 a = switch 45 [(1,10)] a + (2==a ? 2 $ a)
+
+noinline1 :: Data Bool -> Data Bool
+noinline1 x = noInline $ not x
+
+-- Test that foreign imports with result type `M ()` can be used as monadic
+-- actions. This expression cannot be created from the Feldspar front end.
+foreignEffect :: UT.UntypedFeld
+foreignEffect =
+    UT.In $ UT.App UT.Then void
+        [ alert
+        , UT.In $ UT.App UT.Bind void
+            [ getPos
+            , UT.In $ UT.Lambda pos $ UT.In $ UT.App UT.Then void
+                [ launchMissiles
+                , cleanUp
+                ]
+            ]
+        ]
+  where
+    void   = UT.MutType (UT.TupType [])
+    pos    = UT.Var 77 (1 UT.:# UT.FloatType) B.empty
+    alert  = UT.In $ UT.App (UT.ForeignImport "alert") void []
+    getPos = UT.In $ UT.App (UT.ForeignImport "getPos") (1 UT.:# UT.FloatType) []
+    launchMissiles = UT.In $ UT.App (UT.ForeignImport "launchMissiles") void [UT.In $ UT.Variable pos]
+    cleanUp = UT.In $ UT.App (UT.ForeignImport "cleanUp") void []
+
+tuples :: Data Int32 -> Data Int32
+tuples a =
+    share (a,a*3) $ \(a1,a2) ->
+      share (a1+a2,a2+a1,a2) $ \(b1,b2,b3) ->
+        share (b1+b2,b2+b3,b3+b1,b3) $ \(c1,c2,c3,c4) ->
+          share (c1+c2,c2+c3,c3+c4,c4+c1,c4) $ \(d1,d2,d3,d4,d5) ->
+            share (d1+d2,d2+d3,d3+d4,d4+d5,d5+d1,d5) $ \(e1,e2,e3,e4,e5,e6) ->
+              share (e1+e2,e2+e3,e3+e4,e4+e5,e5+e6,e6+e1,e6) $ \(f1,f2,f3,f4,f5,f6,f7) ->
+                share (f1+f2,f2+f3,f3+f4,f4+f5,f5+f6,f6+f7,f7+f1,f1+f2,f2+f3,f3+f4,f4+f5,f5+f6,f6+f7,f7+f1,f7*f1) $ \(g1,g2,g3,g4,g5,g6,g7,g8,g9,g10,g11,g12,g13,g14,g15) ->
+                  g1+g2+g3+g4+g5+g6+g7+g8+g9+g10+g11+g12+g13+g14+g15
+
+loadFun ['tuples]
+
+deepArrayCopyTest :: Data [[[Length]]] -> (Data [[[Length]]], Data [[[Length]]])
+deepArrayCopyTest xs = (xs, xs)
+
+tests :: TestTree
+tests = testGroup "RegressionTests" [compilerTests, externalProgramTests]
+
+prop_concatV = forAll (vectorOf 3 (choose (0,5))) $ \ls ->
+                 forAll (mapM (\l -> vectorOf l arbitrary) ls) $ \xss ->
+                   Prelude.concat xss === c_concatV xss
+
+prop_concatVM = forAll (vectorOf 3 (choose (0,5))) $ \ls ->
+                  forAll (mapM (\l -> vectorOf l arbitrary) ls) $ \xss ->
+                    Prelude.concat xss === c_concatVM xss
+
+prop_divConq3 = forAll (choose (1,3)) $ \l ->
+                  forAll (vectorOf (l*1024) arbitrary) $ \xs ->
+                    map (+1) xs === c_divConq3 xs
+
+compilerTests :: TestTree
+compilerTests = testGroup "Compiler-RegressionTests"
+    [ testProperty "example9 (plugin)" $ eval example9 ==== c_example9
+    , testProperty "concatV (plugin)" prop_concatV
+    , testProperty "concatVM (plugin)" prop_concatVM
+    -- , testProperty "divConq3 (plugin)" prop_divConq3
+    , testProperty "bindToThen" (\y -> eval bindToThen y === y)
+    , testProperty "tuples (plugin)" $ eval tuples ==== c_tuples
+    , mkGoldTest example9 "example9" defaultOptions
+    , mkGoldTest pairParam "pairParam" defaultOptions
+    , mkGoldTest pairParam "pairParam_ret" nativeRetOpts
+    , mkGoldTest pairParam2 "pairParam2" defaultOptions
+    , mkGoldTest concatV "concatV" defaultOptions
+    , mkGoldTest concatVM "concatVM" defaultOptions
+    , mkGoldTest complexWhileCond "complexWhileCond" defaultOptions
+    , mkGoldTest topLevelConsts "topLevelConsts" defaultOptions
+    , mkGoldTest topLevelConsts "topLevelConsts_native" nativeOpts
+    , mkGoldTest topLevelConsts "topLevelConsts_sics" sicsOptions2
+    , mkGoldTest metrics "metrics" defaultOptions
+    , mkGoldTest scanlPush "scanlPush" defaultOptions
+    , mkGoldTest divConq3 "divConq3" defaultOptions
+    , mkGoldTest switcher "switcher" defaultOptions
+    , mkGoldTest ivartest "ivartest" defaultOptions
+    , mkGoldTest ivartest2 "ivartest2" defaultOptions
+    , mkGoldTest arrayInStruct "arrayInStruct" defaultOptions
+    , mkGoldTest arrayInStruct "arrayInStruct_wool" woolOpts
+    , mkGoldTest arrayInStruct "arrayInStruct_openMP" openMPOpts
+    , mkGoldTest arrayInStructInStruct "arrayInStructInStruct" defaultOptions
+    , mkGoldTest fut1 "fut1" defaultOptions
+    , mkGoldTest fut1 "fut1_ret" nativeRetOpts
+    , mkGoldTest not1 "not1" defaultOptions
+    , mkGoldTest not1 "not1_ret" nativeRetOpts
+    , mkGoldTest issue128_ex1 "issue128_ex1" defaultOptions
+    , mkGoldTest issue128_ex2 "issue128_ex2" defaultOptions
+    , mkGoldTest issue128_ex3 "issue128_ex3" defaultOptions
+    , mkGoldTest noinline1 "noinline1" defaultOptions
+    , mkGoldTestUT foreignEffect "foreignEffect" defaultOptions
+    , mkGoldTest tuples "tuples" defaultOptions
+    , mkGoldTest deepArrayCopyTest "deepArrayCopy" defaultOptions
+   -- Build tests.
+    , mkBuildTest pairParam "pairParam" defaultOptions
+    , mkBuildTest pairParam "pairParam_ret" nativeRetOpts
+    , mkBuildTest concatV "concatV" defaultOptions
+    , mkBuildTest concatVM "concatVM" defaultOptions
+    , mkBuildTest topLevelConsts "topLevelConsts" defaultOptions
+    , mkBuildTest topLevelConsts "topLevelConsts_native" nativeOpts
+    , mkBuildTest topLevelConsts "topLevelConsts_sics" sicsOptions2
+    , mkBuildTest metrics "metrics" defaultOptions
+    , mkBuildTest copyPush "copyPush" defaultOptions
+    , mkBuildTest scanlPush "scanlPush" defaultOptions
+    , mkBuildTest divConq3 "divConq3" defaultOptions
+    , mkBuildTest ivartest "ivartest" defaultOptions
+    , mkBuildTest ivartest2 "ivartest2" defaultOptions
+    , mkBuildTest arrayInStruct "arrayInStruct" defaultOptions
+    , mkBuildTest arrayInStructInStruct "arrayInStructInStruct" defaultOptions
+    , mkBuildTest fut1 "fut1" defaultOptions
+    , mkBuildTest fut1 "fut1_ret" nativeRetOpts
+    , mkBuildTest not1 "not1" defaultOptions
+    , mkBuildTest not1 "not1_ret" nativeRetOpts
+    , mkBuildTest issue128_ex1 "issue128_ex1" defaultOptions
+    , mkBuildTest issue128_ex2 "issue128_ex2" defaultOptions
+    , mkBuildTest issue128_ex3 "issue128_ex3" defaultOptions
+    , mkBuildTest noinline1 "noinline1" defaultOptions
+    , mkBuildTest tuples "tuples" defaultOptions
+    , mkBuildTest deepArrayCopyTest "deepArrayCopy" defaultOptions
+    ]
+
+externalProgramTests :: TestTree
+externalProgramTests = testGroup "ExternalProgram-RegressionTests"
+    [ mkParseTest "example9" defaultOptions
+    , mkParseTest "pairParam" defaultOptions
+    , mkParseTest "pairParam_ret" defaultOptions
+    , mkParseTest "pairParam2" defaultOptions
+    , mkParseTest "concatV" defaultOptions
+    , mkParseTest "concatVM" defaultOptions
+    , mkParseTest "complexWhileCond" defaultOptions
+    , mkParseTest "topLevelConsts" defaultOptions
+    , mkParseTest "topLevelConsts_native" nativeOpts
+    , mkParseTest "topLevelConsts_sics" sicsOptions
+    -- TODO: Enable with a typed array representation (both tests).
+    -- , mkParseTest "metrics" defaultOptions
+    -- , mkParseTest "scanlPush" defaultOptions
+    , mkParseTest "divConq3" defaultOptions
+    , mkParseTest "switcher" defaultOptions
+    , mkParseTest "ivartest" defaultOptions
+    , mkParseTest "ivartest2" defaultOptions
+    , mkParseTest "arrayInStruct" defaultOptions
+    , mkParseTest "arrayInStructInStruct" defaultOptions
+    , mkParseTest "not1" defaultOptions
+    , mkParseTest "not1_ret" defaultOptions
+    ]
+
+main :: IO ()
+main = defaultMain tests
+
+
+-- Helper functions
+testDir, goldDir :: Prelude.FilePath
+testDir = "tests/"
+goldDir = "tests/gold/"
+
+nativeOpts :: Options
+nativeOpts = defaultOptions{useNativeArrays=True}
+nativeRetOpts :: Options
+nativeRetOpts = defaultOptions{useNativeReturns=True}
+woolOpts :: Options
+woolOpts = sicsOptions3
+openMPOpts :: Options
+openMPOpts = c99OpenMpPlatformOptions
+
+writeGoldFile :: Syntax a => a -> Prelude.FilePath -> Options -> IO ()
+writeGoldFile fun n = compile fun (goldDir <> n) n
+
+-- | Make a golden test for a Feldspar expression
+mkGoldTest :: Syntactic a => a -> Prelude.FilePath -> Options -> TestTree
+mkGoldTest fun n opts = do
+    let ref = goldDir <> n
+        new = testDir <> n
+        act = compile fun new n opts
+        cmp = simpleCmp $ printf "Files '%s.{c,h}' and '%s.{c,h}' differ" ref new
+        upd = LB.writeFile ref
+    goldenTest n (vgReadFiles ref) (liftIO act >> vgReadFiles new) cmp upd
+
+-- | Make a golden test for an untyped Feldspar expression
+mkGoldTestUT :: UT.UntypedFeld -> Prelude.FilePath -> Options -> TestTree
+mkGoldTestUT untyped n opts = do
+    let ref = goldDir <> n
+        new = testDir <> n
+        act = compileUT untyped new n opts
+        cmp = simpleCmp $ printf "Files '%s.{c,h}' and '%s.{c,h}' differ" ref new
+        upd = LB.writeFile ref
+    goldenTest n (vgReadFiles ref) (liftIO act >> vgReadFiles new) cmp upd
+
+simpleCmp :: Prelude.Eq a => String -> a -> a -> IO (Maybe String)
+simpleCmp e x y =
+  return $ if x Prelude.== y then Nothing else Just e
+
+mkParseTest :: Prelude.FilePath -> Options -> TestTree
+mkParseTest n opts = do
+    let ref = goldDir <> n
+        new = testDir <> "ep-" <> n
+        act = compileFile ref new opts
+        cmp = fuzzyCmp $ printf "Files '%s.{c,h}' and '%s.{c,h}' differ" ref new
+        upd = LB.writeFile ref
+    goldenTest n (vgReadFiles ref) (liftIO act >> vgReadFiles new) cmp upd
+
+fuzzyCmp :: String -> LB.ByteString -> LB.ByteString -> IO (Maybe String)
+fuzzyCmp e x y =
+  return $ if x Prelude.== (filterEp y) then Nothing else Just e
+
+-- Removes "EP-"-related prefixes from the generated output.
+filterEp :: LB.ByteString -> LB.ByteString
+filterEp xs = LB.replace (B.pack "TESTS_EP-") (B.pack "TESTS_") xs'
+  where xs' = LB.replace (B.pack "#include \"ep-") (B.pack "#include \"") xs
+
+mkBuildTest :: Syntactic a => a -> Prelude.FilePath -> Options -> TestTree
+mkBuildTest fun n opts = do
+    let new = testDir <> n <> "_build_test"
+        cfile = new <> ".c"
+        act = do compile fun new n opts
+                 let ghcArgs = [cfile, "-c", "-optc -Iclib", "-optc -std=c99", "-Wall"]
+                 (ex,_,_) <- readProcessWithExitCode "ghc" ghcArgs ""
+                 case ex of
+                   ExitFailure e -> Prelude.error (show ex)
+                   _ -> return ()
+        cmp _ _ = return Nothing
+        upd _ = return ()
+    goldenTest n (return "") (liftIO act >> return "") cmp upd

--- a/tests/gold/arrayInStruct.c
+++ b/tests/gold/arrayInStruct.c
@@ -1,0 +1,35 @@
+#include "arrayInStruct.h"
+
+
+void arrayInStruct(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out)
+{
+  struct s_2_unsignedS32_awl_unsignedS32 e10 = { 0 };
+  struct s_2_unsignedS32_awl_unsignedS32 v6 = { 0 };
+  uint32_t len11;
+  struct awl_unsignedS32 e12 = { 0 };
+  bool v3;
+  
+  (e10).member1 = (*v0).length;
+  ((e10).member2).buffer = initCopyArray(((e10).member2).buffer, ((e10).member2).length, sizeof(uint32_t), (*v0).buffer, (*v0).length);
+  ((e10).member2).length = (*v0).length;
+  v3 = ((e10).member1 > 0);
+  while (v3)
+  {
+    (v6).member1 = ((e10).member1 - 1);
+    len11 = ((e10).member2).length;
+    ((v6).member2).buffer = initArray(((v6).member2).buffer, ((v6).member2).length, sizeof(uint32_t), len11);
+    ((v6).member2).length = len11;
+    for (uint32_t v9 = 0; v9 < len11; v9 += 1)
+    {
+      ((v6).member2).buffer[v9] = (((e10).member2).buffer[v9] + 5);
+    }
+    e12 = (e10).member2;
+    e10 = v6;
+    (v6).member2 = e12;
+    v3 = ((e10).member1 > 0);
+  }
+  (*out).buffer = initCopyArray((*out).buffer, (*out).length, sizeof(uint32_t), ((e10).member2).buffer, ((e10).member2).length);
+  (*out).length = ((e10).member2).length;
+  freeArray(((e10).member2).buffer);
+  freeArray(((v6).member2).buffer);
+}

--- a/tests/gold/arrayInStruct.h
+++ b/tests/gold/arrayInStruct.h
@@ -1,0 +1,30 @@
+#ifndef TESTS_ARRAYINSTRUCT_H
+#define TESTS_ARRAYINSTRUCT_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_unsignedS32
+{
+  uint32_t * buffer;
+  uint32_t length;
+};
+
+struct s_2_unsignedS32_awl_unsignedS32
+{
+  uint32_t member1;
+  struct awl_unsignedS32 member2;
+};
+
+void arrayInStruct(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out);
+
+#endif // TESTS_ARRAYINSTRUCT_H

--- a/tests/gold/arrayInStructInStruct.c
+++ b/tests/gold/arrayInStructInStruct.c
@@ -1,0 +1,10 @@
+#include "arrayInStructInStruct.h"
+
+
+void arrayInStructInStruct(struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * v0, struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * out)
+{
+  (*out).member1 = (*v0).member1;
+  ((*out).member2).member1 = ((*v0).member2).member1;
+  (((*out).member2).member2).buffer = initCopyArray((((*out).member2).member2).buffer, (((*out).member2).member2).length, sizeof(uint32_t), (((*v0).member2).member2).buffer, (((*v0).member2).member2).length);
+  (((*out).member2).member2).length = (((*v0).member2).member2).length;
+}

--- a/tests/gold/arrayInStructInStruct.h
+++ b/tests/gold/arrayInStructInStruct.h
@@ -1,0 +1,36 @@
+#ifndef TESTS_ARRAYINSTRUCTINSTRUCT_H
+#define TESTS_ARRAYINSTRUCTINSTRUCT_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_unsignedS32
+{
+  uint32_t * buffer;
+  uint32_t length;
+};
+
+struct s_2_unsignedS32_awl_unsignedS32
+{
+  uint32_t member1;
+  struct awl_unsignedS32 member2;
+};
+
+struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32
+{
+  uint32_t member1;
+  struct s_2_unsignedS32_awl_unsignedS32 member2;
+};
+
+void arrayInStructInStruct(struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * v0, struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * out);
+
+#endif // TESTS_ARRAYINSTRUCTINSTRUCT_H

--- a/tests/gold/arrayInStruct_openMP.c
+++ b/tests/gold/arrayInStruct_openMP.c
@@ -1,0 +1,37 @@
+#include "arrayInStruct_openMP.h"
+
+
+void arrayInStruct__openMP(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out)
+{
+  struct s_2_unsignedS32_awl_unsignedS32 e10 = { 0 };
+  struct s_2_unsignedS32_awl_unsignedS32 v6 = { 0 };
+  bool v3;
+  
+  (e10).member1 = (*v0).length;
+  ((e10).member2).buffer = initCopyArray(((e10).member2).buffer, ((e10).member2).length, sizeof(uint32_t), (*v0).buffer, (*v0).length);
+  ((e10).member2).length = (*v0).length;
+  v3 = ((e10).member1 > 0);
+  while (v3)
+  {
+    uint32_t len11;
+    struct awl_unsignedS32 e12 = { 0 };
+    
+    (v6).member1 = ((e10).member1 - 1);
+    len11 = ((e10).member2).length;
+    ((v6).member2).buffer = initArray(((v6).member2).buffer, ((v6).member2).length, sizeof(uint32_t), len11);
+    ((v6).member2).length = len11;
+    #pragma omp parallel for
+    for (uint32_t v9 = 0; v9 < len11; v9 += 1)
+    {
+      ((v6).member2).buffer[v9] = (((e10).member2).buffer[v9] + 5);
+    }
+    e12 = (e10).member2;
+    e10 = v6;
+    (v6).member2 = e12;
+    v3 = ((e10).member1 > 0);
+  }
+  (*out).buffer = initCopyArray((*out).buffer, (*out).length, sizeof(uint32_t), ((e10).member2).buffer, ((e10).member2).length);
+  (*out).length = ((e10).member2).length;
+  freeArray(((e10).member2).buffer);
+  freeArray(((v6).member2).buffer);
+}

--- a/tests/gold/arrayInStruct_openMP.h
+++ b/tests/gold/arrayInStruct_openMP.h
@@ -1,0 +1,30 @@
+#ifndef TESTS_ARRAYINSTRUCT_OPENMP_H
+#define TESTS_ARRAYINSTRUCT_OPENMP_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_unsignedS32
+{
+  uint32_t * buffer;
+  uint32_t length;
+};
+
+struct s_2_unsignedS32_awl_unsignedS32
+{
+  uint32_t member1;
+  struct awl_unsignedS32 member2;
+};
+
+void arrayInStruct__openMP(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out);
+
+#endif // TESTS_ARRAYINSTRUCT_OPENMP_H

--- a/tests/gold/arrayInStruct_wool.c
+++ b/tests/gold/arrayInStruct_wool.c
@@ -1,0 +1,45 @@
+#include "arrayInStruct_wool.h"
+
+
+LOOP_BODY_2(wool0,
+            LARGE_BODY,
+            uint32_t,
+            v9,
+            struct s_2_unsignedS32_awl_unsignedS32,
+            e10,
+            struct s_2_unsignedS32_awl_unsignedS32,
+            v6)
+{
+  ((v6).member2).buffer[v9] = (((e10).member2).buffer[v9] + 5);
+}
+
+void arrayInStruct__wool(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out)
+{
+  struct s_2_unsignedS32_awl_unsignedS32 e10 = { 0 };
+  struct s_2_unsignedS32_awl_unsignedS32 v6 = { 0 };
+  bool v3;
+  
+  (e10).member1 = (*v0).length;
+  ((e10).member2).buffer = initCopyArray(((e10).member2).buffer, ((e10).member2).length, sizeof(uint32_t), (*v0).buffer, (*v0).length);
+  ((e10).member2).length = (*v0).length;
+  v3 = ((e10).member1 > 0);
+  while (v3)
+  {
+    uint32_t len11;
+    struct awl_unsignedS32 e12 = { 0 };
+    
+    (v6).member1 = ((e10).member1 - 1);
+    len11 = ((e10).member2).length;
+    ((v6).member2).buffer = initArray(((v6).member2).buffer, ((v6).member2).length, sizeof(uint32_t), len11);
+    ((v6).member2).length = len11;
+    FOR(wool0, 0, len11, e10, v6);
+    e12 = (e10).member2;
+    e10 = v6;
+    (v6).member2 = e12;
+    v3 = ((e10).member1 > 0);
+  }
+  (*out).buffer = initCopyArray((*out).buffer, (*out).length, sizeof(uint32_t), ((e10).member2).buffer, ((e10).member2).length);
+  (*out).length = ((e10).member2).length;
+  freeArray(((e10).member2).buffer);
+  freeArray(((v6).member2).buffer);
+}

--- a/tests/gold/arrayInStruct_wool.h
+++ b/tests/gold/arrayInStruct_wool.h
@@ -1,0 +1,31 @@
+#ifndef TESTS_ARRAYINSTRUCT_WOOL_H
+#define TESTS_ARRAYINSTRUCT_WOOL_H
+
+#include "wool.h"
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_unsignedS32
+{
+  uint32_t * buffer;
+  uint32_t length;
+};
+
+struct s_2_unsignedS32_awl_unsignedS32
+{
+  uint32_t member1;
+  struct awl_unsignedS32 member2;
+};
+
+void arrayInStruct__wool(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out);
+
+#endif // TESTS_ARRAYINSTRUCT_WOOL_H

--- a/tests/gold/complexWhileCond.c
+++ b/tests/gold/complexWhileCond.c
@@ -1,0 +1,27 @@
+#include "complexWhileCond.h"
+
+
+void complexWhileCond(int32_t v0, struct s_2_signedS32_signedS32 * out)
+{
+  struct s_2_signedS32_signedS32 e10 = { 0 };
+  struct s_2_signedS32_signedS32 v9 = { 0 };
+  int32_t v3;
+  int32_t v5;
+  bool v2;
+  
+  (e10).member1 = 0;
+  (e10).member2 = v0;
+  v3 = (e10).member1;
+  v5 = ((e10).member2 - v3);
+  v2 = ((v3 * v3) != (v5 * v5));
+  while (v2)
+  {
+    (v9).member1 = ((e10).member1 + 1);
+    (v9).member2 = (e10).member2;
+    e10 = v9;
+    v3 = (e10).member1;
+    v5 = ((e10).member2 - v3);
+    v2 = ((v3 * v3) != (v5 * v5));
+  }
+  *out = e10;
+}

--- a/tests/gold/complexWhileCond.h
+++ b/tests/gold/complexWhileCond.h
@@ -1,0 +1,24 @@
+#ifndef TESTS_COMPLEXWHILECOND_H
+#define TESTS_COMPLEXWHILECOND_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct s_2_signedS32_signedS32
+{
+  int32_t member1;
+  int32_t member2;
+};
+
+void complexWhileCond(int32_t v0, struct s_2_signedS32_signedS32 * out);
+
+#endif // TESTS_COMPLEXWHILECOND_H

--- a/tests/gold/concatV.c
+++ b/tests/gold/concatV.c
@@ -1,0 +1,46 @@
+#include "concatV.h"
+
+
+void concatV(struct awl_awl_signedS32 * v1, struct awl_signedS32 * out)
+{
+  struct awl_signedS32 v26 = { 0 };
+  uint32_t len31;
+  struct awl_signedS32 v6 = { 0 };
+  uint32_t v11;
+  uint32_t v9;
+  uint32_t len32;
+  struct awl_signedS32 e33 = { 0 };
+  uint32_t v27;
+  
+  len31 = (*v1).length;
+  (v26).buffer = initArray((v26).buffer, (v26).length, sizeof(int32_t), 0);
+  (v26).length = 0;
+  for (uint32_t v5 = 0; v5 < len31; v5 += 1)
+  {
+    v11 = (v26).length;
+    v9 = ((*v1).buffer[v5]).length;
+    len32 = (v11 + v9);
+    (v6).buffer = initArray((v6).buffer, (v6).length, sizeof(int32_t), len32);
+    (v6).length = len32;
+    for (uint32_t v16 = 0; v16 < v11; v16 += 1)
+    {
+      (v6).buffer[v16] = (v26).buffer[v16];
+    }
+    for (uint32_t v20 = 0; v20 < v9; v20 += 1)
+    {
+      (v6).buffer[(v20 + v11)] = ((*v1).buffer[v5]).buffer[v20];
+    }
+    e33 = v26;
+    v26 = v6;
+    v6 = e33;
+  }
+  v27 = (v26).length;
+  (*out).buffer = initArray((*out).buffer, (*out).length, sizeof(int32_t), v27);
+  (*out).length = v27;
+  for (uint32_t v30 = 0; v30 < v27; v30 += 1)
+  {
+    (*out).buffer[v30] = (v26).buffer[v30];
+  }
+  freeArray((v26).buffer);
+  freeArray((v6).buffer);
+}

--- a/tests/gold/concatV.h
+++ b/tests/gold/concatV.h
@@ -1,0 +1,30 @@
+#ifndef TESTS_CONCATV_H
+#define TESTS_CONCATV_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_signedS32
+{
+  int32_t * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_signedS32
+{
+  struct awl_signedS32 * buffer;
+  uint32_t length;
+};
+
+void concatV(struct awl_awl_signedS32 * v1, struct awl_signedS32 * out);
+
+#endif // TESTS_CONCATV_H

--- a/tests/gold/concatVM.c
+++ b/tests/gold/concatVM.c
@@ -1,0 +1,39 @@
+#include "concatVM.h"
+
+
+void concatVM(struct awl_awl_signedS32 * v1, struct awl_signedS32 * out)
+{
+  uint32_t len22;
+  struct awl_signedS32 e23 = { 0 };
+  struct awl_signedS32 v7 = { 0 };
+  uint32_t v12;
+  uint32_t v10;
+  uint32_t len24;
+  struct awl_signedS32 e25 = { 0 };
+  
+  len22 = (*v1).length;
+  e23 = *out;
+  (e23).buffer = initArray((e23).buffer, (e23).length, sizeof(int32_t), 0);
+  (e23).length = 0;
+  for (uint32_t v6 = 0; v6 < len22; v6 += 1)
+  {
+    v12 = (e23).length;
+    v10 = ((*v1).buffer[v6]).length;
+    len24 = (v12 + v10);
+    (v7).buffer = initArray((v7).buffer, (v7).length, sizeof(int32_t), len24);
+    (v7).length = len24;
+    for (uint32_t v17 = 0; v17 < v12; v17 += 1)
+    {
+      (v7).buffer[v17] = (e23).buffer[v17];
+    }
+    for (uint32_t v21 = 0; v21 < v10; v21 += 1)
+    {
+      (v7).buffer[(v21 + v12)] = ((*v1).buffer[v6]).buffer[v21];
+    }
+    e25 = e23;
+    e23 = v7;
+    v7 = e25;
+  }
+  *out = e23;
+  freeArray((v7).buffer);
+}

--- a/tests/gold/concatVM.h
+++ b/tests/gold/concatVM.h
@@ -1,0 +1,30 @@
+#ifndef TESTS_CONCATVM_H
+#define TESTS_CONCATVM_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_signedS32
+{
+  int32_t * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_signedS32
+{
+  struct awl_signedS32 * buffer;
+  uint32_t length;
+};
+
+void concatVM(struct awl_awl_signedS32 * v1, struct awl_signedS32 * out);
+
+#endif // TESTS_CONCATVM_H

--- a/tests/gold/deepArrayCopy.c
+++ b/tests/gold/deepArrayCopy.c
@@ -1,0 +1,128 @@
+#include "deepArrayCopy.h"
+
+
+struct awl_awl_unsignedS32 * copyArrayPos_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, int32_t dstLen, struct awl_awl_unsignedS32 * src, int32_t srcLen, int32_t pos)
+{
+  for (int32_t i = 0; i < srcLen; i += 1)
+  {
+    (dst[(pos + i)]).buffer = initCopyArray_awl_unsignedS32((dst[(pos + i)]).buffer, (dst[(pos + i)]).length, (src[i]).buffer, (src[i]).length);
+    (dst[(pos + i)]).length = (src[i]).length;
+  }
+  return(dst);
+}
+
+struct awl_awl_unsignedS32 * copyArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, int32_t dstLen, struct awl_awl_unsignedS32 * src, int32_t srcLen)
+{
+  dst = copyArrayPos_awl_awl_unsignedS32(dst, dstLen, src, srcLen, 0);
+  return(dst);
+}
+
+struct awl_awl_unsignedS32 * initCopyArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, int32_t dstLen, struct awl_awl_unsignedS32 * src, int32_t srcLen)
+{
+  dst = initArray_awl_awl_unsignedS32(dst, dstLen, srcLen);
+  dstLen = srcLen;
+  dst = copyArrayPos_awl_awl_unsignedS32(dst, dstLen, src, srcLen, 0);
+  return(dst);
+}
+
+struct awl_unsignedS32 * copyArrayPos_awl_unsignedS32(struct awl_unsignedS32 * dst, int32_t dstLen, struct awl_unsignedS32 * src, int32_t srcLen, int32_t pos)
+{
+  for (int32_t i = 0; i < srcLen; i += 1)
+  {
+    (dst[(pos + i)]).buffer = initCopyArray((dst[(pos + i)]).buffer, (dst[(pos + i)]).length, sizeof(uint32_t), (src[i]).buffer, (src[i]).length);
+    (dst[(pos + i)]).length = (src[i]).length;
+  }
+  return(dst);
+}
+
+struct awl_unsignedS32 * copyArray_awl_unsignedS32(struct awl_unsignedS32 * dst, int32_t dstLen, struct awl_unsignedS32 * src, int32_t srcLen)
+{
+  dst = copyArrayPos_awl_unsignedS32(dst, dstLen, src, srcLen, 0);
+  return(dst);
+}
+
+struct awl_unsignedS32 * initCopyArray_awl_unsignedS32(struct awl_unsignedS32 * dst, int32_t dstLen, struct awl_unsignedS32 * src, int32_t srcLen)
+{
+  dst = initArray_awl_unsignedS32(dst, dstLen, srcLen);
+  dstLen = srcLen;
+  dst = copyArrayPos_awl_unsignedS32(dst, dstLen, src, srcLen, 0);
+  return(dst);
+}
+
+struct awl_awl_unsignedS32 * initArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, uint32_t oldLen, uint32_t newLen)
+{
+  if ((oldLen != newLen))
+  {
+    if ((oldLen < newLen))
+    {
+      dst = resizeArray(dst, sizeof(struct awl_awl_unsignedS32), newLen);
+      for (int32_t i = oldLen; i < newLen; i += 1)
+      {
+        struct awl_awl_unsignedS32 null_arr_0 = { 0 };
+        
+        dst[i] = null_arr_0;
+      }
+    }
+    else
+    {
+      for (int32_t i = newLen; i < oldLen; i += 1)
+      {
+        freeArray_awl_unsignedS32((dst[i]).buffer, (dst[i]).length);
+      }
+      dst = resizeArray(dst, sizeof(struct awl_awl_unsignedS32), newLen);
+    }
+  }
+  return(dst);
+}
+
+void freeArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * src, int32_t srcLen)
+{
+  for (int32_t i = 0; i < srcLen; i += 1)
+  {
+    freeArray_awl_unsignedS32((src[i]).buffer, (src[i]).length);
+  }
+  freeArray(src);
+}
+
+struct awl_unsignedS32 * initArray_awl_unsignedS32(struct awl_unsignedS32 * dst, uint32_t oldLen, uint32_t newLen)
+{
+  if ((oldLen != newLen))
+  {
+    if ((oldLen < newLen))
+    {
+      dst = resizeArray(dst, sizeof(struct awl_unsignedS32), newLen);
+      for (int32_t i = oldLen; i < newLen; i += 1)
+      {
+        struct awl_unsignedS32 null_arr_0 = { 0 };
+        
+        dst[i] = null_arr_0;
+      }
+    }
+    else
+    {
+      for (int32_t i = newLen; i < oldLen; i += 1)
+      {
+        freeArray((dst[i]).buffer);
+      }
+      dst = resizeArray(dst, sizeof(struct awl_unsignedS32), newLen);
+    }
+  }
+  return(dst);
+}
+
+void freeArray_awl_unsignedS32(struct awl_unsignedS32 * src, int32_t srcLen)
+{
+  for (int32_t i = 0; i < srcLen; i += 1)
+  {
+    freeArray((src[i]).buffer);
+  }
+  freeArray(src);
+}
+
+void deepArrayCopy(struct awl_awl_awl_unsignedS32 * v0, struct s_2_awl_awl_awl_unsignedS32_awl_awl_awl_unsignedS32 * out)
+{
+  ((*out).member1).buffer = initCopyArray_awl_awl_unsignedS32(((*out).member1).buffer, ((*out).member1).length, (*v0).buffer, (*v0).length);
+  ((*out).member1).length = (*v0).length;
+  ((*out).member2).buffer = initCopyArray_awl_awl_unsignedS32(((*out).member2).buffer, ((*out).member2).length, (*v0).buffer, (*v0).length);
+  ((*out).member2).length = (*v0).length;
+}

--- a/tests/gold/deepArrayCopy.h
+++ b/tests/gold/deepArrayCopy.h
@@ -1,0 +1,62 @@
+#ifndef TESTS_DEEPARRAYCOPY_H
+#define TESTS_DEEPARRAYCOPY_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_unsignedS32
+{
+  uint32_t * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_unsignedS32
+{
+  struct awl_unsignedS32 * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_awl_unsignedS32
+{
+  struct awl_awl_unsignedS32 * buffer;
+  uint32_t length;
+};
+
+struct s_2_awl_awl_awl_unsignedS32_awl_awl_awl_unsignedS32
+{
+  struct awl_awl_awl_unsignedS32 member1;
+  struct awl_awl_awl_unsignedS32 member2;
+};
+
+struct awl_awl_unsignedS32 * copyArrayPos_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, int32_t dstLen, struct awl_awl_unsignedS32 * src, int32_t srcLen, int32_t pos);
+
+struct awl_awl_unsignedS32 * copyArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, int32_t dstLen, struct awl_awl_unsignedS32 * src, int32_t srcLen);
+
+struct awl_awl_unsignedS32 * initCopyArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, int32_t dstLen, struct awl_awl_unsignedS32 * src, int32_t srcLen);
+
+struct awl_unsignedS32 * copyArrayPos_awl_unsignedS32(struct awl_unsignedS32 * dst, int32_t dstLen, struct awl_unsignedS32 * src, int32_t srcLen, int32_t pos);
+
+struct awl_unsignedS32 * copyArray_awl_unsignedS32(struct awl_unsignedS32 * dst, int32_t dstLen, struct awl_unsignedS32 * src, int32_t srcLen);
+
+struct awl_unsignedS32 * initCopyArray_awl_unsignedS32(struct awl_unsignedS32 * dst, int32_t dstLen, struct awl_unsignedS32 * src, int32_t srcLen);
+
+struct awl_awl_unsignedS32 * initArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * dst, uint32_t oldLen, uint32_t newLen);
+
+void freeArray_awl_awl_unsignedS32(struct awl_awl_unsignedS32 * src, int32_t srcLen);
+
+struct awl_unsignedS32 * initArray_awl_unsignedS32(struct awl_unsignedS32 * dst, uint32_t oldLen, uint32_t newLen);
+
+void freeArray_awl_unsignedS32(struct awl_unsignedS32 * src, int32_t srcLen);
+
+void deepArrayCopy(struct awl_awl_awl_unsignedS32 * v0, struct s_2_awl_awl_awl_unsignedS32_awl_awl_awl_unsignedS32 * out);
+
+#endif // TESTS_DEEPARRAYCOPY_H

--- a/tests/gold/divConq3.c
+++ b/tests/gold/divConq3.c
@@ -1,0 +1,89 @@
+#include "divConq3.h"
+
+
+void task_core0(uint32_t v8, uint32_t v3, struct awl_signedS32 * v1, struct awl_i_awl_signedS32 v24)
+{
+  uint32_t v9;
+  uint32_t v12;
+  struct awl_signedS32 e54 = { 0 };
+  
+  v9 = (v8 << 10);
+  v12 = min(1024, (v3 - v9));
+  (e54).buffer = initArray((e54).buffer, (e54).length, sizeof(int32_t), v12);
+  (e54).length = v12;
+  for (uint32_t v15 = 0; v15 < v12; v15 += 1)
+  {
+    (e54).buffer[v15] = ((*v1).buffer[(v15 + v9)] + 1);
+  }
+  ivar_put_array_shallow((v24).buffer[v8], &e54, sizeof(int32_t));
+}
+
+void task0(void * params)
+{
+  run4(task_core0, uint32_t, uint32_t, struct awl_signedS32 *, struct awl_i_awl_signedS32);
+}
+
+void divConq3(struct awl_signedS32 * v1, struct awl_signedS32 * out)
+{
+  uint32_t v3;
+  uint32_t v4;
+  struct awl_i_awl_signedS32 v24 = { 0 };
+  struct awl_signedS32 v49 = { 0 };
+  uint32_t len55;
+  struct awl_signedS32 v28 = { 0 };
+  uint32_t v34;
+  struct awl_signedS32 v31 = { 0 };
+  struct ivar e56;
+  uint32_t v32;
+  uint32_t len57;
+  struct awl_signedS32 e58 = { 0 };
+  uint32_t v50;
+  
+  taskpool_init(4, 4, 4);
+  v3 = (*v1).length;
+  v4 = (v3 >> 10);
+  (v24).buffer = initArray((v24).buffer, (v24).length, sizeof(struct ivar), v4);
+  (v24).length = v4;
+  for (uint32_t v8 = 0; v8 < v4; v8 += 1)
+  {
+    ivar_init(&(v24).buffer[v8]);
+    spawn4(task0, uint32_t, v8, uint32_t, v3, struct awl_signedS32 *, v1, struct awl_i_awl_signedS32, v24);
+  }
+  len55 = (v24).length;
+  (v49).buffer = initArray((v49).buffer, (v49).length, sizeof(int32_t), 0);
+  (v49).length = 0;
+  for (uint32_t v27 = 0; v27 < len55; v27 += 1)
+  {
+    v34 = (v49).length;
+    e56 = (v24).buffer[v27];
+    ivar_get_array_shallow_nontask(&v31, e56, sizeof(int32_t));
+    v32 = (v31).length;
+    len57 = (v34 + v32);
+    (v28).buffer = initArray((v28).buffer, (v28).length, sizeof(int32_t), len57);
+    (v28).length = len57;
+    for (uint32_t v39 = 0; v39 < v34; v39 += 1)
+    {
+      (v28).buffer[v39] = (v49).buffer[v39];
+    }
+    for (uint32_t v43 = 0; v43 < v32; v43 += 1)
+    {
+      (v28).buffer[(v43 + v34)] = (v31).buffer[v43];
+    }
+    e58 = v49;
+    v49 = v28;
+    v28 = e58;
+  }
+  v50 = (v49).length;
+  (*out).buffer = initArray((*out).buffer, (*out).length, sizeof(int32_t), v50);
+  (*out).length = v50;
+  for (uint32_t v53 = 0; v53 < v50; v53 += 1)
+  {
+    (*out).buffer[v53] = (v49).buffer[v53];
+  }
+  taskpool_shutdown();
+  freeArray((v24).buffer);
+  freeArray((v49).buffer);
+  freeArray((v28).buffer);
+  freeArray((v31).buffer);
+  ivar_destroy(&e56);
+}

--- a/tests/gold/divConq3.h
+++ b/tests/gold/divConq3.h
@@ -1,0 +1,34 @@
+#ifndef TESTS_DIVCONQ3_H
+#define TESTS_DIVCONQ3_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_i_awl_signedS32
+{
+  struct ivar * buffer;
+  uint32_t length;
+};
+
+struct awl_signedS32
+{
+  int32_t * buffer;
+  uint32_t length;
+};
+
+void task_core0(uint32_t v8, uint32_t v3, struct awl_signedS32 * v1, struct awl_i_awl_signedS32 v24);
+
+void task0(void * params);
+
+void divConq3(struct awl_signedS32 * v1, struct awl_signedS32 * out);
+
+#endif // TESTS_DIVCONQ3_H

--- a/tests/gold/example9.c
+++ b/tests/gold/example9.c
@@ -1,0 +1,17 @@
+#include "example9.h"
+
+
+void example9(int32_t v0, int32_t * out)
+{
+  int32_t v2;
+  
+  v2 = (v0 + 20);
+  if ((v0 < 5))
+  {
+    *out = (3 * v2);
+  }
+  else
+  {
+    *out = (30 * v2);
+  }
+}

--- a/tests/gold/example9.h
+++ b/tests/gold/example9.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_EXAMPLE9_H
+#define TESTS_EXAMPLE9_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void example9(int32_t v0, int32_t * out);
+
+#endif // TESTS_EXAMPLE9_H

--- a/tests/gold/foreignEffect.c
+++ b/tests/gold/foreignEffect.c
@@ -1,0 +1,12 @@
+#include "foreignEffect.h"
+
+
+void foreignEffect(void * out)
+{
+  float v77;
+  
+  alert();
+  v77 = getPos();
+  launchMissiles(v77);
+  *out = cleanUp();
+}

--- a/tests/gold/foreignEffect.h
+++ b/tests/gold/foreignEffect.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_FOREIGNEFFECT_H
+#define TESTS_FOREIGNEFFECT_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void foreignEffect(void * out);
+
+#endif // TESTS_FOREIGNEFFECT_H

--- a/tests/gold/fut1.c
+++ b/tests/gold/fut1.c
@@ -1,0 +1,31 @@
+#include "fut1.h"
+
+
+void task_core0(struct ivar e3)
+{
+  int32_t e4;
+  
+  ivar_get(int32_t, &e4, e3);
+  ivar_put(int32_t, e3, &e4);
+}
+
+void task0(void * params)
+{
+  run1(task_core0, struct ivar);
+}
+
+void fut1(struct ivar v0, struct ivar * out)
+{
+  struct ivar e3;
+  
+  taskpool_init(4, 4, 4);
+  e3 = *out;
+  e3 = v0;
+  for (uint32_t v1 = 0; v1 < 20; v1 += 1)
+  {
+    ivar_init(&e3);
+    spawn1(task0, struct ivar, e3);
+  }
+  *out = e3;
+  taskpool_shutdown();
+}

--- a/tests/gold/fut1.h
+++ b/tests/gold/fut1.h
@@ -1,0 +1,22 @@
+#ifndef TESTS_FUT1_H
+#define TESTS_FUT1_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void task_core0(struct ivar e3);
+
+void task0(void * params);
+
+void fut1(struct ivar v0, struct ivar * out);
+
+#endif // TESTS_FUT1_H

--- a/tests/gold/fut1_ret.c
+++ b/tests/gold/fut1_ret.c
@@ -1,0 +1,31 @@
+#include "fut1_ret.h"
+
+
+void task_core0(struct ivar e3)
+{
+  int32_t e4;
+  
+  ivar_get(int32_t, &e4, e3);
+  ivar_put(int32_t, e3, &e4);
+}
+
+void task0(void * params)
+{
+  run1(task_core0, struct ivar);
+}
+
+void fut1__ret(struct ivar v0, struct ivar * out)
+{
+  struct ivar e3;
+  
+  taskpool_init(4, 4, 4);
+  e3 = *out;
+  e3 = v0;
+  for (uint32_t v1 = 0; v1 < 20; v1 += 1)
+  {
+    ivar_init(&e3);
+    spawn1(task0, struct ivar, e3);
+  }
+  *out = e3;
+  taskpool_shutdown();
+}

--- a/tests/gold/fut1_ret.h
+++ b/tests/gold/fut1_ret.h
@@ -1,0 +1,22 @@
+#ifndef TESTS_FUT1_RET_H
+#define TESTS_FUT1_RET_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void task_core0(struct ivar e3);
+
+void task0(void * params);
+
+void fut1__ret(struct ivar v0, struct ivar * out);
+
+#endif // TESTS_FUT1_RET_H

--- a/tests/gold/issue128_ex1.c
+++ b/tests/gold/issue128_ex1.c
@@ -1,0 +1,24 @@
+#include "issue128_ex1.h"
+
+
+void issue128__ex1(uint32_t v0, uint32_t * out)
+{
+  bool v1;
+  
+  v1 = (1 == v0);
+  if (v1)
+  {
+    if (v1)
+    {
+      *out = 10;
+    }
+    else
+    {
+      *out = 45;
+    }
+  }
+  else
+  {
+    *out = v0;
+  }
+}

--- a/tests/gold/issue128_ex1.h
+++ b/tests/gold/issue128_ex1.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_ISSUE128_EX1_H
+#define TESTS_ISSUE128_EX1_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void issue128__ex1(uint32_t v0, uint32_t * out);
+
+#endif // TESTS_ISSUE128_EX1_H

--- a/tests/gold/issue128_ex2.c
+++ b/tests/gold/issue128_ex2.c
@@ -1,0 +1,22 @@
+#include "issue128_ex2.h"
+
+
+void issue128__ex2(uint32_t v0, uint32_t * out)
+{
+  if ((2 == v0))
+  {
+    switch (v0)
+    {
+      case 1:
+        *out = 20;
+        break;
+      default:
+        *out = 45;
+        break;
+    }
+  }
+  else
+  {
+    *out = v0;
+  }
+}

--- a/tests/gold/issue128_ex2.h
+++ b/tests/gold/issue128_ex2.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_ISSUE128_EX2_H
+#define TESTS_ISSUE128_EX2_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void issue128__ex2(uint32_t v0, uint32_t * out);
+
+#endif // TESTS_ISSUE128_EX2_H

--- a/tests/gold/issue128_ex3.c
+++ b/tests/gold/issue128_ex3.c
@@ -1,0 +1,27 @@
+#include "issue128_ex3.h"
+
+
+void issue128__ex3(uint32_t v0, uint32_t * out)
+{
+  uint32_t e1;
+  uint32_t e2;
+  
+  switch (v0)
+  {
+    case 1:
+      e1 = 10;
+      break;
+    default:
+      e1 = 45;
+      break;
+  }
+  if ((2 == v0))
+  {
+    e2 = 2;
+  }
+  else
+  {
+    e2 = v0;
+  }
+  *out = (e1 + e2);
+}

--- a/tests/gold/issue128_ex3.h
+++ b/tests/gold/issue128_ex3.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_ISSUE128_EX3_H
+#define TESTS_ISSUE128_EX3_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void issue128__ex3(uint32_t v0, uint32_t * out);
+
+#endif // TESTS_ISSUE128_EX3_H

--- a/tests/gold/ivartest.c
+++ b/tests/gold/ivartest.c
@@ -1,0 +1,29 @@
+#include "ivartest.h"
+
+
+void task_core0(uint32_t v0, struct ivar e2)
+{
+  uint32_t e3;
+  
+  e3 = (v0 + 1);
+  ivar_put(uint32_t, e2, &e3);
+}
+
+void task0(void * params)
+{
+  run2(task_core0, uint32_t, struct ivar);
+}
+
+void ivartest(uint32_t v0, uint32_t * out)
+{
+  uint32_t e1;
+  struct ivar e2;
+  
+  taskpool_init(4, 4, 4);
+  ivar_init(&e2);
+  spawn2(task0, uint32_t, v0, struct ivar, e2);
+  ivar_get_nontask(uint32_t, &e1, e2);
+  *out = (e1 << 1);
+  taskpool_shutdown();
+  ivar_destroy(&e2);
+}

--- a/tests/gold/ivartest.h
+++ b/tests/gold/ivartest.h
@@ -1,0 +1,22 @@
+#ifndef TESTS_IVARTEST_H
+#define TESTS_IVARTEST_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void task_core0(uint32_t v0, struct ivar e2);
+
+void task0(void * params);
+
+void ivartest(uint32_t v0, uint32_t * out);
+
+#endif // TESTS_IVARTEST_H

--- a/tests/gold/ivartest2.c
+++ b/tests/gold/ivartest2.c
@@ -1,0 +1,24 @@
+#include "ivartest2.h"
+
+
+void task_core0(struct s_2_unsignedS32_unsignedS32 * v0, struct ivar e1)
+{
+  ivar_put(struct s_2_unsignedS32_unsignedS32, e1, &*v0);
+}
+
+void task0(void * params)
+{
+  run2(task_core0, struct s_2_unsignedS32_unsignedS32 *, struct ivar);
+}
+
+void ivartest2(struct s_2_unsignedS32_unsignedS32 * v0, struct s_2_unsignedS32_unsignedS32 * out)
+{
+  struct ivar e1;
+  
+  taskpool_init(4, 4, 4);
+  ivar_init(&e1);
+  spawn2(task0, struct s_2_unsignedS32_unsignedS32 *, v0, struct ivar, e1);
+  ivar_get_nontask(struct s_2_unsignedS32_unsignedS32, &*out, e1);
+  taskpool_shutdown();
+  ivar_destroy(&e1);
+}

--- a/tests/gold/ivartest2.h
+++ b/tests/gold/ivartest2.h
@@ -1,0 +1,28 @@
+#ifndef TESTS_IVARTEST2_H
+#define TESTS_IVARTEST2_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct s_2_unsignedS32_unsignedS32
+{
+  uint32_t member1;
+  uint32_t member2;
+};
+
+void task_core0(struct s_2_unsignedS32_unsignedS32 * v0, struct ivar e1);
+
+void task0(void * params);
+
+void ivartest2(struct s_2_unsignedS32_unsignedS32 * v0, struct s_2_unsignedS32_unsignedS32 * out);
+
+#endif // TESTS_IVARTEST2_H

--- a/tests/gold/metrics.c
+++ b/tests/gold/metrics.c
@@ -1,0 +1,85 @@
+#include "metrics.h"
+
+
+struct awl_signedS32 * initArray_awl_signedS32(struct awl_signedS32 * dst, uint32_t oldLen, uint32_t newLen)
+{
+  if ((oldLen != newLen))
+  {
+    if ((oldLen < newLen))
+    {
+      dst = resizeArray(dst, sizeof(struct awl_signedS32), newLen);
+      for (int32_t i = oldLen; i < newLen; i += 1)
+      {
+        struct awl_signedS32 null_arr_0 = { 0 };
+        
+        dst[i] = null_arr_0;
+      }
+    }
+    else
+    {
+      for (int32_t i = newLen; i < oldLen; i += 1)
+      {
+        freeArray((dst[i]).buffer);
+      }
+      dst = resizeArray(dst, sizeof(struct awl_signedS32), newLen);
+    }
+  }
+  return(dst);
+}
+
+void freeArray_awl_signedS32(struct awl_signedS32 * src, int32_t srcLen)
+{
+  for (int32_t i = 0; i < srcLen; i += 1)
+  {
+    freeArray((src[i]).buffer);
+  }
+  freeArray(src);
+}
+
+void metrics(struct awl_signedS32 * v1, struct awl_signedS32 * v2, struct awl_awl_s_2_unsignedS32_unsignedS32 * v3, struct awl_awl_signedS32 * out)
+{
+  uint32_t v10;
+  uint32_t v9;
+  struct awl_awl_signedS32 v33 = { 0 };
+  uint32_t v19;
+  struct awl_signedS32 st41 = { 0 };
+  struct awl_signedS32 * v14 = NULL;
+  uint32_t v37;
+  
+  v10 = (*v3).length;
+  v9 = (*v1).length;
+  (st41).buffer = initArray((st41).buffer, (st41).length, sizeof(int32_t), 8);
+  (st41).length = 8;
+  for (uint32_t v6 = 0; v6 < 8; v6 += 1)
+  {
+    (st41).buffer[v6] = -32678;
+  }
+  v14 = &st41;
+  (v33).buffer = initArray_awl_signedS32((v33).buffer, (v33).length, v10);
+  (v33).length = v10;
+  for (uint32_t v13 = 0; v13 < v10; v13 += 1)
+  {
+    v19 = min(((*v3).buffer[v13]).length, v9);
+    ((v33).buffer[v13]).buffer = initArray(((v33).buffer[v13]).buffer, ((v33).buffer[v13]).length, sizeof(int32_t), v19);
+    ((v33).buffer[v13]).length = v19;
+    for (uint32_t v24 = 0; v24 < v19; v24 += 1)
+    {
+      ((v33).buffer[v13]).buffer[v24] = (*v14).buffer[(((*v3).buffer[v13]).buffer[v24]).member1];
+    }
+    v14 = &(v33).buffer[v13];
+  }
+  (*out).buffer = initArray_awl_signedS32((*out).buffer, (*out).length, v10);
+  (*out).length = v10;
+  for (uint32_t v34 = 0; v34 < v10; v34 += 1)
+  {
+    v37 = ((v33).buffer[v34]).length;
+    ((*out).buffer[v34]).buffer = initArray(((*out).buffer[v34]).buffer, ((*out).buffer[v34]).length, sizeof(int32_t), v37);
+    ((*out).buffer[v34]).length = v37;
+    for (uint32_t v40 = 0; v40 < v37; v40 += 1)
+    {
+      ((*out).buffer[v34]).buffer[v40] = ((v33).buffer[v34]).buffer[v40];
+    }
+  }
+  freeArray_awl_signedS32((v33).buffer, (v33).length);
+  freeArray((st41).buffer);
+}

--- a/tests/gold/metrics.h
+++ b/tests/gold/metrics.h
@@ -1,0 +1,52 @@
+#ifndef TESTS_METRICS_H
+#define TESTS_METRICS_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_signedS32
+{
+  int32_t * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_signedS32
+{
+  struct awl_signedS32 * buffer;
+  uint32_t length;
+};
+
+struct s_2_unsignedS32_unsignedS32
+{
+  uint32_t member1;
+  uint32_t member2;
+};
+
+struct awl_s_2_unsignedS32_unsignedS32
+{
+  struct s_2_unsignedS32_unsignedS32 * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_s_2_unsignedS32_unsignedS32
+{
+  struct awl_s_2_unsignedS32_unsignedS32 * buffer;
+  uint32_t length;
+};
+
+struct awl_signedS32 * initArray_awl_signedS32(struct awl_signedS32 * dst, uint32_t oldLen, uint32_t newLen);
+
+void freeArray_awl_signedS32(struct awl_signedS32 * src, int32_t srcLen);
+
+void metrics(struct awl_signedS32 * v1, struct awl_signedS32 * v2, struct awl_awl_s_2_unsignedS32_unsignedS32 * v3, struct awl_awl_signedS32 * out);
+
+#endif // TESTS_METRICS_H

--- a/tests/gold/noinline1.c
+++ b/tests/gold/noinline1.c
@@ -1,0 +1,12 @@
+#include "noinline1.h"
+
+
+void noinline0(bool v0, bool * out)
+{
+  *out = !(v0);
+}
+
+void noinline1(bool v0, bool * out)
+{
+  noinline0(v0, out);
+}

--- a/tests/gold/noinline1.h
+++ b/tests/gold/noinline1.h
@@ -1,0 +1,20 @@
+#ifndef TESTS_NOINLINE1_H
+#define TESTS_NOINLINE1_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void noinline0(bool v0, bool * out);
+
+void noinline1(bool v0, bool * out);
+
+#endif // TESTS_NOINLINE1_H

--- a/tests/gold/not1.c
+++ b/tests/gold/not1.c
@@ -1,0 +1,7 @@
+#include "not1.h"
+
+
+void not1(bool v0, bool * out)
+{
+  *out = !(v0);
+}

--- a/tests/gold/not1.h
+++ b/tests/gold/not1.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_NOT1_H
+#define TESTS_NOT1_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void not1(bool v0, bool * out);
+
+#endif // TESTS_NOT1_H

--- a/tests/gold/not1_ret.c
+++ b/tests/gold/not1_ret.c
@@ -1,0 +1,10 @@
+#include "not1_ret.h"
+
+
+bool not1__ret(bool v0)
+{
+  bool out;
+  
+  out = !(v0);
+  return(out);
+}

--- a/tests/gold/not1_ret.h
+++ b/tests/gold/not1_ret.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_NOT1_RET_H
+#define TESTS_NOT1_RET_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+bool not1__ret(bool v0);
+
+#endif // TESTS_NOT1_RET_H

--- a/tests/gold/pairParam.c
+++ b/tests/gold/pairParam.c
@@ -1,0 +1,7 @@
+#include "pairParam.h"
+
+
+void pairParam(struct s_2_unsignedS32_unsignedS32 * v0, uint32_t * out)
+{
+  *out = (*v0).member1;
+}

--- a/tests/gold/pairParam.h
+++ b/tests/gold/pairParam.h
@@ -1,0 +1,24 @@
+#ifndef TESTS_PAIRPARAM_H
+#define TESTS_PAIRPARAM_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct s_2_unsignedS32_unsignedS32
+{
+  uint32_t member1;
+  uint32_t member2;
+};
+
+void pairParam(struct s_2_unsignedS32_unsignedS32 * v0, uint32_t * out);
+
+#endif // TESTS_PAIRPARAM_H

--- a/tests/gold/pairParam2.c
+++ b/tests/gold/pairParam2.c
@@ -1,0 +1,10 @@
+#include "pairParam2.h"
+
+
+void pairParam2(struct s_2_signedS16_signedS16 * v0, struct s_2_s_2_signedS16_signedS16_s_2_signedS16_signedS16 * out)
+{
+  ((*out).member1).member1 = (*v0).member1;
+  ((*out).member1).member2 = (*v0).member2;
+  ((*out).member2).member1 = (*v0).member1;
+  ((*out).member2).member2 = (*v0).member2;
+}

--- a/tests/gold/pairParam2.h
+++ b/tests/gold/pairParam2.h
@@ -1,0 +1,30 @@
+#ifndef TESTS_PAIRPARAM2_H
+#define TESTS_PAIRPARAM2_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct s_2_signedS16_signedS16
+{
+  int16_t member1;
+  int16_t member2;
+};
+
+struct s_2_s_2_signedS16_signedS16_s_2_signedS16_signedS16
+{
+  struct s_2_signedS16_signedS16 member1;
+  struct s_2_signedS16_signedS16 member2;
+};
+
+void pairParam2(struct s_2_signedS16_signedS16 * v0, struct s_2_s_2_signedS16_signedS16_s_2_signedS16_signedS16 * out);
+
+#endif // TESTS_PAIRPARAM2_H

--- a/tests/gold/pairParam_ret.c
+++ b/tests/gold/pairParam_ret.c
@@ -1,0 +1,10 @@
+#include "pairParam_ret.h"
+
+
+uint32_t pairParam__ret(struct s_2_unsignedS32_unsignedS32 * v0)
+{
+  uint32_t out;
+  
+  out = (*v0).member1;
+  return(out);
+}

--- a/tests/gold/pairParam_ret.h
+++ b/tests/gold/pairParam_ret.h
@@ -1,0 +1,24 @@
+#ifndef TESTS_PAIRPARAM_RET_H
+#define TESTS_PAIRPARAM_RET_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct s_2_unsignedS32_unsignedS32
+{
+  uint32_t member1;
+  uint32_t member2;
+};
+
+uint32_t pairParam__ret(struct s_2_unsignedS32_unsignedS32 * v0);
+
+#endif // TESTS_PAIRPARAM_RET_H

--- a/tests/gold/scanlPush.c
+++ b/tests/gold/scanlPush.c
@@ -1,0 +1,79 @@
+#include "scanlPush.h"
+
+
+struct awl_unsignedS32 * initArray_awl_unsignedS32(struct awl_unsignedS32 * dst, uint32_t oldLen, uint32_t newLen)
+{
+  if ((oldLen != newLen))
+  {
+    if ((oldLen < newLen))
+    {
+      dst = resizeArray(dst, sizeof(struct awl_unsignedS32), newLen);
+      for (int32_t i = oldLen; i < newLen; i += 1)
+      {
+        struct awl_unsignedS32 null_arr_0 = { 0 };
+        
+        dst[i] = null_arr_0;
+      }
+    }
+    else
+    {
+      for (int32_t i = newLen; i < oldLen; i += 1)
+      {
+        freeArray((dst[i]).buffer);
+      }
+      dst = resizeArray(dst, sizeof(struct awl_unsignedS32), newLen);
+    }
+  }
+  return(dst);
+}
+
+void freeArray_awl_unsignedS32(struct awl_unsignedS32 * src, int32_t srcLen)
+{
+  for (int32_t i = 0; i < srcLen; i += 1)
+  {
+    freeArray((src[i]).buffer);
+  }
+  freeArray(src);
+}
+
+void scanlPush(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * v1, struct awl_awl_unsignedS32 * out)
+{
+  uint32_t v9;
+  uint32_t v2;
+  struct awl_unsignedS32 v12 = { 0 };
+  uint32_t v15;
+  struct awl_unsignedS32 v23 = { 0 };
+  uint32_t v24;
+  struct awl_unsignedS32 e27 = { 0 };
+  
+  v9 = (*v1).length;
+  (*out).buffer = initArray_awl_unsignedS32((*out).buffer, (*out).length, v9);
+  (*out).length = v9;
+  v2 = (*v0).length;
+  (v12).buffer = initArray((v12).buffer, (v12).length, sizeof(uint32_t), v2);
+  (v12).length = v2;
+  for (uint32_t v4 = 0; v4 < v2; v4 += 1)
+  {
+    (v12).buffer[v4] = (*v0).buffer[v4];
+  }
+  for (uint32_t v13 = 0; v13 < v9; v13 += 1)
+  {
+    v15 = (v12).length;
+    (v12).buffer = initArray((v12).buffer, (v12).length, sizeof(uint32_t), v15);
+    (v12).length = v15;
+    (v23).buffer = initCopyArray((v23).buffer, (v23).length, sizeof(uint32_t), (v12).buffer, (v12).length);
+    (v23).length = (v12).length;
+    v24 = (v23).length;
+    (e27).buffer = initArray((e27).buffer, (e27).length, sizeof(uint32_t), v24);
+    (e27).length = v24;
+    for (uint32_t v26 = 0; v26 < v24; v26 += 1)
+    {
+      (e27).buffer[v26] = (v23).buffer[v26];
+    }
+    ((*out).buffer[v13]).buffer = initCopyArray(((*out).buffer[v13]).buffer, ((*out).buffer[v13]).length, sizeof(uint32_t), (e27).buffer, (e27).length);
+    ((*out).buffer[v13]).length = (e27).length;
+  }
+  freeArray((v12).buffer);
+  freeArray((v23).buffer);
+  freeArray((e27).buffer);
+}

--- a/tests/gold/scanlPush.h
+++ b/tests/gold/scanlPush.h
@@ -1,0 +1,34 @@
+#ifndef TESTS_SCANLPUSH_H
+#define TESTS_SCANLPUSH_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+struct awl_unsignedS32
+{
+  uint32_t * buffer;
+  uint32_t length;
+};
+
+struct awl_awl_unsignedS32
+{
+  struct awl_unsignedS32 * buffer;
+  uint32_t length;
+};
+
+struct awl_unsignedS32 * initArray_awl_unsignedS32(struct awl_unsignedS32 * dst, uint32_t oldLen, uint32_t newLen);
+
+void freeArray_awl_unsignedS32(struct awl_unsignedS32 * src, int32_t srcLen);
+
+void scanlPush(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * v1, struct awl_awl_unsignedS32 * out);
+
+#endif // TESTS_SCANLPUSH_H

--- a/tests/gold/switcher.c
+++ b/tests/gold/switcher.c
@@ -1,0 +1,18 @@
+#include "switcher.h"
+
+
+void switcher(uint8_t v0, bool v1, uint8_t * out)
+{
+  switch (v1)
+  {
+    case true:
+      *out = v0;
+      break;
+    case false:
+      *out = 2;
+      break;
+    default:
+      *out = 0;
+      break;
+  }
+}

--- a/tests/gold/switcher.h
+++ b/tests/gold/switcher.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_SWITCHER_H
+#define TESTS_SWITCHER_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void switcher(uint8_t v0, bool v1, uint8_t * out);
+
+#endif // TESTS_SWITCHER_H

--- a/tests/gold/topLevelConsts.c
+++ b/tests/gold/topLevelConsts.c
@@ -1,0 +1,17 @@
+#include "topLevelConsts.h"
+
+
+void topLevelConsts(uint32_t v1, uint32_t v2, uint32_t * out)
+{
+  uint32_t v5;
+  
+  v5 = (v2 + 5);
+  if ((v1 < 5))
+  {
+    *out = ((uint32_t[]){2, 3, 4, 5, 6})[v5];
+  }
+  else
+  {
+    *out = ((uint32_t[]){1, 2, 3, 4, 5})[v5];
+  }
+}

--- a/tests/gold/topLevelConsts.h
+++ b/tests/gold/topLevelConsts.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_TOPLEVELCONSTS_H
+#define TESTS_TOPLEVELCONSTS_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void topLevelConsts(uint32_t v1, uint32_t v2, uint32_t * out);
+
+#endif // TESTS_TOPLEVELCONSTS_H

--- a/tests/gold/topLevelConsts_native.c
+++ b/tests/gold/topLevelConsts_native.c
@@ -1,0 +1,17 @@
+#include "topLevelConsts_native.h"
+
+
+void topLevelConsts__native(uint32_t v1, uint32_t v2, uint32_t * out)
+{
+  uint32_t v5;
+  
+  v5 = (v2 + 5);
+  if ((v1 < 5))
+  {
+    *out = ((uint32_t[]){2, 3, 4, 5, 6})[v5];
+  }
+  else
+  {
+    *out = ((uint32_t[]){1, 2, 3, 4, 5})[v5];
+  }
+}

--- a/tests/gold/topLevelConsts_native.h
+++ b/tests/gold/topLevelConsts_native.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_TOPLEVELCONSTS_NATIVE_H
+#define TESTS_TOPLEVELCONSTS_NATIVE_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void topLevelConsts__native(uint32_t v1, uint32_t v2, uint32_t * out);
+
+#endif // TESTS_TOPLEVELCONSTS_NATIVE_H

--- a/tests/gold/topLevelConsts_sics.c
+++ b/tests/gold/topLevelConsts_sics.c
@@ -1,0 +1,17 @@
+#include "topLevelConsts_sics.h"
+
+
+void topLevelConsts__sics(uint32_t v1, uint32_t v2, uint32_t * out)
+{
+  uint32_t v5;
+  
+  v5 = (v2 + 5);
+  if ((v1 < 5))
+  {
+    *out = ((uint32_t[]){2, 3, 4, 5, 6})[v5];
+  }
+  else
+  {
+    *out = ((uint32_t[]){1, 2, 3, 4, 5})[v5];
+  }
+}

--- a/tests/gold/topLevelConsts_sics.h
+++ b/tests/gold/topLevelConsts_sics.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_TOPLEVELCONSTS_SICS_H
+#define TESTS_TOPLEVELCONSTS_SICS_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void topLevelConsts__sics(uint32_t v1, uint32_t v2, uint32_t * out);
+
+#endif // TESTS_TOPLEVELCONSTS_SICS_H

--- a/tests/gold/tuples.c
+++ b/tests/gold/tuples.c
@@ -1,0 +1,64 @@
+#include "tuples.h"
+
+
+void tuples(int32_t v0, int32_t * out)
+{
+  int32_t v1;
+  int32_t v7;
+  int32_t v13;
+  int32_t v23;
+  int32_t v6;
+  int32_t v15;
+  int32_t v22;
+  int32_t v36;
+  int32_t v14;
+  int32_t v24;
+  int32_t v33;
+  int32_t v51;
+  int32_t v25;
+  int32_t v35;
+  int32_t v49;
+  int32_t v68;
+  int32_t v37;
+  int32_t v48;
+  int32_t v34;
+  int32_t v46;
+  int32_t v67;
+  int32_t v47;
+  int32_t v66;
+  int32_t v64;
+  int32_t v50;
+  int32_t v63;
+  int32_t v62;
+  int32_t v61;
+  
+  v1 = (v0 * 3);
+  v7 = (v0 + v1);
+  v13 = (v1 + v7);
+  v23 = (v13 + v1);
+  v6 = (v1 + v0);
+  v15 = (v6 + v1);
+  v22 = (v15 + v13);
+  v36 = (v22 + v23);
+  v14 = (v7 + v6);
+  v24 = (v1 + v14);
+  v33 = (v23 + v24);
+  v51 = (v36 + v33);
+  v25 = (v14 + v15);
+  v35 = (v25 + v22);
+  v49 = (v35 + v36);
+  v68 = (v49 + v51);
+  v37 = (v1 + v25);
+  v48 = (v37 + v1);
+  v34 = (v24 + v1);
+  v46 = (v34 + v37);
+  v67 = (v46 + v48);
+  v47 = (v1 + v35);
+  v66 = (v47 + v1);
+  v64 = (v1 + v49);
+  v50 = (v33 + v34);
+  v63 = (v51 + v50);
+  v62 = (v50 + v46);
+  v61 = (v48 + v47);
+  *out = ((((((((((((((v68 + v63) + v62) + v67) + v61) + v66) + v64) + v68) + v63) + v62) + v67) + v61) + v66) + v64) + (v1 * v49));
+}

--- a/tests/gold/tuples.h
+++ b/tests/gold/tuples.h
@@ -1,0 +1,18 @@
+#ifndef TESTS_TUPLES_H
+#define TESTS_TUPLES_H
+
+#include "feldspar_c99.h"
+#include "feldspar_array.h"
+#include "feldspar_future.h"
+#include "ivar.h"
+#include "taskpool.h"
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <stdbool.h>
+#include <complex.h>
+
+
+void tuples(int32_t v0, int32_t * out);
+
+#endif // TESTS_TUPLES_H


### PR DESCRIPTION
This is a straightforward:

cp -a ../feldspar-compiler/{src,clib,test} .

coupled with some whitespace and hlint
fixes on top of that to bring the sources
from feldspar-compiler into feldspar-language.
The reason I squashed the whitespace and hlint
fixes in this commit is they are unlikely to break
anything so having additional whitespace commits
on top of this will just make it more tedious
to figure out that the relevant commit history
for an issue requires looking in feldspar-compiler.

The benchmarks in feldspar-compiler are not
imported in this commit since they depend
on the interaction with a custom cabal setup.
The changes in Setup.hs are imported but the
benchmarks remain in feldspar-compiler for now.