### PR TITLE
Convert fromTypedUT to use AUntypedFeld

### DIFF
--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -85,8 +85,7 @@ import Feldspar.Core.Middleend.UniqueVars
 import qualified Feldspar.Core.SizeProp as SP
 import Feldspar.Core.Representation (AExpr)
 import Feldspar.Core.Reify (ASTF, Syntactic(..), desugar, unASTF)
-import Feldspar.Core.UntypedRepresentation (AUntypedFeld, UntypedFeld,
-                                            prettyExp, rename, unAnnotate)
+import Feldspar.Core.UntypedRepresentation (AUntypedFeld, prettyExp, rename)
 import Feldspar.Core.ValueInfo (PrettyInfo(..), ValueInfo)
 
 -- The front-end driver.
@@ -104,10 +103,8 @@ frontend :: Options
                 (Either
                   (AUntypedFeld ValueInfo)
                   (Either
-                    UntypedFeld
-                    (Either
-                      Module
-                      (Either (Module, Module) SplitModule)))))
+                    Module
+                    (Either (Module, Module) SplitModule))))
          -> ([String], Maybe SplitModule)
 frontend opts = evalPasses 0
                    ( codegen opts
@@ -115,7 +112,6 @@ frontend opts = evalPasses 0
                    . pc BPRename   (either (Left . ML.rename opts False) Right)
                    . pc BPArrayOps (either (Left . arrayOps opts) Right)
                    . pt BPFromCore (either (Left . fromCoreUT opts) id)
-                   . pt FPUnAnnotate       (either (Left . unAnnotate) id)
                    . pc FPCreateTasks      (either (Left . createTasks opts) Right)
                    . pc FPUnique           (either (Left . uniqueVars) Right)
                    . pc FPExpand           (either (Left . expand) Right)

--- a/src/Feldspar/Compiler/ExternalProgram.hs
+++ b/src/Feldspar/Compiler/ExternalProgram.hs
@@ -50,7 +50,7 @@ compileFile' opts (hfilename, hfile) (cfilename, cfile) =
                    Just cprg -> (Just hres', Just cres)
                      where res = fromMaybe (error "Failed parsing C file")
                                $ snd $ frontend opts
-                                   (Right . Right . Right . Right . Left $ cprg)
+                                   (Right . Right . Right . Left $ cprg)
                            cres = implementation res
                            -- Un-duplicated hres.
                            hres' = interface res
@@ -59,4 +59,4 @@ compileFile' opts (hfilename, hfile) (cfilename, cfile) =
             -- that so the user is probably not that picky on
             -- potential duplicate declarations if they had succeeded.
             hres = interface $ fromMaybe (error "Failed parsing H file") $ snd
-                 $ frontend opts (Right . Right . Right . Right . Left $ hprg)
+                 $ frontend opts (Right . Right . Right . Left $ hprg)

--- a/src/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore.hs
@@ -66,7 +66,7 @@ import Data.Maybe (fromJust, isJust)
 import Data.Semigroup (Semigroup(..))
 
 import Feldspar.Core.UntypedRepresentation
-         ( VarId(..), AUntypedFeld, ATerm(..), Lit(..)
+         ( VarId(..), AUntypedFeld, Term(..), Lit(..)
          , UntypedFeldF(App, LetFun), Fork(..), collectBinders
          , collectLetBinders
          )

--- a/src/Feldspar/Compiler/Options.hs
+++ b/src/Feldspar/Compiler/Options.hs
@@ -116,7 +116,6 @@ data Pass
   | FPPushLets
   | FPExpand
   | FPUnique
-  | FPUnAnnotate
   | FPCreateTasks
   | BPFromCore
   | BPArrayOps

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -142,8 +142,8 @@ showExpr = showUntyped' FPUnASTF defaultOptions
 -- | Show an untyped expression
 showUntyped :: Syntactic a => Options -> a -> String
 showUntyped opts prg = head . fst $ translate opts' prg
-  where opts' = opts{passCtrl = (passCtrl opts){ wrBefore = [FPUnAnnotate]
-                                               , stopBefore = [FPUnAnnotate]}}
+  where opts' = opts{passCtrl = (passCtrl opts){ wrBefore = [FPCreateTasks]
+                                               , stopBefore = [FPCreateTasks]}}
 
 -- | Show an expression after a specific frontend pass
 showUntyped' :: Syntactic a => Pass -> Options -> a -> String

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -123,9 +123,9 @@ import Feldspar.Core.Middleend.PushLets
 import Feldspar.Core.Middleend.UniqueVars
 import qualified Feldspar.Core.SizeProp as SP
 import Feldspar.Core.Types
