### PR TITLE
Use type-level naturals for tuple selection

### DIFF
--- a/src/Feldspar/Core/Semantics.hs
+++ b/src/Feldspar/Core/Semantics.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wall #-}
 -- FIXME: PropSize and Switch not matched by semantics.

--- a/src/Feldspar/Option.hs
+++ b/src/Feldspar/Option.hs
@@ -78,11 +78,11 @@ desugarOption a = resugar $ twotup (isSome a) (fromSome a)
 -- | One-layer sugaring of 'Option'
 sugarOption :: Type a => Data (Tuple '[Bool, a]) -> Option (Data a)
 sugarOption (resugar -> t) = Option (nfst t) (nsnd' t)
-  where -- Workaround for loss of type information with resugar. Should
-        -- be possible to add a type signature instead but I couldn't get
-        -- that to work.
+  where -- Workaround for loss of type information with resugar.
+        -- FIXME: GHC 8.8: Remove nsnd' and put a typesignature:
+        --        sugarOption (resugar -> (t :: Tuple '[a, b]))
         nsnd' :: Tuple '[a, b] -> b
-        nsnd' = sel (Skip First)
+        nsnd' = nsnd
 
 some :: a -> Option a
 some = Option true

--- a/tests/RegressionTests.hs
+++ b/tests/RegressionTests.hs
@@ -237,7 +237,7 @@ shareT :: (Tuple '[Data Length, Data Length]
 shareT = (build $ tuple 1 2, build $ tuple 1 2)
 
 selectT :: Data Length
-selectT = sel First $ snd noshareT
+selectT = nfst $ snd noshareT
 
 prop_concatV = forAll (vectorOf 3 (choose (0,5))) $ \ls ->
                  forAll (mapM (`vectorOf` arbitrary) ls) $ \xss ->


### PR DESCRIPTION
This allows us to remove First and Skip by
using 0.. instead.

I am not sure why but this change also enables
GHC to not require additional function bindings
in Option.hs.