### PR TITLE
Make PassCtrl monomorphic

### DIFF
--- a/src/Feldspar/Compiler/Options.hs
+++ b/src/Feldspar/Compiler/Options.hs
@@ -35,7 +35,7 @@ module Feldspar.Compiler.Options
   , Pretty(..)
   , PassCtrl(..)
   , defaultPassCtrl
-  , FrontendPass(..)
+  , Pass(..)
   , ProgOpts(..)
   , defaultProgOpts
   , Target(..)
@@ -86,21 +86,21 @@ class Pretty a where
 
 -- * Option handling data structures and utils.
 
-data PassCtrl a = PassCtrl
-  { wrBefore   :: [a] -- ^ Write IR before these passes
-  , wrAfter    :: [a] -- ^ Write IR after these passes
-  , stopBefore :: [a] -- ^ Stop before these passes
-  , stopAfter  :: [a] -- ^ Stop after these passes
-  , skip       :: [a] -- ^ Skip these passes
+data PassCtrl = PassCtrl
+  { wrBefore   :: [Pass] -- ^ Write IR before these passes
+  , wrAfter    :: [Pass] -- ^ Write IR after these passes
+  , stopBefore :: [Pass] -- ^ Stop before these passes
+  , stopAfter  :: [Pass] -- ^ Stop after these passes
+  , skip       :: [Pass] -- ^ Skip these passes
   } deriving Show
 
 -- | A default PassCtrl that runs all passes without writing
 --   any intermediate results
-defaultPassCtrl :: PassCtrl a
+defaultPassCtrl :: PassCtrl
 defaultPassCtrl = PassCtrl [] [] [] [] []
 
--- | Enumeration of frontend passes
-data FrontendPass
+-- | Enumeration of compiler passes
+data Pass
   = FPUnASTF
   | FPAdjustBind
   | FPSizeProp
@@ -127,7 +127,7 @@ data ProgOpts = ProgOpts
   , passFileName :: String
   , outFileName  :: String
   , functionName :: String
-  , frontendCtrl :: PassCtrl FrontendPass
+  , frontendCtrl :: PassCtrl
   , printHelp    :: Bool
   }
 

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -44,7 +44,7 @@ module Feldspar.Core.Frontend
 
     , Data
 
-    , FrontendPass(..)
+    , Pass(..)
     , frontend
 
     , module Feldspar.Core.Language
@@ -109,7 +109,7 @@ import Feldspar.Core.Reify hiding (desugar, sugar)
 import qualified Feldspar.Core.Eval as E
 
 import Feldspar.Compiler (frontend, reifyFeld, renameExp)
-import Feldspar.Compiler.Options (FrontendPass(..), Options(..),
+import Feldspar.Compiler.Options (Options(..), Pass(..),
                                   PassCtrl(..), Target(..),
                                   c99OpenMpPlatformOptions,
                                   c99PlatformOptions,
@@ -149,7 +149,7 @@ showUntyped opts prg = head . fst $ out
                                   , stopBefore = [FPUnAnnotate]}
 
 -- | Show an expression after a specific frontend pass
-showUntyped' :: Syntactic a => FrontendPass -> Options -> a -> String
+showUntyped' :: Syntactic a => Pass -> Options -> a -> String
 showUntyped' p opts prg = head . fst $ out
   where out = frontend passCtrl opts "dummy" (Left $ reifyFeld prg)
         passCtrl = defaultPassCtrl{wrAfter = [p], stopAfter = [p]}


### PR DESCRIPTION
Since we no longer have more than one pass enumeration
type, rename FrontendPass to Pass and make PassCtrl
contain lists of Pass.