### PR TITLE
Normalize typerep output

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -128,6 +128,7 @@ library
     srcloc,
     storable-tuple              >= 0.0.2,
     storable-record             >= 0.0.2.5,
+    stringsearch                >= 0.3,
     template-haskell,
     tuple                       >= 0.2    && < 0.5,
     monad-par                   >= 0.3.4.5,


### PR DESCRIPTION
This is an attempt to get stable variable names
in our test outputs across GHC versions. This part
works locally for me with GHC 8.8.3 now.