### PR TITLE
Rename AUntypedFeld to UntypedFeld, NFC

### DIFF
--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -85,12 +85,12 @@ import Feldspar.Core.Middleend.UniqueVars
 import qualified Feldspar.Core.SizeProp as SP
 import Feldspar.Core.Representation (AExpr)
 import Feldspar.Core.Reify (ASTF, Syntactic(..), desugar, unASTF)
-import Feldspar.Core.UntypedRepresentation (AUntypedFeld, prettyExp, rename)
+import Feldspar.Core.UntypedRepresentation (UntypedFeld, prettyExp, rename)
 import Feldspar.Core.ValueInfo (PrettyInfo(..), ValueInfo)
 
 -- The front-end driver.
 
-instance PrettyInfo a => Pretty (AUntypedFeld a) where
+instance PrettyInfo a => Pretty (UntypedFeld a) where
   pretty = prettyExp f
      where f t x = " | " ++ prettyInfo t x
 
@@ -101,7 +101,7 @@ frontend :: Options
               (Either
                 (AExpr a)
                 (Either
-                  (AUntypedFeld ValueInfo)
+                  (UntypedFeld ValueInfo)
                   (Either
                     Module
                     (Either (Module, Module) SplitModule))))
@@ -133,14 +133,14 @@ frontend opts = evalPasses 0
 reifyFeld :: Syntactic a => a -> ASTF (Internal a)
 reifyFeld = desugar
 
-renameExp :: AUntypedFeld a -> AUntypedFeld a
+renameExp :: UntypedFeld a -> UntypedFeld a
 renameExp e = evalState (rename e) 0
 
 compile :: Syntactic t => t -> FilePath -> String -> Options -> IO ()
 compile prg fileName funName opts = writeFiles opts compRes fileName
   where compRes = compileToCCore funName opts prg
 
-compileUT :: AUntypedFeld ValueInfo -> FilePath -> String -> Options -> IO ()
+compileUT :: UntypedFeld ValueInfo -> FilePath -> String -> Options -> IO ()
 compileUT prg fileName funName opts = writeFiles opts compRes fileName
   where compRes = fromMaybe (error "compileUT: compilation failed")
                 $ snd $ frontend opts' (Right . Right . Left $ prg)

--- a/src/Feldspar/Core/Frontend.hs
+++ b/src/Feldspar/Core/Frontend.hs
@@ -123,7 +123,7 @@ import Feldspar.Core.Middleend.PushLets
 import Feldspar.Core.Middleend.UniqueVars
 import qualified Feldspar.Core.SizeProp as SP
 import Feldspar.Core.Types
