### PR TITLE
travis: add GHC 8.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ jobs:
       addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-2.2,ghc-8.4.4,happy-1.19.5,alex-3.1.7]}}
     - env: CABALVER=2.4 GHCVER=8.6.5
       addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-2.4,ghc-8.6.5,happy-1.19.5,alex-3.1.7]}}
+    - env: CABALVER=3.0 GHCVER=8.8.3
+      addons: {apt: {sources: [hvr-ghc], packages: [cabal-install-3.0,ghc-8.8.3,happy-1.19.5,alex-3.1.7]}}
 
   allow_failures:
     - env: CABALVER=head GHCVER=head

--- a/tests/Feldspar/Range/Test.hs
+++ b/tests/Feldspar/Range/Test.hs
@@ -433,11 +433,11 @@ prop_and t = rangePropagationSafety t (.&.) rangeAnd
 prop_xor t = rangePropagationSafety t xor rangeXor
 
 prop_shiftLU t1 t2
-    = rangePropagationSafetyPre2 t1 t2 fixShiftL rangeShiftLU (\_ _ -> True)
+    = rangePropagationSafetyPre2 t1 t2 fixShiftL rangeShiftLU (\_ n -> n >= 0)
   where fixShiftL a b = shiftL a (fromIntegral b)
 
 prop_shiftRU t1 t2
-    = rangePropagationSafetyPre2 t1 t2 fixShiftR rangeShiftRU (\_ _ -> True)
+    = rangePropagationSafetyPre2 t1 t2 fixShiftR rangeShiftRU (\_ n -> n >= 0)
   where fixShiftR = correctShiftRU
 
 prop_rangeMax1 t r1 = rangeMax r1 r1 == (r1 `rangeTy` t)


### PR DESCRIPTION
Ubuntu 20 ships with GHC 8.8 so add that to the build.

Using shiftL/shiftR with a negative amount throws an arithmetic
exception in this version of GHC so stop doing that in our
tests.