### PR TITLE
Remove values in Platform

### DIFF
--- a/src/Feldspar/Compiler/Backend/C/Options.hs
+++ b/src/Feldspar/Compiler/Backend/C/Options.hs
@@ -48,13 +48,10 @@ data Options = Options
 data Platform = Platform {
     name            :: String,
     types           :: [(Type, String)],
-    values          :: [(Type, ShowValue)],
     includes        :: [String],
     varFloating     :: Bool,
     codeGenerator   :: String
 } deriving Show
-
-type ShowValue = Constant () -> String
 
 -- * Renamer data types to avoid cyclic imports.
 

--- a/src/Feldspar/Compiler/Backend/C/Platforms.hs
+++ b/src/Feldspar/Compiler/Backend/C/Platforms.hs
@@ -69,11 +69,6 @@ c99 = Platform {
         , (1 :# ComplexType (1 :# FloatType),  "float complex")
         , (1 :# ComplexType (1 :# DoubleType), "double complex")
         ] ,
-    values =
-        [ (1 :# ComplexType (1 :# FloatType), \cx -> "(" ++ showRe cx ++ "+" ++ showIm cx ++ "i)")
-        , (1 :# ComplexType (1 :# DoubleType), \cx -> "(" ++ showRe cx ++ "+" ++ showIm cx ++ "i)")
-        , (1 :# BoolType, \b -> if boolValue b then "true" else "false")
-        ] ,
     includes =
         [ "feldspar_c99.h"
         , "feldspar_array.h"
@@ -125,25 +120,11 @@ tic64x = Platform {
         , (1 :# ComplexType (1 :# FloatType),  "complexOf_float")
         , (1 :# ComplexType (1 :# DoubleType), "complexOf_double")
         ] ,
-    values =
-        [ (1 :# ComplexType (1 :# FloatType), \cx -> "complex_fun_float(" ++ showRe cx ++ "," ++ showIm cx ++ ")")
-        , (1 :# ComplexType (1 :# DoubleType), \cx -> "complex_fun_double(" ++ showRe cx ++ "," ++ showIm cx ++ ")")
-        , (1 :# BoolType, \b -> if boolValue b then "1" else "0")
-        ] ,
     includes = [ "feldspar_tic64x.h", "feldspar_array.h", "<c6x.h>", "<string.h>"
                , "<math.h>"],
     varFloating = True,
     codeGenerator = "c"
 }
-
-showRe, showIm :: Constant t -> String
-showRe = showConstant . realPartComplexValue
-showIm = showConstant . imagPartComplexValue
-
-showConstant :: Constant t -> String
-showConstant (DoubleConst c) = show c ++ "f"
-showConstant (FloatConst c)  = show c ++ "f"
-showConstant c               = show c
 
 extend :: Platform -> String -> Type -> String
 extend Platform{..} s t = s ++ "_fun_" ++ fromMaybe (show t) (lookup t types)

--- a/src/Feldspar/Compiler/Plugin.hs
+++ b/src/Feldspar/Compiler/Plugin.hs
@@ -223,7 +223,4 @@ instance Lift Options where
         [| Options platform ph una unr frontopts sl ns |]
 
 instance Lift Platform where
-    lift (Platform n t vs is vf be) = [| Platform n t vs is vf be |]
-
-instance Lift (Constant () -> String) where
-    lift _ = [| error "No TH instance for ShowValue" |]
+    lift (Platform n t is vf be) = [| Platform n t is vf be |]


### PR DESCRIPTION
Print literals directly in CodeGen.hs instead.
This saves us a bogus Lift instance for a function
type.