### PR TITLE
Factor out reifyFeld from frontend again

### DIFF
--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -100,18 +100,20 @@ instance PrettyInfo a => Pretty (AUntypedFeld a) where
 -- | Front-end driver
 frontend :: PassCtrl FrontendPass
          -> Options
-         -> Either (ASTF a) (Either (AExpr a) (AUntypedFeld ValueInfo))
+         -> Either (ASTF a)
+                   (Either (AExpr a)
+                           (Either (AUntypedFeld ValueInfo) UntypedFeld))
          -> ([String], Maybe UntypedFeld)
 frontend ctrl opts = evalPasses 0
                    ( pc FPCreateTasks      (createTasks opts)
-                   . pt FPUnAnnotate       unAnnotate
-                   . pc FPUnique           uniqueVars
-                   . pc FPExpand           expand
-                   . pc FPPushLets         pushLets
-                   . pc FPOptimize         optimize
-                   . pc FPSinkLets         (sinkLets opts)
-                   . pc FPRename           renameExp
-                   . pt FPUntype           (either toU id)
+                   . pt FPUnAnnotate       (either unAnnotate id)
+                   . pc FPUnique           (either (Left . uniqueVars) Right)
+                   . pc FPExpand           (either (Left . expand) Right)
+                   . pc FPPushLets         (either (Left . pushLets) Right)
+                   . pc FPOptimize         (either (Left . optimize) Right)
+                   . pc FPSinkLets         (either (Left . sinkLets opts) Right)
+                   . pc FPRename           (either (Left . renameExp) Right)
+                   . pt FPUntype           (either (Left . toU) id)
                    . pc FPSizeProp         (either (Left . SP.sizeProp) Right)
                    . pc FPAdjustBind       (either (Left . adjustBindings) Right)
                    . pt FPUnASTF           (either (Left . unASTF) id)

--- a/src/Feldspar/Compiler/ExternalProgram.hs
+++ b/src/Feldspar/Compiler/ExternalProgram.hs
@@ -48,7 +48,7 @@ compileFile' opts (hfilename, hfile) (cfilename, cfile) =
     Just hprg -> case parseFile cfilename cfile (entities hprg) of
                    Nothing -> (Just hres, Nothing)
                    Just cprg -> (Just hres', Just cres)
-                     where res = compileToCCore' opts "unusedDummyNameC" cprg
+                     where res = compileToCCore' opts cprg
                            cres = implementation res
                            -- Un-duplicated hres.
                            hres' = interface res
@@ -56,4 +56,4 @@ compileFile' opts (hfilename, hfile) (cfilename, cfile) =
             -- just failed parsing the c file and return nothing for
             -- that so the user is probably not that picky on
             -- potential duplicate declarations if they had succeeded.
-            hres = interface $ compileToCCore' opts "unusedDummyNameH" hprg
+            hres = interface $ compileToCCore' opts hprg

--- a/src/Feldspar/Compiler/Options.hs
+++ b/src/Feldspar/Compiler/Options.hs
@@ -36,7 +36,6 @@ module Feldspar.Compiler.Options
   , PassCtrl(..)
   , defaultPassCtrl
   , FrontendPass(..)
-  , BackendPass(..)
   , ProgOpts(..)
   , defaultProgOpts
   , Target(..)
@@ -115,11 +114,7 @@ data FrontendPass
   | FPUnAnnotate
   | FPCreateTasks
   | BPFromCore
-  deriving (Bounded, Enum, Eq, Read, Show)
-
--- | Enumeration of backend passes
-data BackendPass
-  = BPArrayOps
+  | BPArrayOps
   | BPRename
   | BPAdapt
   | BPSplit
@@ -133,7 +128,6 @@ data ProgOpts = ProgOpts
   , outFileName  :: String
   , functionName :: String
   , frontendCtrl :: PassCtrl FrontendPass
-  , backendCtrl  :: PassCtrl BackendPass
   , printHelp    :: Bool
   }
 
@@ -144,7 +138,6 @@ defaultProgOpts = ProgOpts
   , outFileName  = ""
   , functionName = ""
   , frontendCtrl = defaultPassCtrl
-  , backendCtrl  = defaultPassCtrl
   , printHelp    = False
   }
 

--- a/src/Feldspar/Compiler/Options.hs
+++ b/src/Feldspar/Compiler/Options.hs
@@ -114,12 +114,12 @@ data FrontendPass
   | FPUnique
   | FPUnAnnotate
   | FPCreateTasks
+  | BPFromCore
   deriving (Bounded, Enum, Eq, Read, Show)
 
 -- | Enumeration of backend passes
 data BackendPass
-  = BPFromCore
-  | BPArrayOps
+  = BPArrayOps
   | BPRename
   | BPAdapt
   | BPSplit

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -143,13 +143,13 @@ showExpr = render . reifyFeld
 
 -- | Show an untyped expression
 showUntyped :: Syntactic a => Options -> a -> String
-showUntyped opts = head . fst . frontend passCtrl opts
+showUntyped opts = head . fst . frontend passCtrl opts . (Left . reifyFeld)
   where passCtrl = defaultPassCtrl{ wrBefore = [FPUnAnnotate]
                                   , stopBefore = [FPUnAnnotate]}
 
 -- | Show an expression after a specific frontend pass
 showUntyped' :: Syntactic a => FrontendPass -> Options -> a -> String
-showUntyped' p opts = head . fst . frontend passCtrl opts
+showUntyped' p opts = head . fst . frontend passCtrl opts . (Left . reifyFeld)
   where passCtrl = defaultPassCtrl{wrAfter = [p], stopAfter = [p]}
 
 -- | Print an optimized untyped expression

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -143,14 +143,16 @@ showExpr = render . reifyFeld
 
 -- | Show an untyped expression
 showUntyped :: Syntactic a => Options -> a -> String
-showUntyped opts = head . fst . frontend passCtrl opts . (Left . reifyFeld)
-  where passCtrl = defaultPassCtrl{ wrBefore = [FPUnAnnotate]
+showUntyped opts prg = head . fst $ out
+  where out = frontend passCtrl opts "dummy" (Left $ reifyFeld prg)
+        passCtrl = defaultPassCtrl{ wrBefore = [FPUnAnnotate]
                                   , stopBefore = [FPUnAnnotate]}
 
 -- | Show an expression after a specific frontend pass
 showUntyped' :: Syntactic a => FrontendPass -> Options -> a -> String
-showUntyped' p opts = head . fst . frontend passCtrl opts . (Left . reifyFeld)
-  where passCtrl = defaultPassCtrl{wrAfter = [p], stopAfter = [p]}
+showUntyped' p opts prg = head . fst $ out
+  where out = frontend passCtrl opts "dummy" (Left $ reifyFeld prg)
+        passCtrl = defaultPassCtrl{wrAfter = [p], stopAfter = [p]}
 
 -- | Print an optimized untyped expression
 printExpr2 :: Syntactic a => a -> IO ()


### PR DESCRIPTION
This enables the either construction from
the backend so one can input multiple formats
into the same pipeline.