-import Feldspar.Core.UntypedRepresentation (AUntypedFeld,
+import Feldspar.Core.UntypedRepresentation (UntypedFeld,
                                             stringTree, stringTreeExp
                                            )
 import Feldspar.Core.Language
@@ -208,28 +208,28 @@ sugar = resugar
 --        with calls to the frontend function.
 
 -- | Untype, optimize and unannotate.
-untype :: Options -> ASTF a -> AUntypedFeld ValueInfo
+untype :: Options -> ASTF a -> UntypedFeld ValueInfo
 untype opts = cleanUp opts
             . untypeDecor opts
 
 -- | Untype and optimize.
-untypeDecor :: Options -> ASTF a -> AUntypedFeld ValueInfo
+untypeDecor :: Options -> ASTF a -> UntypedFeld ValueInfo
 untypeDecor opts = pushLets
                  . optimize
                  . sinkLets opts
                  . justUntype
 
 -- | External module interface.
-untypeUnOpt :: Options -> ASTF a -> AUntypedFeld ValueInfo
+untypeUnOpt :: Options -> ASTF a -> UntypedFeld ValueInfo
 untypeUnOpt opts = cleanUp opts
                  . justUntype
 
--- | Only do the conversion to AUntypedFeld ValueInfo
-justUntype :: ASTF a -> AUntypedFeld ValueInfo
+-- | Only do the conversion to UntypedFeld ValueInfo
+justUntype :: ASTF a -> UntypedFeld ValueInfo
 justUntype = renameExp . toU . SP.sizeProp . adjustBindings . unASTF
 
 -- | Prepare the code for fromCore
-cleanUp :: Options -> AUntypedFeld ValueInfo -> AUntypedFeld ValueInfo
+cleanUp :: Options -> UntypedFeld ValueInfo -> UntypedFeld ValueInfo
 cleanUp opts = createTasks opts . uniqueVars
 
 --------------------------------------------------------------------------------

--- a/src/Feldspar/Core/Middleend/Constructors.hs
+++ b/src/Feldspar/Core/Middleend/Constructors.hs
@@ -81,7 +81,7 @@ fromExpr :: UntypedFeld a -> AExpB a
 fromExpr e = (Bags [], e)
 
 unAnnotateB :: AExpB a -> RExpB a
-unAnnotateB (b, AIn _ e) = (b, e)
+unAnnotateB (b, In _ e) = (b, e)
 
 fromRExpr :: RRExp a -> RExpB a
 fromRExpr e = (Bags [], e)
@@ -102,7 +102,7 @@ app op t es = (concatBags bs, App op t es1)
   where (bs,es1) = unzip es
 
 aIn :: a -> RExpB a -> AExpB a
-aIn r (b,e) = (b, AIn r e)
+aIn r (b,e) = (b, In r e)
 
 mkBinds :: ([(Var, AExpB a)], AExpB a) -> AExpB a
 mkBinds (bs,(b,e)) = (foldr appendBag (appendBag (Item $ zip vs es1) b) bs1, e)

--- a/src/Feldspar/Core/Middleend/Constructors.hs
+++ b/src/Feldspar/Core/Middleend/Constructors.hs
@@ -54,7 +54,7 @@ data Bag a = Bags [Bag a]
            | Item a
            deriving (Eq, Ord, Show)
 
-type BindBag a = Bag [(Var, AUntypedFeld a)]
+type BindBag a = Bag [(Var, UntypedFeld a)]
 
 foldBag :: (a -> b -> b) -> b -> Bag a -> b
 foldBag f u (Bags bs) = foldr (\ b r -> foldBag f r b) u bs
@@ -69,15 +69,15 @@ appendBag l         (Item r)  = Bags [l, Item r]
 concatBags :: [Bag a] -> Bag a
 concatBags = foldr appendBag (Bags [])
 
-type AExpB a = (BindBag a, AUntypedFeld a)
+type AExpB a = (BindBag a, UntypedFeld a)
 type RExpB a = (BindBag a, RRExp a)
 
-type RRExp a = UntypedFeldF (AUntypedFeld a)
+type RRExp a = UntypedFeldF (UntypedFeld a)
 
-toExpr :: AExpB a -> AUntypedFeld a
+toExpr :: AExpB a -> UntypedFeld a
 toExpr (b,e) = foldBag (curry mkLets) e b
 
-fromExpr :: AUntypedFeld a -> AExpB a
+fromExpr :: UntypedFeld a -> AExpB a
 fromExpr e = (Bags [], e)
 
 unAnnotateB :: AExpB a -> RExpB a

--- a/src/Feldspar/Core/Middleend/CreateTasks.hs
+++ b/src/Feldspar/Core/Middleend/CreateTasks.hs
@@ -38,10 +38,10 @@ import Feldspar.Core.ValueInfo (ValueInfo, topInfo)
 
 -- | Create tasks from MkFuture and similar constructs.
 -- Invariant: There are no MkFuture, ParFork or NoInline constructs in the output.
-createTasks :: Options -> AUntypedFeld ValueInfo -> AUntypedFeld ValueInfo
+createTasks :: Options -> UntypedFeld ValueInfo -> UntypedFeld ValueInfo
 createTasks opts e = evalState (go opts e) 0
 
-go :: Options -> AUntypedFeld ValueInfo -> State Integer (AUntypedFeld ValueInfo)
+go :: Options -> UntypedFeld ValueInfo -> State Integer (UntypedFeld ValueInfo)
 go _   e@(AIn _ Variable{}) = return e
 go env (AIn r (Lambda v e)) = do
   e' <- go env e

--- a/src/Feldspar/Core/Middleend/Expand.hs
+++ b/src/Feldspar/Core/Middleend/Expand.hs
@@ -49,7 +49,7 @@ import Control.Monad.State
 import Data.List (partition)
 
 type VarMap = M.Map Var (S.Set Var, RExp)
-type UExp = AUntypedFeld ValueInfo
+type UExp = UntypedFeld ValueInfo
 type RExp = UntypedFeldF UExp
 
 expand :: UExp -> UExp
@@ -104,7 +104,7 @@ idxLenExpr ai = ixTop $ reverse ai
         add x y = AIn (addVI (getAnnotation x) (getAnnotation y)) $ App Add (typeof x) [x, y]
         mul x y = AIn (mulVI (getAnnotation x) (getAnnotation y)) $ App Mul (typeof x) [x, y]
 
-mkBinds :: ([BindInfo], AUntypedFeld ValueInfo) -> AbsInfo -> ([BindInfo], UExp)
+mkBinds :: ([BindInfo], UntypedFeld ValueInfo) -> AbsInfo -> ([BindInfo], UExp)
 mkBinds (bs, e) LoopI{trip = (_,eTrip), ixVar = v} = catch (shiftBIs bs) loopE
   where loopE = AIn r $ App EparFor (typeof e) [eTrip, AIn r $ Lambda v e]
         r = getAnnotation e

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -54,7 +54,7 @@ import qualified Feldspar.Core.Representation as R
 import Feldspar.Core.Representation (AExpr(..), Expr(..))
 import Data.Complex (Complex(..))
 
-toU :: AExpr a -> AUntypedFeld ValueInfo
+toU :: AExpr a -> UntypedFeld ValueInfo
 toU (((R.Info i) :: R.Info a) :& e)
   | Sym (R.Variable (R.Var n s)) <- e
   = i2 $ Variable $ Var n (untypeType tr i) s
@@ -82,7 +82,7 @@ toU (((R.Info i) :: R.Info a) :& e)
   = i2 $ App op (untypeType tr i) es
   where tr = typeRepF :: TypeRep a
         i2 = AIn $ toValueInfo tr i
-        go :: forall a' . Expr a' -> [AUntypedFeld ValueInfo] -> (Op, [AUntypedFeld ValueInfo])
+        go :: forall a' . Expr a' -> [UntypedFeld ValueInfo] -> (Op, [UntypedFeld ValueInfo])
         go (Sym op) es = (trOp op, es)
         go (f :@ e') es = go f $ toU e' : es
         addDrop e'@(AIn _ (App (Drop _) _ _)) = e'

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -67,26 +67,26 @@ toU (((R.Info i) :: R.Info a) :& e)
   = i2 $ Lambda (Var n (untypeType b (fst i)) s) $ toU e'
   | Sym R.Cons :@ a1 :@ a2 <- e
   , e' <- toU a1
-  , AIn _ (App Tup (U.TupType ts) es) <- toU a2
+  , In _ (App Tup (U.TupType ts) es) <- toU a2
   = i2 $ App Tup (U.TupType $ typeof e' : ts) $ e' : es
   | Sym R.Car :@ a <- e
-  , AIn _ (App (Drop n) (U.TupType (t:_)) es) <- addDrop $ toU a
+  , In _ (App (Drop n) (U.TupType (t:_)) es) <- addDrop $ toU a
   = i2 $ App (Sel n) t es
   | Sym R.Cdr :@ a <- e
-  , AIn _ (App (Drop n) (U.TupType (_:ts)) es) <- addDrop $ toU a
+  , In _ (App (Drop n) (U.TupType (_:ts)) es) <- addDrop $ toU a
   = i2 $ App (Drop $ n + 1) (U.TupType ts) es
   | Sym R.Tup :@ a <- e
-  , AIn _ e' <- toU a
+  , In _ e' <- toU a
   = i2 e'
   | (op, es) <- go e []
   = i2 $ App op (untypeType tr i) es
   where tr = typeRepF :: TypeRep a
-        i2 = AIn $ toValueInfo tr i
+        i2 = In $ toValueInfo tr i
         go :: forall a' . Expr a' -> [UntypedFeld ValueInfo] -> (Op, [UntypedFeld ValueInfo])
         go (Sym op) es = (trOp op, es)
         go (f :@ e') es = go f $ toU e' : es
-        addDrop e'@(AIn _ (App (Drop _) _ _)) = e'
-        addDrop e' = AIn (error "FromTyped: temporary drop")
+        addDrop e'@(In _ (App (Drop _) _ _)) = e'
+        addDrop e' = In (error "FromTyped: temporary drop")
                          (App (Drop 0) (typeof e') [e'])
 
 -- | Translate a Typed operator to the corresponding untyped one

--- a/src/Feldspar/Core/Middleend/LetSinking.hs
+++ b/src/Feldspar/Core/Middleend/LetSinking.hs
@@ -10,17 +10,17 @@ import Feldspar.Core.UntypedRepresentation
 --
 sinkLets :: Options -> UntypedFeld a -> UntypedFeld a
 sinkLets opts = collectAtTop opts . go
-  where go e@(AIn _ Variable{}) = e
-        go (AIn r (Lambda v e))
-         | (bs1, AIn r' (Lambda v' body)) <- collectLetBinders e
+  where go e@(In _ Variable{}) = e
+        go (In r (Lambda v e))
+         | (bs1, In r' (Lambda v' body)) <- collectLetBinders e
          , not $ null bs1
-         = AIn r (Lambda v $ go (AIn r' (Lambda v' $ mkLets (bs1, body))))
-        go (AIn r (Lambda v e)) = AIn r (Lambda v (go e))
-        go (AIn r (LetFun (s, k, e1) e2)) = AIn r (LetFun (s, k, go e1) (go e2))
-        go l@(AIn _ Literal{}) = l
-        go (AIn r (App Let t [e1, AIn r' (Lambda x e2)]))
-         = AIn r (App Let t [go e1, AIn r' (Lambda x $ go e2)])
-        go (AIn r (App p t es)) = AIn r (App p t $ map go es)
+         = In r (Lambda v $ go (In r' (Lambda v' $ mkLets (bs1, body))))
+        go (In r (Lambda v e)) = In r (Lambda v (go e))
+        go (In r (LetFun (s, k, e1) e2)) = In r (LetFun (s, k, go e1) (go e2))
+        go l@(In _ Literal{}) = l
+        go (In r (App Let t [e1, In r' (Lambda x e2)]))
+         = In r (App Let t [go e1, In r' (Lambda x $ go e2)])
+        go (In r (App p t es)) = In r (App p t $ map go es)
 
 -- | Converts let x = .. in .. \x2 -> e to \x2 -> let x = .. in e
 --   for the top level expression when BA is a target.

--- a/src/Feldspar/Core/Middleend/LetSinking.hs
+++ b/src/Feldspar/Core/Middleend/LetSinking.hs
@@ -8,7 +8,7 @@ import Feldspar.Core.UntypedRepresentation
 -- | Sink lets that are stuck between two lambdas.
 -- Necessary invariant: lambdas can only appear in special places.
 --
-sinkLets :: Options -> AUntypedFeld a -> AUntypedFeld a
+sinkLets :: Options -> UntypedFeld a -> UntypedFeld a
 sinkLets opts = collectAtTop opts . go
   where go e@(AIn _ Variable{}) = e
         go (AIn r (Lambda v e))
@@ -24,7 +24,7 @@ sinkLets opts = collectAtTop opts . go
 
 -- | Converts let x = .. in .. \x2 -> e to \x2 -> let x = .. in e
 --   for the top level expression when BA is a target.
-collectAtTop :: Options -> AUntypedFeld a -> AUntypedFeld a
+collectAtTop :: Options -> UntypedFeld a -> UntypedFeld a
 collectAtTop opts e
   | BA `inTarget` opts
   , (bs, e1) <- collectLetBinders e -- Get outermost let bindings

--- a/src/Feldspar/Core/Middleend/OptimizeUntyped.hs
+++ b/src/Feldspar/Core/Middleend/OptimizeUntyped.hs
@@ -38,10 +38,10 @@ import Feldspar.Core.Middleend.FromTypeUtil (convSize)
 import Feldspar.Core.Types (BitWidth(..))
 
 -- | General simplification. Could in theory be done at earlier stages.
-optimize :: AUntypedFeld ValueInfo -> AUntypedFeld ValueInfo
+optimize :: UntypedFeld ValueInfo -> UntypedFeld ValueInfo
 optimize e = deadCodeElim $ simplify M.empty e -- go empty . go empty
 
-type AExp = AUntypedFeld ValueInfo -- ^ Annotated expressions
+type AExp = UntypedFeld ValueInfo -- ^ Annotated expressions
 type UExp = UntypedFeldF AExp -- ^ Unannotated expressions
 type SM = M.Map VarId AExp -- ^ Associate a let bound variable with its value
 
@@ -261,14 +261,14 @@ unwrap :: AExp -> UExp
 unwrap (AIn _ e) = e
 
 -- | Is this a literal zero.
-zero :: AUntypedFeld a -> Bool
+zero :: UntypedFeld a -> Bool
 zero (AIn _ (Literal (LInt    _ _ 0))) = True
 zero (AIn _ (Literal (LFloat      0))) = True
 zero (AIn _ (Literal (LDouble     0))) = True
 zero _                                 = False
 
 -- | Is this a literal one.
-one :: AUntypedFeld a -> Bool
+one :: UntypedFeld a -> Bool
 one (AIn _ (Literal (LInt    _ _ 1))) = True
 one (AIn _ (Literal (LFloat      1))) = True
 one (AIn _ (Literal (LDouble     1))) = True
@@ -276,7 +276,7 @@ one _                                 = False
 
 -- | Simple constant folder that returns result or the original expression
 -- | Num, Ord and Eq operations
-constFold :: AUntypedFeld ValueInfo -> Op -> Lit -> Lit -> AUntypedFeld ValueInfo
+constFold :: UntypedFeld ValueInfo -> Op -> Lit -> Lit -> UntypedFeld ValueInfo
 constFold _ Add (LInt sz n n1) (LInt _ _ n2) = aLit (LInt sz n (n1 + n2))
 constFold _ Sub (LInt sz n n1) (LInt _ _ n2) = aLit (LInt sz n (n1 - n2))
 constFold _ Mul (LInt sz n n1) (LInt _ _ n2) = aLit (LInt sz n (n1 * n2))
@@ -325,13 +325,13 @@ constFold _ GetIx (LArray _ ls) (LInt _ _ n)
 
 constFold e _ _ _ = e
 
-constFold1 :: AUntypedFeld ValueInfo -> Op -> Lit -> AUntypedFeld ValueInfo
+constFold1 :: UntypedFeld ValueInfo -> Op -> Lit -> UntypedFeld ValueInfo
 constFold1 e GetLength (LArray _ xs)
   | 1 :# IntType s n <- typeof e = aLit (LInt s n $ fromIntegral $ length xs)
 constFold1 e _ _ = e
 
 -- | Scan an Epar/Ewrite-nest and return the element written to a position.
-grabWrite :: Integer -> AUntypedFeld a -> Maybe (AUntypedFeld a)
+grabWrite :: Integer -> UntypedFeld a -> Maybe (UntypedFeld a)
 grabWrite n (AIn _ (App EPar _ [e1,e2]))
  | Nothing <- r1 = grabWrite n e2
  | otherwise = r1
@@ -343,7 +343,7 @@ grabWrite _ _ = Nothing
 mkLet :: Var -> AExp -> AExp -> AExp
 mkLet v rhs body = mkLets ([(v,rhs)], body)
 
-eUnit :: AUntypedFeld ValueInfo
+eUnit :: UntypedFeld ValueInfo
 eUnit = aLit $ LTup []
 
 -- We need to eliminate dead bindings

--- a/src/Feldspar/Core/Middleend/PushLets.hs
+++ b/src/Feldspar/Core/Middleend/PushLets.hs
@@ -33,7 +33,7 @@ module Feldspar.Core.Middleend.PushLets (pushLets) where
 import Feldspar.Core.UntypedRepresentation
 import Feldspar.Core.Middleend.Constructors
 
-pushLets :: AUntypedFeld a -> AUntypedFeld a
+pushLets :: UntypedFeld a -> UntypedFeld a
 pushLets = toExpr . go
   where go (AIn _ (App Let _ [rhs, AIn _ (Lambda v body)]))
            | legalToInline rhs = push v (go rhs) (toExpr $ go body)
@@ -48,7 +48,7 @@ data OCount = OC {low, high :: Int}
 data DSCount = DS {dynamic :: OCount, static :: Int}
   deriving (Eq, Show)
 
-push :: Var -> AExpB a -> AUntypedFeld a -> AExpB a
+push :: Var -> AExpB a -> UntypedFeld a -> AExpB a
 push v rhs = snd . goA False False
   where goA lo pa (AIn r1 e) = (norm n1, aIn r1 $ if ph then eB else e1)
            where (n1,e1) = go lo (pa || ph) e

--- a/src/Feldspar/Core/Middleend/PushLets.hs
+++ b/src/Feldspar/Core/Middleend/PushLets.hs
@@ -35,11 +35,11 @@ import Feldspar.Core.Middleend.Constructors
 
 pushLets :: UntypedFeld a -> UntypedFeld a
 pushLets = toExpr . go
-  where go (AIn _ (App Let _ [rhs, AIn _ (Lambda v body)]))
+  where go (In _ (App Let _ [rhs, In _ (Lambda v body)]))
            | legalToInline rhs = push v (go rhs) (toExpr $ go body)
            | otherwise = mkBinds ([(v, go rhs)], go body)
-        go (AIn r (App op t es)) = aIn r $ app op t $ map go es
-        go (AIn r (Lambda v e)) = aIn r $ lambda v $ go e
+        go (In r (App op t es)) = aIn r $ app op t $ map go es
+        go (In r (Lambda v e)) = aIn r $ lambda v $ go e
         go e = fromExpr e
 
 data OCount = OC {low, high :: Int}
@@ -50,7 +50,7 @@ data DSCount = DS {dynamic :: OCount, static :: Int}
 
 push :: Var -> AExpB a -> UntypedFeld a -> AExpB a
 push v rhs = snd . goA False False
-  where goA lo pa (AIn r1 e) = (norm n1, aIn r1 $ if ph then eB else e1)
+  where goA lo pa (In r1 e) = (norm n1, aIn r1 $ if ph then eB else e1)
            where (n1,e1) = go lo (pa || ph) e
                  d1 = dynamic n1
                  ph = not pa && (high d1 > 1 || low d1 > 0 && static n1 > 1)

--- a/src/Feldspar/Core/Middleend/UniqueVars.hs
+++ b/src/Feldspar/Core/Middleend/UniqueVars.hs
@@ -37,17 +37,17 @@ import qualified Data.Map.Strict as M
 import Control.Monad.State
 
 type U a = State (S.Set VarId) a
-type RRExp a = UntypedFeldF (AUntypedFeld a)
+type RRExp a = UntypedFeldF (UntypedFeld a)
 
 {- | Ensure that each variable binding binds a unique variable.
      This invariant is import since some back ends declare all
      variables at top level.
 -}
 
-uniqueVars :: AUntypedFeld a -> AUntypedFeld a
+uniqueVars :: UntypedFeld a -> UntypedFeld a
 uniqueVars e = evalState (uniqA M.empty e) S.empty
 
-uniqA :: M.Map VarId (RRExp a) -> AUntypedFeld a -> U (AUntypedFeld a)
+uniqA :: M.Map VarId (RRExp a) -> UntypedFeld a -> U (UntypedFeld a)
 uniqA vm (AIn r e) = do e1 <- uniq vm e
                         return $ AIn r e1
 

--- a/src/Feldspar/Core/Middleend/UniqueVars.hs
+++ b/src/Feldspar/Core/Middleend/UniqueVars.hs
@@ -48,8 +48,8 @@ uniqueVars :: UntypedFeld a -> UntypedFeld a
 uniqueVars e = evalState (uniqA M.empty e) S.empty
 
 uniqA :: M.Map VarId (RRExp a) -> UntypedFeld a -> U (UntypedFeld a)
-uniqA vm (AIn r e) = do e1 <- uniq vm e
-                        return $ AIn r e1
+uniqA vm (In r e) = do e1 <- uniq vm e
+                       return $ In r e1
 
 uniq :: M.Map VarId (RRExp a) -> RRExp a -> U (RRExp a)
 uniq vm (Variable v) = return $ vm M.! varNum v

--- a/src/Feldspar/Core/ValueInfo.hs
+++ b/src/Feldspar/Core/ValueInfo.hs
@@ -108,7 +108,7 @@ instance Show ValueInfo where
 
 -- | Annotate a literal with value info.
 aLit :: Lit -> UntypedFeld ValueInfo
-aLit l = AIn (literalVI l) (Literal l)
+aLit l = In (literalVI l) (Literal l)
 
 -- | Construct an Elements value info from those of the index and value parts
 elementsVI :: ValueInfo -> ValueInfo -> ValueInfo

--- a/src/Feldspar/Core/ValueInfo.hs
+++ b/src/Feldspar/Core/ValueInfo.hs
@@ -107,7 +107,7 @@ instance Show ValueInfo where
   show (VIProd vs)  = "VIProd " ++ show vs
 
 -- | Annotate a literal with value info.
-aLit :: Lit -> AUntypedFeld ValueInfo
+aLit :: Lit -> UntypedFeld ValueInfo
 aLit l = AIn (literalVI l) (Literal l)
 
 -- | Construct an Elements value info from those of the index and value parts

--- a/tests/RegressionTests.hs
+++ b/tests/RegressionTests.hs
@@ -169,12 +169,12 @@ noinline1 x = noInline $ not x
 --   actions. This expression cannot be created from the Feldspar front end.
 foreignEffect :: UT.UntypedFeld ValueInfo
 foreignEffect =
-    UT.AIn (topInfo void) $ UT.App UT.Then void
+    UT.In (topInfo void) $ UT.App UT.Then void
         [ alert
-        , UT.AIn (topInfo void) $ UT.App UT.Bind void
+        , UT.In (topInfo void) $ UT.App UT.Bind void
             [ getPos
-            , UT.AIn (topInfo void) $
-               UT.Lambda pos $ UT.AIn (topInfo void) $ UT.App UT.Then void
+            , UT.In (topInfo void) $
+               UT.Lambda pos $ UT.In (topInfo void) $ UT.App UT.Then void
                   [ launchMissiles
                   , cleanUp
                   ]
@@ -183,15 +183,15 @@ foreignEffect =
   where
     void   = UT.MutType (UT.TupType [])
     pos    = UT.Var 77 posType B.empty
-    alert  = UT.AIn (topInfo void) $ UT.App (UT.ForeignImport "alert") void []
+    alert  = UT.In (topInfo void) $ UT.App (UT.ForeignImport "alert") void []
     posType = 1 UT.:# UT.FloatType
-    getPos = UT.AIn (topInfo posType) $
+    getPos = UT.In (topInfo posType) $
                UT.App (UT.ForeignImport "getPos") posType []
     launchMissiles =
-      UT.AIn (topInfo void) $
+      UT.In (topInfo void) $
         UT.App (UT.ForeignImport "launchMissiles") void
-          [UT.AIn (topInfo posType) $ UT.Variable pos]
-    cleanUp = UT.AIn (topInfo void) $
+          [UT.In (topInfo posType) $ UT.Variable pos]
+    cleanUp = UT.In (topInfo void) $
                 UT.App (UT.ForeignImport "cleanUp") void []
 
 tuples :: Data Int32 -> Data Int32

--- a/tests/RegressionTests.hs
+++ b/tests/RegressionTests.hs
@@ -167,7 +167,7 @@ noinline1 x = noInline $ not x
 
 -- | Test that foreign imports with result type `M ()` can be used as monadic
 --   actions. This expression cannot be created from the Feldspar front end.
-foreignEffect :: UT.AUntypedFeld ValueInfo
+foreignEffect :: UT.UntypedFeld ValueInfo
 foreignEffect =
     UT.AIn (topInfo void) $ UT.App UT.Then void
         [ alert
@@ -495,7 +495,7 @@ mkGoldTest fun n opts = do
     goldenTest n (vgReadFiles ref) (liftIO act >> vgReadFiles new) cmp upd
 
 -- | Make a golden test for an untyped Feldspar expression
-mkGoldTestUT :: UT.AUntypedFeld ValueInfo -> Prelude.FilePath -> Options -> TestTree
+mkGoldTestUT :: UT.UntypedFeld ValueInfo -> Prelude.FilePath -> Options -> TestTree
 mkGoldTestUT untyped n opts = do
     let ref = goldDir <> n
         new = testDir <> n


### PR DESCRIPTION
After the removal of the un-annotated UntypedFeld,
we can now use that name for the annotated representation.