### PR TITLE
travis: build 3 files in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
  - cabal new-configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal new-build -j4  # this builds all libraries and executables (including tests/benchmarks)
+ - cabal new-build -j4 --ghc-options=-j2 # this builds all libraries and executables (including tests/benchmarks)
  # There is no "cabal new-test" in Cabal 1.24 so run tests/benchmarks manually.
  # The path for build outputs has also changed so special-case on the cabal version.
  # Regression is most likely to break from variable number changes so start with that.


### PR DESCRIPTION
There is support for passing -j to ghc --make
so pass -j3.

There is a slight speedup when building from a clean
state with j3 compared to j2 on my machine, j4 is
the same as j2 but uses four times as much sys time.