### PR TITLE
Add new test output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@ cabal.sandbox.config
 *.hp
 .stack-work/
 
+tests/*.[hc]
 tests/*.txt
+tests/gold/ep-*.[hc]
+tests/gold/*_build_test.[hc]
+tmp


### PR DESCRIPTION
The tests in feldspar-compiler had some
gitignore lines for the generated output.
Reinstate those lines and add the parser
tests and build test outputs in this
gitignore.