### PR TITLE
Remove unused parameter on "extend"

### DIFF
--- a/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
+++ b/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
@@ -121,10 +121,10 @@ findFun name argtype m tp = go m
 -- | Returns a new name according to specification.
 newName :: String -> Type -> Type -> Destination -> String
 newName _    _       _  (Name s)                   = s
-newName name _       tp (Extend FunType p)         = extend p name tp
-newName name argtype _  (Extend ArgType p)         = extend p name argtype
-newName _    _       tp (ExtendRename FunType p s) = extend p s tp
-newName _    argtype _  (ExtendRename ArgType p s) = extend p s argtype
+newName name _       tp (Extend FunType _)         = extend name tp
+newName name argtype _  (Extend ArgType _)         = extend name argtype
+newName _    _       tp (ExtendRename FunType _ s) = extend s tp
+newName _    argtype _  (ExtendRename ArgType _ s) = extend s argtype
 
 -- | Tells whether a predicate holds for a type.
 true :: Predicate -> Type -> Bool

--- a/src/Feldspar/Compiler/Backend/C/Tic64x.hs
+++ b/src/Feldspar/Compiler/Backend/C/Tic64x.hs
@@ -64,7 +64,7 @@ adaptTic64xExp (ArrayElem e es)    = ArrayElem (adaptTic64xExp e) $ map adaptTic
 adaptTic64xExp (StructField e s)   = StructField (adaptTic64xExp e) s
 adaptTic64xExp c@ConstExpr{}       = c
 adaptTic64xExp (FunctionCall (Function "/=" t) [arg1,arg2]) | isComplex (typeof arg1)
-  = fun t "!" [fun t (extend tic64x "equal" $ typeof arg1) [arg1, arg2]]
+  = fun t "!" [fun t (extend "equal" $ typeof arg1) [arg1, arg2]]
 adaptTic64xExp (FunctionCall (Function "bitCount" t) [arg]) | isComplex (typeof arg)
   = fun t "_dotpu4" [fun t "_bitc4" [arg], litI32 0x01010101]
 adaptTic64xExp (FunctionCall f es)
@@ -89,5 +89,5 @@ adaptTic64xFun :: Type -> Int -> Function -> Function
 adaptTic64xFun argtype args f@(Function _ t)
   | isComplex argtype
   , args == 1 -- TODO: This transformation looks dangerous.
-  = Function (extend tic64x "creal" argtype) t
+  = Function (extend "creal" argtype) t
   | otherwise                           = f

--- a/src/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore.hs
@@ -74,7 +74,7 @@ import Feldspar.Range (fullRange, upperBound)
 
 import Feldspar.Compiler.Imperative.Frontend
 import Feldspar.Compiler.Imperative.Representation
-import Feldspar.Compiler.Options (Options(..), Platform(..), c99)
+import Feldspar.Compiler.Options (Options(..), Platform(..))
 
 -- | Code generation monad
 type CodeWriter = RWS CodeEnv CodeParts VarId
@@ -833,7 +833,7 @@ compileExpr (In (App Ut.I2N t1 [e])) = do
       1 :# (ComplexType t) -> do
         e' <- compileExpr e
         let args = [Cast t e', litF 0]
-        return $ fun t' (extend c99 "complex" t) args
+        return $ fun t' (extend "complex" t) args
       _ -> do
         e' <- compileExpr e
         return $ Cast t' e'

--- a/src/Feldspar/Compiler/Imperative/Representation.hs
+++ b/src/Feldspar/Compiler/Imperative/Representation.hs
@@ -64,7 +64,7 @@ import Data.Semigroup (Semigroup(..))
 import Language.Haskell.TH.Syntax (Lift(..))
 
 import Feldspar.Range (Range)
-import Feldspar.Compiler.Options (ErrorClass(..), Platform(..), handleError)
+import Feldspar.Compiler.Options (ErrorClass(..), handleError)
 import Feldspar.Core.Types (Length)
 import Feldspar.Core.UntypedRepresentation
         (Signedness(..), Size(..), HasType(..))
@@ -343,8 +343,8 @@ renderType (StructType n _) = "struct " ++ n
 renderType IVarType{} = "struct ivar"
 
 -- | Extend a helper function for the platform
-extend :: Platform -> String -> Type -> String
-extend Platform{..} s t = s ++ "_fun_" ++ renderType t
+extend :: String -> Type -> String
+extend s t = s ++ "_fun_" ++ renderType t
 
 ----------------------
 -- * Type inference
@@ -387,7 +387,8 @@ instance HasType (Expression t) where
     typeof FunctionCall{..} = returnType function
     typeof Cast{..}         = castType
     typeof AddrOf{..}       = 1 :# Pointer (typeof addrExpr)
-    typeof SizeOf{..}       = 1 :# NumType Signed S32
+    -- FIXME: Non-portable size_t assumption for SizeOf.
+    typeof SizeOf{}         = 1 :# NumType Signed S32
     typeof Deref{..}        = case typeof ptrExpr of
                                 1 :# (Pointer btype) -> btype
                                 wtype         -> reprError InternalError $ "Type of dereferenced expression " ++ show ptrExpr ++ " has type " ++ show wtype


### PR DESCRIPTION
Remove the unused parameter for now.
The general question of how to always
generate portable code even for oddball
platforms still remains.