-import Feldspar.Core.UntypedRepresentation (UntypedFeld, AUntypedFeld,
-                                            stringTree, stringTreeExp,
-                                            unAnnotate)
+import Feldspar.Core.UntypedRepresentation (AUntypedFeld,
+                                            stringTree, stringTreeExp
+                                           )
 import Feldspar.Core.Language
 import Feldspar.Core.ValueInfo (ValueInfo)
 
@@ -208,7 +208,7 @@ sugar = resugar
 --        with calls to the frontend function.
 
 -- | Untype, optimize and unannotate.
-untype :: Options -> ASTF a -> UntypedFeld
+untype :: Options -> ASTF a -> AUntypedFeld ValueInfo
 untype opts = cleanUp opts
             . untypeDecor opts
 
@@ -220,7 +220,7 @@ untypeDecor opts = pushLets
                  . justUntype
 
 -- | External module interface.
-untypeUnOpt :: Options -> ASTF a -> UntypedFeld
+untypeUnOpt :: Options -> ASTF a -> AUntypedFeld ValueInfo
 untypeUnOpt opts = cleanUp opts
                  . justUntype
 
@@ -229,8 +229,8 @@ justUntype :: ASTF a -> AUntypedFeld ValueInfo
 justUntype = renameExp . toU . SP.sizeProp . adjustBindings . unASTF
 
 -- | Prepare the code for fromCore
-cleanUp :: Options -> AUntypedFeld ValueInfo -> UntypedFeld
-cleanUp opts = unAnnotate . createTasks opts . uniqueVars
+cleanUp :: Options -> AUntypedFeld ValueInfo -> AUntypedFeld ValueInfo
+cleanUp opts = createTasks opts . uniqueVars
 
 --------------------------------------------------------------------------------
 -- * QuickCheck

--- a/src/Feldspar/Core/Middleend/Constructors.hs
+++ b/src/Feldspar/Core/Middleend/Constructors.hs
@@ -72,7 +72,7 @@ concatBags = foldr appendBag (Bags [])
 type AExpB a = (BindBag a, AUntypedFeld a)
 type RExpB a = (BindBag a, RRExp a)
 
-type RRExp a = UntypedFeldF (ATerm a UntypedFeldF)
+type RRExp a = UntypedFeldF (AUntypedFeld a)
 
 toExpr :: AExpB a -> AUntypedFeld a
 toExpr (b,e) = foldBag (curry mkLets) e b

--- a/src/Feldspar/Core/Middleend/CreateTasks.hs
+++ b/src/Feldspar/Core/Middleend/CreateTasks.hs
@@ -56,18 +56,18 @@ go env (AIn r (App p _ [e])) | p `elem` [MkFuture, ParFork] = do
       core = "task_core" ++ show i
       k = if p == MkFuture then Future else Par
   return $ AIn r (LetFun (core, k, p'') (AIn r (App (Call k taskName) t' vs')))
-   where vs = fvA e
+   where vs = fv e
          vs' = map (\(r', v') -> AIn r' $ Variable v') vs
-         p' = mkLam' vs e
+         p' = mkLam vs e
          t' = FValType $ typeof e
 go env (AIn r (App NoInline _ [p])) = do
   p'' <- go env p'
   i <- freshId
   let name = "noinline" ++ show i
   return $ AIn r (LetFun (name, None, p'') (AIn r (App (Call None name) t' vs')))
-   where vs = fvA p
+   where vs = fv p
          vs' = map (\(r', v') -> AIn r' $ Variable v') vs
-         p' = mkLam' vs p
+         p' = mkLam vs p
          t' = typeof p
 go env (AIn r1 (App f t [l, e@(AIn r2 (Lambda v body))]))
   | Wool `inTarget` env && f `elem` [EparFor, Parallel] = do
