### PR TITLE
stack: use LTS-16.5

### DIFF
--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -17,7 +17,8 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.5
+resolver: lts-15.14
+compiler: ghc-8.4.4
 
 ghc-options:
     # Somewhere deep inside there is a call to ghc --make, pass -j3 to


### PR DESCRIPTION
Keep the previous stack.yaml as stack-8.4.4.yaml.