### PR TITLE
cabal: remove base-compat dependency

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -291,6 +291,8 @@ test-suite regression
     tasty-quickcheck >= 0.3,
     QuickCheck       >= 2.7.1 && < 3.0
 
+  ghc-options: -threaded -with-rtsopts=-maxN4
+
 test-suite callconv
   type: exitcode-stdio-1.0
 
@@ -306,6 +308,8 @@ test-suite callconv
     tasty            >= 0.3,
     tasty-quickcheck >= 0.3,
     QuickCheck       >= 2.7.1 && < 3.0
+
+  ghc-options: -threaded -with-rtsopts=-maxN4
 
 custom-setup
   setup-depends:

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -110,7 +110,6 @@ library
   build-depends:
     array,
     base                        >= 4.9.1  && < 5.9,
-    base-compat                 >= 0.8,
     bytestring                  >= 0.10   && < 0.11,
     Cabal,
     containers                  >= 0.4    && < 0.7,


### PR DESCRIPTION
This is not required with the GHC versions we use.