### PR TITLE
Push targets into Platform

### DIFF
--- a/benchs/MatMul.hs
+++ b/benchs/MatMul.hs
@@ -32,7 +32,7 @@ matmul :: Pull DIM2 (Data Double) -> Pull DIM2 (Data Double) -> Pull DIM2 (Data 
 matmul = mmMult True
 
 loadFunOpts ["-optc=-O2", "-optc=-fno-vectorize"] ['matmul]
-loadFunOptsWith "_sics" sicsOptions ["-optc=-O2", "-optc=-fno-vectorize"] ['matmul]
+loadFunOptsWith "_sics" c99WoolPlatformOptions ["-optc=-O2", "-optc=-fno-vectorize"] ['matmul]
 
 len :: Length
 len = 64

--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -190,14 +190,6 @@ icompile' opts fName prg = do
       putStrLn "=============== Source ================"
     putStrLn $ sourceCode $ implementation res
 
-targetsFromPlatform :: Platform -> [Target]
-targetsFromPlatform = tfp . platformName
-   where tfp "c99"       = []
-         tfp "c99OpenMp" = []
-         tfp "c99Wool"   = [Wool]
-         tfp "ba"        = [BA]
-         tfp p           = error $ "Interface.tfp: Unknown platform:" ++ p
-
 program :: Syntactic a => a -> IO ()
 program p = programOpts p defaultOptions
 
@@ -271,8 +263,7 @@ driverOpts =
   ]
 
 setTarget :: Options -> String -> Options
-setTarget opts str = opts{platform = pf, targets = targetsFromPlatform pf}
-   where pf = platformFromName str
+setTarget opts str = opts{platform = platformFromName str}
 
 chooseEnd :: (PassCtrl -> Pass -> PassCtrl) -> String -> Options -> Options
 chooseEnd f str opts

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -52,11 +52,9 @@ module Feldspar.Core.Frontend
     -- * Options
     , Options(..)
     , defaultOptions
-    , sicsOptions
-    , sicsOptions2
-    , sicsOptions3
     , c99PlatformOptions
     , c99OpenMpPlatformOptions
+    , c99WoolPlatformOptions
     , tic64xPlatformOptions
     , Target(..)
 
@@ -113,8 +111,8 @@ import Feldspar.Compiler.Options (Options(..), Pass(..),
                                   PassCtrl(..), Target(..),
                                   c99OpenMpPlatformOptions,
                                   c99PlatformOptions,
-                                  defaultOptions, sicsOptions,
-                                  sicsOptions2, sicsOptions3,
+                                  c99WoolPlatformOptions,
+                                  defaultOptions,
                                   tic64xPlatformOptions)
 import Feldspar.Core.AdjustBindings (adjustBindings)
 import Feldspar.Core.Middleend.CreateTasks

--- a/tests/RegressionTests.hs
+++ b/tests/RegressionTests.hs
@@ -467,7 +467,7 @@ nativeOpts = defaultOptions{useNativeArrays=True}
 nativeRetOpts :: Options
 nativeRetOpts = defaultOptions{useNativeReturns=True}
 woolOpts :: Options
-woolOpts = sicsOptions3
+woolOpts = c99WoolPlatformOptions
 openMPOpts :: Options
 openMPOpts = c99OpenMpPlatformOptions
 


### PR DESCRIPTION
These are leftovers from the repo-split, put
the targets in the platform since that is
essentially what we use it for anyway.

Remove the unused constructors and the corresponding
option record definitions (sicsOptions*).