@@ -78,9 +78,9 @@ go env (AIn r1 (App f t [l, e@(AIn r2 (Lambda v body))]))
   return $ AIn r1 (LetFun (name, Loop, p'') (AIn r1 (App f t [l,body'])))
    where -- Make sure index is outermost parameter.
          -- FIXME: We are losing precision in the annotations here.
-         vs  = (topInfo $ varType v, v):fvA e
+         vs  = (topInfo $ varType v, v):fv e
          vs' = map (\(r', v') -> AIn r' $ Variable v') vs
-         p'  = mkLam' vs body
+         p'  = mkLam vs body
          t'  = typeof body
 go env (AIn r (App p t es)) = do
   es' <- mapM (go env) es

--- a/src/Feldspar/Core/Middleend/LetSinking.hs
+++ b/src/Feldspar/Core/Middleend/LetSinking.hs
@@ -31,5 +31,5 @@ collectAtTop opts e
   , not $ null bs
   , (vs, body) <- collectBinders e1 -- Get all lambdas immediately within
   , not $ null vs
-  = mkLam' vs $ mkLets (bs, body)
+  = mkLam vs $ mkLets (bs, body)
   | otherwise = e

--- a/src/Feldspar/Core/Middleend/UniqueVars.hs
+++ b/src/Feldspar/Core/Middleend/UniqueVars.hs
@@ -37,7 +37,7 @@ import qualified Data.Map.Strict as M
 import Control.Monad.State
 
 type U a = State (S.Set VarId) a
-type RRExp a = UntypedFeldF (ATerm a UntypedFeldF)
+type RRExp a = UntypedFeldF (AUntypedFeld a)
 
 {- | Ensure that each variable binding binds a unique variable.
      This invariant is import since some back ends declare all

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -44,7 +44,7 @@
 
 module Feldspar.Core.UntypedRepresentation (
     VarId (..)
-  , ATerm(..)
+  , Term(..)
   , AUntypedFeld
   , UntypedFeldF(..)
   , Op(..)
@@ -101,12 +101,12 @@ import Feldspar.Core.Types (Length)
 -- but it does not reflect into the host language type system.
 
 -- | Types representing an annotated term
-type AUntypedFeld a = ATerm a UntypedFeldF
+type AUntypedFeld a = Term a UntypedFeldF
 
-data ATerm a f = AIn a (f (ATerm a f))
+data Term a f = AIn a (f (Term a f))
 
-deriving instance (Eq a, Eq (f (ATerm a f))) => Eq (ATerm a f)
-instance (Show (f (ATerm a f))) => Show (ATerm a f) where
+deriving instance (Eq a, Eq (f (Term a f))) => Eq (Term a f)
+instance (Show (f (Term a f))) => Show (Term a f) where
   show (AIn _ f) = show f
 
 -- | Extract the annotation part of an AUntypedFeld

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -59,8 +59,6 @@ module Feldspar.Core.UntypedRepresentation (
   , Signedness(..)
   , Fork(..)
   , HasType(..)
-  , unAnnotate
-  , annotate
   , getAnnotation
   , dropAnnotation
   , fvA
@@ -131,15 +129,6 @@ data ATerm a f = AIn a (f (ATerm a f))
 deriving instance (Eq a, Eq (f (ATerm a f))) => Eq (ATerm a f)
 instance (Show (f (ATerm a f))) => Show (ATerm a f) where
   show (AIn _ f) = show f
-
--- | Remove annotations and translate to UntypedFeld
-unAnnotate :: AUntypedFeld a -> UntypedFeld
-unAnnotate (AIn _ e) = In $ go e
-  where go (Lambda v e)         = Lambda v (unAnnotate e)
-        go (LetFun (s,k,e1) e2) = LetFun (s, k, unAnnotate e1) (unAnnotate e2)
-        go (App f t es)         = App f t (map unAnnotate es)
-        go (Variable v)         = Variable v
-        go (Literal l)          = Literal l
 
 -- | Add annotations using an annotation function
 annotate :: (UntypedFeldF (AUntypedFeld a) -> a) -> UntypedFeld -> AUntypedFeld a
@@ -481,8 +470,8 @@ prType (FunType t1 t2)  = "(" ++ prType t1 ++ "->" ++ prType t2 ++ ")"
 prType (FValType t)     = "F" ++ prType t
 
 -- | Convert an untyped unannotated syntax tree into a @Tree@ of @String@s
-stringTree :: UntypedFeld -> Tree String
-stringTree = stringTreeExp (const "") . annotate (const ())
+stringTree :: AUntypedFeld a -> Tree String
+stringTree = stringTreeExp (const "")
 
 -- | Convert an untyped annotated syntax tree into a @Tree@ of @String@s
 stringTreeExp :: (a -> String) -> AUntypedFeld a -> Tree String

--- a/src/Feldspar/Core/UntypedRepresentation.hs
+++ b/src/Feldspar/Core/UntypedRepresentation.hs
@@ -695,7 +695,7 @@ type Rename a = State VarId a
 rename :: AUntypedFeld a -> Rename (AUntypedFeld a)
 rename = renameA M.empty
 
-type RRExp a = UntypedFeldF (ATerm a UntypedFeldF)
+type RRExp a = UntypedFeldF (AUntypedFeld a)
 
 renameA :: M.Map VarId (RRExp a) -> AUntypedFeld a -> Rename (AUntypedFeld a)
 renameA env (AIn a r) = do r1 <- renameR env r

--- a/tests/gold/tfModel.txt
+++ b/tests/gold/tfModel.txt
@@ -1,5 +1,5 @@
 
-========== Before FPUnAnnotate ==========
+========== Before FPCreateTasks ==========
 
 \ v1 : a1xf32 ->
   \ v2 : a1xf32 ->


### PR DESCRIPTION
This allows us to remove the un-annotation pass which
is a leftover from the split repositories. Long-term
this will allow us to carry annotations from
the frontend all the way down into the code generation.