### PR TITLE
Use strict version of Data.Map

### DIFF
--- a/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
+++ b/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
@@ -6,18 +6,19 @@ module Feldspar.Compiler.Backend.C.MachineLowering
   ( rename
   ) where
 
-import qualified Data.Map as M
+import qualified Data.Map.Strict as M
 
 import Feldspar.Compiler.Imperative.Representation
 import Feldspar.Compiler.Imperative.Frontend
 import Feldspar.Compiler.Backend.C.RuntimeLibrary
 import Feldspar.Compiler.Options
 
--- This module does function renaming as well as copy expansion, in a single pass.
+-- | This module does function renaming as well as copy expansion, in a single
+--   pass.
 --
--- Missing from the old C99 rules: Constant folding of 0 - x. That really belongs
--- in the frontend but there is no negate in NUM and multiplying by -1 gives crazy
--- results due to overflow.
+--   Missing from the old C99 rules: Constant folding of 0 - x. That really
+--   belongs in the frontend but there is no negate in NUM and multiplying
+--   by -1 gives crazy results due to overflow.
 
 -- | External interface for renaming.
 rename :: Options -> Bool -> Module -> Module

--- a/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
+++ b/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
@@ -22,8 +22,8 @@ import Feldspar.Compiler.Options
 
 -- | External interface for renaming.
 rename :: Options -> Bool -> Module -> Module
-rename opts _             | codeGenerator (platform opts) /= "c" = id
-rename opts addRuntimeLib = rename' opts addRuntimeLib x
+rename opts addRuntimeLib m | null x = m
+                            | otherwise = rename' opts addRuntimeLib x m
   where x = getPlatformRenames opts
 
 -- | Internal interface for renaming.

--- a/src/Feldspar/Compiler/ExternalProgram.hs
+++ b/src/Feldspar/Compiler/ExternalProgram.hs
@@ -12,7 +12,7 @@ import Feldspar.Compiler
          sourceCode, writeFiles)
 import Feldspar.Compiler.Imperative.ExternalProgram (parseFile)
 import Feldspar.Compiler.Imperative.Representation (Module(..))
-import Feldspar.Compiler.Options (Options(..), Platform(..), defaultOptions)
+import Feldspar.Compiler.Options (Options(..), defaultOptions)
 
 icompileFile :: FilePath -> IO ()
 icompileFile filename = do
@@ -37,7 +37,7 @@ compileFile fileName outFile opts = do
   case comp of
     (Nothing, _) -> print $ "Could not parse " ++ hfilename
     (_, Nothing) -> putStrLn $ "Could not parse " ++ cfilename
-    (Just hprg, Just cprg) -> writeFiles prg outFile (codeGenerator $ platform opts)
+    (Just hprg, Just cprg) -> writeFiles opts prg outFile
       where prg = SplitModule cprg hprg
 
 compileFile' :: Options -> (String, B.ByteString) -> (String, B.ByteString)


### PR DESCRIPTION
We access all elements so use the strict version
of the container.