### PR TITLE
Import benchmarks from feldspar-compiler

### DIFF
--- a/benchs/BenchmarkUtils.hs
+++ b/benchs/BenchmarkUtils.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module BenchmarkUtils where
+
+import Feldspar.Compiler.Plugin (pack)
+import Control.Exception (evaluate)
+import Criterion.Main
+import Criterion.Types
+import Data.List (intercalate)
+
+mkConfig report = defaultConfig { reportFile = Just report }
+
+dimToString ls = intercalate "x" (map show ls)
+
+mkData ds ls = do
+  putStrLn $ unwords ["Alloc array with", dimToString ls, "elements"]
+  evaluate =<< pack (take (fromIntegral $ product ls) ds)
+
+mkData2 ds ls = do
+  putStrLn $ unwords ["Alloc array with", dimToString ls, "elements"]
+  evaluate =<< pack (ls, take (fromIntegral $ product ls) ds)
+
+mkBench name ls = bench (name ++ "_" ++ dimToString ls)

--- a/benchs/CRC.hs
+++ b/benchs/CRC.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+import Feldspar
+import Feldspar.Vector
+import Feldspar.Compiler.Plugin
+import Feldspar.Compiler.Marshal (SA(..))
+import Feldspar.Algorithm.CRC
+
+import Foreign.Ptr
+import Foreign.Marshal (malloc)
+import Control.DeepSeq (NFData(..),force)
+import Control.Exception (evaluate)
+
+import BenchmarkUtils
+import Criterion.Main
+
+len :: Length
+len = 16 * 1024
+
+testdata :: [Word8]
+testdata = Prelude.take (fromIntegral len) $ cycle [1,2,3,4]
+
+naive :: Pull1 Word8 -> Data Word16
+naive = crcNaive 0x8005 0
+
+normal :: Pull1 Word8 -> Data Word16
+normal v = share (makeCrcTable 0x8005) $ \t -> crcNormal t 0 v
+
+h_naive :: [Word8] -> Word16
+h_naive = eval naive
+loadFun ['naive]
+
+h_normal :: [Word8] -> Word16
+h_normal = eval normal
+loadFun ['normal]
+
+setupPlugins :: IO ()
+setupPlugins = do
+    putStrLn "Compiling plugins"
+    _  <- evaluate c_naive_builder
+    _  <- evaluate c_normal_builder
+    return ()
+
+setupData :: Length -> IO [Word8]
+setupData l = return $ Prelude.take (fromIntegral l) testdata
+
+setupRaw :: Length -> IO (Ptr Word16, Ptr (SA Word8))
+setupRaw l = do
+    o  <- malloc
+    pd <- pack (Prelude.take (fromIntegral l) testdata)
+    return (o, pd)
+
+main :: IO ()
+main =
+    defaultMainWith (mkConfig "report_crc.html")
+      [
+        env (setupData 1024) $ \d ->
+          bgroup "evaluated"
+            [ bench "h_naive"  $ nf h_naive  d
+            , bench "h_normal" $ nf h_normal d
+            ]
+      , env setupPlugins $ \_ -> bgroup "compiled"
+          [ env (setupData len) $ \d -> bgroup "marshal"
+              [ bench "c_naive"  $ whnfIO $ c_naive_worker d
+              , bench "c_normal" $ whnfIO $ c_normal_worker d
+              ]
+          , env (setupRaw len) $ \ ~(o, pd) -> bgroup "raw"
+              [ bench "c_naive"  $ whnfIO $ c_naive_raw pd o
+              , bench "c_normal" $ whnfIO $ c_normal_raw pd o
+              ]
+          ]
+      ]

--- a/benchs/FFT.hs
+++ b/benchs/FFT.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Main where
+
+import Feldspar (Length, Complex)
+import Feldspar.Algorithm.FFT
+import Feldspar.Compiler
+import Feldspar.Compiler.Plugin
+import Feldspar.Compiler.Marshal
+
+import Foreign.Ptr
+import Foreign.Marshal (new)
+import Control.DeepSeq (NFData(..))
+import Control.Exception (evaluate)
+
+import BenchmarkUtils
+import Criterion.Main
+
+testdata :: [Complex Float]
+testdata = cycle [1,2,3,4]
+
+loadFunOpts ["-optc=-O2"] ['fft]
+loadFunOpts ["-optc=-O2"] ['ifft]
+
+len :: Length
+len = 4096
+
+sizes :: [[Length]]
+sizes = map (map (*len)) [[1],[2],[4],[8]]
+
+setupPlugins :: IO ()
+setupPlugins = do
+    _ <- evaluate c_fft_builder
+    return ()
+
+setupData :: [Length] -> IO (Ptr (SA (Complex Float)), Ptr (SA (Complex Float)))
+setupData lengths = do
+    d <- mkData testdata lengths
+    ds <- allocSA $ fromIntegral $ product lengths :: IO (Ptr (SA (Complex Float)))
+    return (ds, d)
+
+mkComp :: [Length] -> Benchmark
+mkComp ls = env (setupData ls) $ \ ~(o, d) ->
+    mkBench "c_fft" ls (whnfIO $ c_fft_raw d o)
+
+main :: IO ()
+main = defaultMainWith (mkConfig "report_fft.html")
+    [ env setupPlugins $ \_ -> bgroup "compiled" $ map mkComp sizes
+    ]

--- a/benchs/FIR_Fusion.hs
+++ b/benchs/FIR_Fusion.hs
@@ -1,0 +1,63 @@
+-- This module implements FIR filters, and compositions of them.
+
+-- The generated code looks OK, but the use of `force` leads to different space/time
+-- characteristics.
+--
+-- In order to fuse filters without forcing the entire intermediate vector, one should use streams
+-- with a cyclic buffer; see example in the Stream library.
+
+import qualified Prelude
+import Feldspar
+import Feldspar.Vector
+import Feldspar.Matrix
+import Feldspar.Compiler
+
+
+
+causalMap :: Syntax a => (Vector a -> a) -> Vector a -> Vector a
+causalMap f = map (f . reverse) . inits
+
+-- | FIR filter
+fir
+    :: Vector1 Float  -- ^ Coefficients
+    -> Vector1 Float  -- ^ Input
+    -> Vector1 Float
+fir coeffs = causalMap (coeffs***)
+
+
+
+--------------------------------------------------------------------------------
+-- Composing filters
+
+composition boundary as bs = fir as . boundary . fir bs
+
+test1 :: Vector1 Float -> Vector1 Float -> Vector1 Float -> Vector1 Float
+test1 = composition id -:: newLen 10 >-> newLen 10 >-> newLen 100 >-> id
+  -- Loop structure:
+  --
+  --   parallel 100
+  --     forLoop 10
+  --       forLoop 10
+
+test2 :: Vector1 Float -> Vector1 Float -> Vector1 Float -> Vector1 Float
+test2 = composition force -:: newLen 10 >-> newLen 10 >-> newLen 100 >-> id
+  -- Loop structure:
+  --
+  --   parallel 100
+  --     forLoop 10
+  --   parallel 100
+  --     forLoop 10
+
+
+
+--------------------------------------------------------------------------------
+-- Filters with hard-coded coefficients
+
+composition2 boundary = fir (value [0.3,0.4,0.5,0.6]) . boundary . fir (value [0.3,-0.4,0.5,-0.6])
+
+test3 :: Vector1 Float -> Vector1 Float
+test3 = composition2 id -:: newLen 100 >-> id
+
+test4 :: Vector1 Float -> Vector1 Float
+test4 = composition2 force -:: newLen 100 >-> id
+

--- a/benchs/MatMul.hs
+++ b/benchs/MatMul.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Main where
+
+import Feldspar (Data(..), Length, WordN)
+import Feldspar.Vector (mmMult, Pull(..), DIM2)
+import Feldspar.Compiler
+import Feldspar.Compiler.Plugin (loadFunOpts, loadFunOptsWith, pack)
+import Feldspar.Compiler.Marshal (Marshal(..), SA(..), allocSA)
+
+import Foreign.Marshal (new,newArray,mallocArray)
+-- Terrible error messages if constructors are not imported. See
+-- https://ghc.haskell.org/trac/ghc/ticket/5610 for more information.
+import Foreign.C.Types (CInt(..), CDouble(..))
+import Foreign.Ptr (Ptr(..))
+import Control.DeepSeq (NFData(..))
+import Control.Exception (evaluate)
+
+import BenchmarkUtils
+import Criterion.Main
+
+testdata :: [Double]
+testdata = cycle [1.1,2.2,3.3,4.4]
+
+foreign import ccall unsafe "MatMulC.h MatMulC" matMulC :: CInt -> CInt -> Ptr CDouble -> Ptr CDouble -> Ptr CDouble -> IO ()
+
+foreign import ccall unsafe "MatMulC.h MatMulCopt" matMulCopt :: CInt -> CInt -> Ptr CDouble -> Ptr CDouble -> Ptr CDouble -> IO ()
+
+matmul :: Pull DIM2 (Data Double) -> Pull DIM2 (Data Double) -> Pull DIM2 (Data Double)
+matmul = mmMult True
+
+loadFunOpts ["-optc=-O2", "-optc=-fno-vectorize"] ['matmul]
+loadFunOptsWith "_sics" sicsOptions ["-optc=-O2", "-optc=-fno-vectorize"] ['matmul]
+
+len :: Length
+len = 64
+
+sizes :: [[Length]]
+sizes = map (map (*len)) [[1,1],[2,2],[4,4],[8,8]]
+
+setupPlugins = do
+    putStrLn "Compiling c_matmul plugin"
+    evaluate c_matmul_builder
+    evaluate c_matmul_sics_builder
+
+setupRefEnv :: [Length] -> IO (Ptr CDouble, Ptr CDouble)
+setupRefEnv ls = do
+    let len = fromIntegral $ product ls
+    let td  = take len (map realToFrac testdata)
+    o <- mallocArray len
+    d <- newArray td
+    return (o,d)
+
+-- FIXME: This type is probably misaligned with our array-representation.
+allocOut :: [Length] -> IO (Ptr (Ptr (SA Length), Ptr (SA Double)))
+allocOut lengths = do
+    ls <- pack lengths
+    ds <- allocSA $ fromIntegral $ product lengths :: IO (Ptr (SA Double))
+    new (ls,ds)
+
+setupCompEnv :: [Length] -> IO (Ptr (SA Length, Ptr (SA Double)))
+setupCompEnv ls = do
+    o <- allocOut ls
+    d <- mkData2 testdata ls
+    return (o,d)
+
+mkReferenceBench :: [Length] -> [Benchmark]
+mkReferenceBench ls =
+  [ env (setupRefEnv ls) $ \ ~(o,d) ->
+    bench "C/matmul" (whnfIO $ matMulC (fromIntegral $ head ls) (fromIntegral $ product ls) d d o)
+  , env (setupRefEnv ls) $ \ ~(o,d) ->
+    bench "C/matmul_opt" (whnfIO $ matMulCopt (fromIntegral $ head ls) (fromIntegral $ product ls) d d o)
+  ]
+
+mkCompiledBench :: [Length] -> [Benchmark]
+mkCompiledBench ls =
+  [ env (setupCompEnv ls) $ \ ~(o,d) ->
+    bench "Feldspar_C/matmul" (whnfIO $ c_matmul_raw d d o)
+  , env (setupCompEnv ls) $ \ ~(o,d) ->
+    bench "Feldspar_C/matmul_sics" (whnfIO $ c_matmul_sics_raw d d o)
+  ]
+
+-- | Create a benchmark that compares references and Feldspar for a specific
+--   input.
+mkComparison :: [Length] -> Benchmark
+mkComparison ls = bgroup (dimToString ls) $
+                    mkReferenceBench ls ++ mkCompiledBench ls
+
+main :: IO ()
+main = do
+    setupPlugins
+    defaultMainWith (mkConfig "report_matmul.html") $ map mkComparison sizes

--- a/benchs/MatMulC.c
+++ b/benchs/MatMulC.c
@@ -1,0 +1,51 @@
+#include <stdlib.h>
+#include "MatMulC.h"
+
+void MatMulC(int rows, int len, double *a, double *bin, double *c) {
+  double *b = malloc(len * sizeof(double));
+
+  // Transpose bin with result in b.
+  for (int n = 0; n < len; n++) {
+    b[n] = bin[rows * (n % rows) + (n / rows)];
+  }
+
+  for (int i = 0; i < rows; i++) {
+    for (int j = 0; j < rows; j++) {
+      double sum = 0.0;
+      for (int k = 0; k < rows; k++) {
+        sum += a[i*rows+k] * b[j*rows + k];
+      }
+      c[i*rows + j] = sum;
+    }
+  }
+
+  free(b);
+}
+
+/**
+ * Same code as above with middle loop unrolled once to improve the balance
+ * between computation and memory reads.
+ */
+void MatMulCopt(int rows, int len, double *a, double *bin, double *c) {
+  double *b = malloc(len * sizeof(double));
+
+  // Transpose bin with result in b.
+  for(int n = 0; n < len; n++ ) {
+    b[n] = bin[rows * (n % rows) + (n / rows)];
+  }
+
+  for (int i = 0; i < rows; i++)  {
+    for (int j = 0; j < rows; j += 2) {
+      double sum0 = 0.0;
+      double sum1 = 0.0;
+      for (int k = 0; k < rows; k++) {
+        sum0 += a[i*rows+k] * b[j*rows + k];
+        sum1 += a[i*rows+k] * b[(j + 1)*rows + k];
+      }
+      c[i*rows + j] = sum0;
+      c[i*rows + j+1] = sum1;
+    }
+  }
+
+  free(b);
+}

--- a/benchs/MatMulC.h
+++ b/benchs/MatMulC.h
@@ -1,0 +1,7 @@
+#ifndef _MATMULC_
+#define _MATMULC_
+
+void MatMulC(int, int, double *, double *, double *);
+void MatMulCopt(int, int, double *, double *, double *);
+
+#endif

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -31,6 +31,10 @@ source-repository head
   type:     git
   location: git://github.com/Feldspar/feldspar-language.git
 
+-- Flag UseICC
+--  Description:         Use ICC for compiling benchmarks.
+--  Default:             False
+
 library
   exposed-modules:
     Feldspar
@@ -348,6 +352,76 @@ test-suite callconv
     QuickCheck       >= 2.7.1 && < 3.0
 
   ghc-options: -threaded -with-rtsopts=-maxN4
+
+benchmark crc
+  type: exitcode-stdio-1.0
+
+  hs-source-dirs: benchs
+
+  main-is: CRC.hs
+
+  other-modules:
+    BenchmarkUtils
+
+  default-language: Haskell2010
+
+  ghc-options: -O2
+
+  build-depends:
+    feldspar-language,
+    base,
+    criterion          >= 1.0,
+    data-default       >= 0.5.3 && < 0.8,
+    deepseq
+
+benchmark fft
+  type: exitcode-stdio-1.0
+
+  hs-source-dirs: benchs
+
+  main-is: FFT.hs
+
+  other-modules:
+    BenchmarkUtils
+
+  default-language: Haskell2010
+
+  ghc-options: -O2
+
+  build-depends:
+    feldspar-language,
+    base,
+    criterion          >= 1.0,
+    data-default       >= 0.5.3 && < 0.8,
+    deepseq
+
+-- benchmark matmul
+--  type: exitcode-stdio-1.0
+--
+--  hs-source-dirs: benchs
+--
+--  main-is: MatMul.hs
+--
+--  other-modules:
+--    BenchmarkUtils
+--
+--  c-sources: benchs/MatMulC.c
+--
+--  default-language: Haskell2010
+--
+--  ghc-options: -O2
+--
+--  CC-Options: -fno-vectorize
+--  if flag(UseICC)
+--    x-cc-name: icc
+--
+--  build-depends:
+--    feldspar-language,
+--    base,
+--    criterion          >= 1.0,
+--    data-default       >= 0.5.3 && < 0.8,
+--    deepseq,
+--    plugins-multistage
 
 custom-setup
   setup-depends:


### PR DESCRIPTION
Leave the FFT and MatMul benchmarks disabled for now:
- The FFT benchmark uses Eq (Data a) which is a binding
  time violation.
- The MatMul benchmark has something strange with
  the test input/output array representation.