### PR TITLE
Regenerate Onnx and update instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ cabal.sandbox.config
 *.aux
 *.hp
 .stack-work/
+src/Onnx.hs
 
 tests/*.[hc]
 tests/*.txt

--- a/src/Feldspar/Onnx/README
+++ b/src/Feldspar/Onnx/README
@@ -1,4 +1,6 @@
 The files in src/Onnx and its subdirectories are generated from the ONNX
 protobuf specification file 'onnx.proto' located in src/Feldspar/Onnx using
 the command 'hprotoc Feldspar/Onnx/onnx.proto' given from the src directory.
-The 'hprotoc' command comes from the 'protocol-buffers-2.4.12' package on Hackage.
+The generated file src/Onnx.hs is not committed.
+
+The 'hprotoc' command comes from the 'hprotoc-2.4.13' package on Hackage.

--- a/src/Onnx/AttributeProto.hs
+++ b/src/Onnx/AttributeProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.AttributeProto (AttributeProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/AttributeProto/AttributeType.hs
+++ b/src/Onnx/AttributeProto/AttributeType.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.AttributeProto.AttributeType (AttributeType(..)) where
 import Prelude ((+), (/), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/GraphProto.hs
+++ b/src/Onnx/GraphProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.GraphProto (GraphProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/ModelProto.hs
+++ b/src/Onnx/ModelProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.ModelProto (ModelProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/NodeProto.hs
+++ b/src/Onnx/NodeProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.NodeProto (NodeProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/NodeProto.hs-boot
+++ b/src/Onnx/NodeProto.hs-boot
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.NodeProto (NodeProto) where
 import qualified Prelude as Prelude'
 import qualified Data.Typeable as Prelude'

--- a/src/Onnx/OperatorSetIdProto.hs
+++ b/src/Onnx/OperatorSetIdProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.OperatorSetIdProto (OperatorSetIdProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/SparseTensorProto.hs
+++ b/src/Onnx/SparseTensorProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.SparseTensorProto (SparseTensorProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/StringStringEntryProto.hs
+++ b/src/Onnx/StringStringEntryProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.StringStringEntryProto (StringStringEntryProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorAnnotation.hs
+++ b/src/Onnx/TensorAnnotation.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorAnnotation (TensorAnnotation(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorProto.hs
+++ b/src/Onnx/TensorProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorProto (TensorProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorProto/DataLocation.hs
+++ b/src/Onnx/TensorProto/DataLocation.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorProto.DataLocation (DataLocation(..)) where
 import Prelude ((+), (/), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorProto/DataType.hs
+++ b/src/Onnx/TensorProto/DataType.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorProto.DataType (DataType(..)) where
 import Prelude ((+), (/), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorProto/Segment.hs
+++ b/src/Onnx/TensorProto/Segment.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorProto.Segment (Segment(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorShapeProto.hs
+++ b/src/Onnx/TensorShapeProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorShapeProto (TensorShapeProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorShapeProto/Dimension.hs
+++ b/src/Onnx/TensorShapeProto/Dimension.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorShapeProto.Dimension (Dimension(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TensorShapeProto/Dimension/Value.hs
+++ b/src/Onnx/TensorShapeProto/Dimension/Value.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TensorShapeProto.Dimension.Value where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TypeProto.hs
+++ b/src/Onnx/TypeProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TypeProto (TypeProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TypeProto.hs-boot
+++ b/src/Onnx/TypeProto.hs-boot
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TypeProto (TypeProto) where
 import qualified Prelude as Prelude'
 import qualified Data.Typeable as Prelude'

--- a/src/Onnx/TypeProto/Map.hs
+++ b/src/Onnx/TypeProto/Map.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TypeProto.Map (Map(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TypeProto/Sequence.hs
+++ b/src/Onnx/TypeProto/Sequence.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TypeProto.Sequence (Sequence(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TypeProto/Tensor.hs
+++ b/src/Onnx/TypeProto/Tensor.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TypeProto.Tensor (Tensor(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/TypeProto/Value.hs
+++ b/src/Onnx/TypeProto/Value.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.TypeProto.Value where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/ValueInfoProto.hs
+++ b/src/Onnx/ValueInfoProto.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.ValueInfoProto (ValueInfoProto(..)) where
 import Prelude ((+), (/), (++), (.))
 import qualified Prelude as Prelude'

--- a/src/Onnx/Version.hs
+++ b/src/Onnx/Version.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveGeneric, FlexibleInstances, MultiParamTypeClasses, OverloadedStrings #-}
-{-# OPTIONS_GHC  -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC  -w #-}
 module Onnx.Version (Version(..)) where
 import Prelude ((+), (/), (.))
 import qualified Prelude as Prelude'


### PR DESCRIPTION
This version avoids warnings in the generated code.

Also update the instructions to indicate that
one file should not be committed and that the package
that contains hprotoc is called hprotoc.