### PR TITLE
Remove unused argument in Destination type

### DIFF
--- a/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
+++ b/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
@@ -122,10 +122,10 @@ findFun name argtype m tp = go m
 -- | Returns a new name according to specification.
 newName :: String -> Type -> Type -> Destination -> String
 newName _    _       _  (Name s)                   = s
-newName name _       tp (Extend FunType _)         = extend name tp
-newName name argtype _  (Extend ArgType _)         = extend name argtype
-newName _    _       tp (ExtendRename FunType _ s) = extend s tp
-newName _    argtype _  (ExtendRename ArgType _ s) = extend s argtype
+newName name _       tp (Extend FunType)           = extend name tp
+newName name argtype _  (Extend ArgType)           = extend name argtype
+newName _    _       tp (ExtendRename FunType s)   = extend s tp
+newName _    argtype _  (ExtendRename ArgType s)   = extend s argtype
 
 -- | Tells whether a predicate holds for a type.
 true :: Predicate -> Type -> Bool

--- a/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
+++ b/src/Feldspar/Compiler/Backend/C/MachineLowering.hs
@@ -24,7 +24,7 @@ import Feldspar.Compiler.Options
 rename :: Options -> Bool -> Module -> Module
 rename opts addRuntimeLib m | null x = m
                             | otherwise = rename' opts addRuntimeLib x m
-  where x = getPlatformRenames opts
+  where x = M.fromList . platformRenames . platform $ opts
 
 -- | Internal interface for renaming.
 rename' :: Options -> Bool -> M.Map String [(Which, Destination)] -> Module

--- a/src/Feldspar/Compiler/Options.hs
+++ b/src/Feldspar/Compiler/Options.hs
@@ -246,8 +246,8 @@ data WhichType = FunType | ArgType
 
 data Destination =
     Name String
-  | Extend WhichType Platform
-  | ExtendRename WhichType Platform String
+  | Extend WhichType
+  | ExtendRename WhichType String
    deriving Show
 
 -- A rename is the name of the function to be renamed coupled with a
@@ -290,7 +290,7 @@ c99list =
 
 -- | Make C99 extend rule.
 mkC99ExtendRule :: WhichType -> String -> Rename
-mkC99ExtendRule t s = (s, [ (All, Extend t c99) ])
+mkC99ExtendRule t s = (s, [ (All, Extend t) ])
 
 -- | Make C99 trig rule.
 mkC99TrigRule :: String -> Rename
@@ -300,25 +300,25 @@ mkC99TrigRule s = (s, [ (Only Complex, Name ('c':s')), (All, Name s') ])
 -- | Tic64x renaming list.
 tic64xlist :: [Rename]
 tic64xlist =
-  [ ("==",          [ (Only Complex, ExtendRename ArgType tic64x "equal") ])
+  [ ("==",          [ (Only Complex, ExtendRename ArgType "equal") ])
   , ("abs",         [ (Only Float, Name "_fabs"), (Only Signed32, Name "_abs") ])
-  , ("+",           [ (Only Complex, ExtendRename ArgType tic64x "add") ])
-  , ("-",           [ (Only Complex, ExtendRename ArgType tic64x "sub") ])
-  , ("*",           [ (Only Complex, ExtendRename ArgType tic64x "mult") ])
-  , ("/",           [ (Only Complex, ExtendRename ArgType tic64x "div") ])
+  , ("+",           [ (Only Complex, ExtendRename ArgType "add") ])
+  , ("-",           [ (Only Complex, ExtendRename ArgType "sub") ])
+  , ("*",           [ (Only Complex, ExtendRename ArgType "mult") ])
+  , ("/",           [ (Only Complex, ExtendRename ArgType "div") ])
   ] ++
   map mkTic64xComplexRule ["exp", "sqrt", "log", "sin", "tan", "cos", "asin"
                           ,"atan", "acos", "sinh", "tanh", "cosh", "asinh"
                           ,"atanh","acosh","creal","cimag", "conjugate"
                           ,"magnitude","phase", "logBase"] ++
-  [ ("**",          [ (Only Complex, ExtendRename ArgType tic64x "cpow") ])
+  [ ("**",          [ (Only Complex, ExtendRename ArgType "cpow") ])
   , ("rotateL",     [ (Only Unsigned32, Name "_rotl") ])
   , ("reverseBits", [ (Only Unsigned32, Name "_bitr") ])
   ]
 
 -- | Create Tic64x rule for complex type.
 mkTic64xComplexRule :: String -> Rename
-mkTic64xComplexRule s = (s, [ (Only Complex, Extend ArgType tic64x) ] )
+mkTic64xComplexRule s = (s, [ (Only Complex, Extend ArgType) ] )
 
 -- | Returns the platform renames based on the platform name.
 getPlatformRenames :: Options -> M.Map String [(Which, Destination)]

--- a/tests/gold/complexWhileCond.c
+++ b/tests/gold/complexWhileCond.c
@@ -1,12 +1,12 @@
 #include "complexWhileCond.h"
 
 
-void complexWhileCond(uint32_t v0, struct s_2_unsignedS32_unsignedS32 * out)
+void complexWhileCond(int32_t v0, struct s_2_signedS32_signedS32 * out)
 {
-  struct s_2_unsignedS32_unsignedS32 e0 = { 0 };
-  struct s_2_unsignedS32_unsignedS32 v9 = { 0 };
-  uint32_t v4;
-  uint32_t v6;
+  struct s_2_signedS32_signedS32 e0 = { 0 };
+  struct s_2_signedS32_signedS32 v9 = { 0 };
+  int32_t v4;
+  int32_t v6;
   bool v2;
   
   (e0).member1 = 0;

--- a/tests/gold/complexWhileCond.h
+++ b/tests/gold/complexWhileCond.h
@@ -3,12 +3,12 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_unsignedS32_unsignedS32
+struct s_2_signedS32_signedS32
 {
-  uint32_t member1;
-  uint32_t member2;
+  int32_t member1;
+  int32_t member2;
 };
 
-void complexWhileCond(uint32_t v0, struct s_2_unsignedS32_unsignedS32 * out);
+void complexWhileCond(int32_t v0, struct s_2_signedS32_signedS32 * out);
 
 #endif // TESTS_COMPLEXWHILECOND_H


### PR DESCRIPTION
The extend function used the platform to lookup
the name of certain types so the Destination had
to carry the platform as a parameter. Since
we use regular C99 names everywhere this parameter
can now be removed.