### PR TITLE
Build Tuple from NestedTuple

### DIFF
--- a/src/Feldspar/Core/NestedTuples.hs
+++ b/src/Feldspar/Core/NestedTuples.hs
@@ -43,11 +43,28 @@
 module Feldspar.Core.NestedTuples
   ( Tuple(..)
   , Proxy(..)
+  , TSelect
   , sel
   , tuple
   , build
+  -- * Taking tuples apart
   , nfst
   , nsnd
+  , sel1
+  , sel2
+  , sel3
+  , sel4
+  , sel5
+  , sel6
+  , sel7
+  , sel8
+  , sel9
+  , sel10
+  , sel11
+  , sel12
+  , sel13
+  , sel14
+  , sel15
   -- * Building tuples
   , onetup
   , twotup
@@ -151,6 +168,66 @@ nfst = sel (Proxy @0)
 -- | Extract the second component of a tuple.
 nsnd :: TSelect 1 a b => Tuple a -> b
 nsnd = sel (Proxy @1)
+
+-- | Extract the first component of a tuple.
+sel1 :: TSelect 0 a b => Tuple a -> b
+sel1 = nfst
+
+-- | Extract the second component of a tuple.
+sel2 :: TSelect 1 a b => Tuple a -> b
+sel2 = nsnd
+
+-- | Extract the third component of a tuple.
+sel3 :: TSelect 2 a b => Tuple a -> b
+sel3 = sel (Proxy @2)
+
+-- | Extract the fourth component of a tuple.
+sel4 :: TSelect 3 a b => Tuple a -> b
+sel4 = sel (Proxy @3)
+
+-- | Extract the fifth component of a tuple.
+sel5 :: TSelect 4 a b => Tuple a -> b
+sel5 = sel (Proxy @4)
+
+-- | Extract the sixth component of a tuple.
+sel6 :: TSelect 5 a b => Tuple a -> b
+sel6 = sel (Proxy @5)
+
+-- | Extract the seventh component of a tuple.
+sel7 :: TSelect 6 a b => Tuple a -> b
+sel7 = sel (Proxy @6)
+
+-- | Extract the eight component of a tuple.
+sel8 :: TSelect 7 a b => Tuple a -> b
+sel8 = sel (Proxy @7)
+
+-- | Extract the ninth component of a tuple.
+sel9 :: TSelect 8 a b => Tuple a -> b
+sel9 = sel (Proxy @8)
+
+-- | Extract the tenth component of a tuple.
+sel10 :: TSelect 9 a b => Tuple a -> b
+sel10 = sel (Proxy @9)
+
+-- | Extract the eleventh component of a tuple.
+sel11 :: TSelect 10 a b => Tuple a -> b
+sel11 = sel (Proxy @10)
+
+-- | Extract the twelth component of a tuple.
+sel12 :: TSelect 11 a b => Tuple a -> b
+sel12 = sel (Proxy @11)
+
+-- | Extract the thirteenth component of a tuple.
+sel13 :: TSelect 12 a b => Tuple a -> b
+sel13 = sel (Proxy @12)
+
+-- | Extract the fourteenth component of a tuple.
+sel14 :: TSelect 13 a b => Tuple a -> b
+sel14 = sel (Proxy @13)
+
+-- | Extract the fifteenth component of a tuple.
+sel15 :: TSelect 14 a b => Tuple a -> b
+sel15 = sel (Proxy @14)
 
 -- | Function for constructing a one-tuple from its components.
 onetup :: a -> Tuple '[a]

--- a/src/Feldspar/Core/Tuple.hs
+++ b/src/Feldspar/Core/Tuple.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# OPTIONS_GHC -Wall #-}
-
 --
 -- Copyright (c) 2019, ERICSSON AB
 -- All rights reserved.
@@ -31,297 +25,175 @@
 -- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 -- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wall #-}
 
 module Feldspar.Core.Tuple where
+
+import Feldspar.Core.NestedTuples (TSelect, Tuple(..), build, tuple)
+import qualified Feldspar.Core.NestedTuples as N
 
 class Tuply a where
   type Unpack a
   unpack :: a -> Unpack a
 
 instance Tuply (a,b) where
-  type Unpack (a,b) = (a, (b, ()))
-  unpack (a,b) = (a, (b, ()))
+  type Unpack (a, b) = Tuple '[a, b]
+  unpack (a, b) = build $ tuple a b
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c) where
-  type Unpack (a,b,c) = (a,(b,(c,())))
-  unpack (a,b,c) = (a,(b,(c,())))
+  type Unpack (a, b, c) = Tuple '[a, b, c]
+  unpack (a, b, c) = build $ tuple a b c
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d) where
-  type Unpack (a,b,c,d) = (a,(b,(c,(d,()))))
-  unpack (a,b,c,d) = (a,(b,(c,(d,()))))
+  type Unpack (a, b, c, d) = Tuple '[a, b, c, d]
+  unpack (a, b, c, d) = build $ tuple a b c d
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e) where
-  type Unpack (a,b,c,d,e)
-             = (a,(b,(c,(d,(e,())))))
-  unpack (a,b,c,d,e)
-             = (a,(b,(c,(d,(e,())))))
+  type Unpack (a, b, c, d, e) = Tuple '[a, b, c, d, e]
+  unpack (a, b, c, d, e) = build $ tuple a b c d e
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f) where
-  type Unpack (a,b,c,d,e,f)
-             = (a,(b,(c,(d,(e,(f,()))))))
-  unpack (a,b,c,d,e,f)
-             = (a,(b,(c,(d,(e,(f,()))))))
+  type Unpack (a, b, c, d, e, f) = Tuple '[a, b, c, d, e, f]
+  unpack (a, b, c, d, e, f) = build $ tuple a b c d e f
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g) where
-  type Unpack (a,b,c,d,e,f,g)
-             = (a,(b,(c,(d,(e,(f,(g,())))))))
-  unpack (a,b,c,d,e,f,g)
-             = (a,(b,(c,(d,(e,(f,(g,())))))))
+  type Unpack (a, b, c, d, e, f, g) = Tuple '[a, b, c, d, e, f, g]
+  unpack (a, b, c, d, e, f, g) = build $ tuple a b c d e f g
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h) where
-  type Unpack (a,b,c,d,e,f,g,h)
-             = (a,(b,(c,(d,(e,(f,(g,(h,()))))))))
-  unpack (a,b,c,d,e,f,g,h)
-             = (a,(b,(c,(d,(e,(f,(g,(h,()))))))))
+  type Unpack (a, b, c, d, e, f, g, h) = Tuple '[a, b, c, d, e, f, g, h]
+  unpack (a, b, c, d, e, f, g, h) = build $ tuple a b c d e f g h
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i) where
-  type Unpack (a,b,c,d,e,f,g,h,i)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,())))))))))
-  unpack (a,b,c,d,e,f,g,h,i)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,())))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i)
+             = Tuple '[a, b, c, d, e, f, g, h, i]
+  unpack (a, b, c, d, e, f, g, h, i) = build $ tuple a b c d e f g h i
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i,j) where
-  type Unpack (a,b,c,d,e,f,g,h,i,j)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,()))))))))))
-  unpack (a,b,c,d,e,f,g,h,i,j)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,()))))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i, j)
+             = Tuple '[a, b, c, d, e, f, g, h, i, j]
+  unpack (a, b, c, d, e, f, g, h, i, j) = build $ tuple a b c d e f g h i j
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i,j,k) where
-  type Unpack (a,b,c,d,e,f,g,h,i,j,k)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,())))))))))))
-  unpack (a,b,c,d,e,f,g,h,i,j,k)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,())))))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i, j, k)
+             = Tuple '[a, b, c, d, e, f, g, h, i, j, k]
+  unpack (a, b, c, d, e, f, g, h, i, j, k) = build $ tuple a b c d e f g h i j k
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i,j,k,l) where
-  type Unpack (a,b,c,d,e,f,g,h,i,j,k,l)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,(l,()))))))))))))
-  unpack (a,b,c,d,e,f,g,h,i,j,k,l)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,(l,()))))))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i, j, k, l)
+             = Tuple '[a, b, c, d, e, f, g, h, i, j, k, l]
+  unpack (a, b, c, d, e, f, g, h, i, j, k, l)
+             = build $ tuple a b c d e f g h i j k l
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i,j,k,l,m) where
-  type Unpack (a,b,c,d,e,f,g,h,i,j,k,l,m)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,(l,(m,())))))))))))))
-  unpack (a,b,c,d,e,f,g,h,i,j,k,l,m)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,(l,(m,())))))))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i, j, k, l, m)
+             = Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m]
+  unpack (a, b, c, d, e, f, g, h, i, j, k, l, m)
+             = build $ tuple a b c d e f g h i j k l m
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i,j,k,l,m,n) where
-  type Unpack (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,(l,(m,(n,()))))))))))))))
-  unpack (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-             = (a,(b,(c,(d,(e,(f,(g,(h,(i,(j,(k,(l,(m,(n,()))))))))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+             = Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m, n]
+  unpack (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+             = build $ tuple a b c d e f g h i j k l m n
   {-# INLINE unpack #-}
 
 instance Tuply (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) where
-  type Unpack (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
-             = (a, (b, (c, (d, (e, (f, (g, (h, (i, (j, (k, (l, (m, (n, (o, ())))))))))))))))
-  unpack (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
-             = (a, (b, (c, (d, (e, (f, (g, (h, (i, (j, (k, (l, (m, (n, (o, ())))))))))))))))
+  type Unpack (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+             = Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o]
+  unpack (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+             = build $ tuple a b c d e f g h i j k l m n o
   {-# INLINE unpack #-}
 
-
-class Sel1C a where
-  type Sel1T a
-  sel1w :: a -> Sel1T a
-
-instance Sel1C (a,z) where
-  type Sel1T (a,z) = a
-  sel1w = fst
-  {-# INLINE sel1w #-}
-
-class Sel1C a => Sel2C a where
-  type Sel2T a
-  sel2w :: a -> Sel2T a
-
-instance Sel1C t => Sel2C (a,t) where
-  type Sel2T (a,t) = Sel1T t
-  sel2w = sel1w . snd
-  {-# INLINE sel2w #-}
-
-class Sel2C a => Sel3C a where
-  type Sel3T a
-  sel3w :: a -> Sel3T a
-
-instance Sel2C t => Sel3C (a,t) where
-  type Sel3T (a,t) = Sel2T t
-  sel3w = sel2w . snd
-  {-# INLINE sel3w #-}
-
-class Sel3C a => Sel4C a where
-  type Sel4T a
-  sel4w :: a -> Sel4T a
-
-instance Sel3C t => Sel4C (a,t) where
-  type Sel4T (a,t) = Sel3T t
-  sel4w = sel3w . snd
-  {-# INLINE sel4w #-}
-
-class Sel4C a => Sel5C a where
-  type Sel5T a
-  sel5w :: a -> Sel5T a
-
-instance Sel4C t => Sel5C (a,t) where
-  type Sel5T (a,t) = Sel4T t
-  sel5w = sel4w . snd
-  {-# INLINE sel5w #-}
-
-class Sel5C a => Sel6C a where
-  type Sel6T a
-  sel6w :: a -> Sel6T a
-
-instance Sel5C t => Sel6C (a,t) where
-  type Sel6T (a,t) = Sel5T t
-  sel6w = sel5w . snd
-  {-# INLINE sel6w #-}
-
-class Sel6C a => Sel7C a where
-  type Sel7T a
-  sel7w :: a -> Sel7T a
-
-instance Sel6C t => Sel7C (a,t) where
-  type Sel7T (a,t) = Sel6T t
-  sel7w = sel6w . snd
-  {-# INLINE sel7w #-}
-
-class Sel7C a => Sel8C a where
-  type Sel8T a
-  sel8w :: a -> Sel8T a
-
-instance Sel7C t => Sel8C (a,t) where
-  type Sel8T (a,t) = Sel7T t
-  sel8w = sel7w . snd
-  {-# INLINE sel8w #-}
-
-class Sel8C a => Sel9C a where
-  type Sel9T a
-  sel9w :: a -> Sel9T a
-
-instance Sel8C t => Sel9C (a,t) where
-  type Sel9T (a,t) = Sel8T t
-  sel9w = sel8w . snd
-  {-# INLINE sel9w #-}
-
-class Sel9C a => Sel10C a where
-  type Sel10T a
-  sel10w :: a -> Sel10T a
-
-instance Sel9C t => Sel10C (a,t) where
-  type Sel10T (a,t) = Sel9T t
-  sel10w = sel9w . snd
-  {-# INLINE sel10w #-}
-
-class Sel10C a => Sel11C a where
-  type Sel11T a
-  sel11w :: a -> Sel11T a
-
-instance Sel10C t => Sel11C (a,t) where
-  type Sel11T (a,t) = Sel10T t
-  sel11w = sel10w . snd
-  {-# INLINE sel11w #-}
-
-class Sel11C a => Sel12C a where
-  type Sel12T a
-  sel12w :: a -> Sel12T a
-
-instance Sel11C t => Sel12C (a,t) where
-  type Sel12T (a,t) = Sel11T t
-  sel12w = sel11w . snd
-  {-# INLINE sel12w #-}
-
-class Sel12C a => Sel13C a where
-  type Sel13T a
-  sel13w :: a -> Sel13T a
-
-instance Sel12C t => Sel13C (a,t) where
-  type Sel13T (a,t) = Sel12T t
-  sel13w = sel12w . snd
-  {-# INLINE sel13w #-}
-
-class Sel13C a => Sel14C a where
-  type Sel14T a
-  sel14w :: a -> Sel14T a
-
-instance Sel13C t => Sel14C (a,t) where
-  type Sel14T (a,t) = Sel13T t
-  sel14w = sel13w . snd
-  {-# INLINE sel14w #-}
-
-class Sel14C a => Sel15C a where
-  type Sel15T a
-  sel15w :: a -> Sel15T a
-
-instance Sel14C t => Sel15C (a,t) where
-  type Sel15T (a,t) = Sel14T t
-  sel15w = sel14w . snd
-  {-# INLINE sel15w #-}
-
-sel1 :: (Tuply w, Sel1C (Unpack w)) => w -> Sel1T (Unpack w)
+-- | Extract the first component of a tuple.
+sel1 :: (TSelect 0 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel1 = N.sel1 . unpack
 {-# INLINE sel1 #-}
-sel1 = sel1w . unpack
 
-sel2 :: (Tuply w, Sel2C (Unpack w)) => w -> Sel2T (Unpack w)
+-- | Extract the second component of a tuple.
+sel2 :: (TSelect 1 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel2 = N.sel2 . unpack
 {-# INLINE sel2 #-}
-sel2 = sel2w . unpack
 
-sel3 :: (Tuply w, Sel3C (Unpack w)) => w -> Sel3T (Unpack w)
+-- | Extract the third component of a tuple.
+sel3 :: (TSelect 2 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel3 = N.sel3 . unpack
 {-# INLINE sel3 #-}
-sel3 = sel3w . unpack
 
-sel4 :: (Tuply w, Sel4C (Unpack w)) => w -> Sel4T (Unpack w)
+-- | Extract the fourth component of a tuple.
+sel4 :: (TSelect 3 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel4 = N.sel4 . unpack
 {-# INLINE sel4 #-}
-sel4 = sel4w . unpack
 
-sel5 :: (Tuply w, Sel5C (Unpack w)) => w -> Sel5T (Unpack w)
+-- | Extract the fifth component of a tuple.
+sel5 :: (TSelect 4 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel5 = N.sel5 . unpack
 {-# INLINE sel5 #-}
-sel5 = sel5w . unpack
 
-sel6 :: (Tuply w, Sel6C (Unpack w)) => w -> Sel6T (Unpack w)
+-- | Extract the sixth component of a tuple.
+sel6 :: (TSelect 5 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel6 = N.sel6 . unpack
 {-# INLINE sel6 #-}
-sel6 = sel6w . unpack
 
-sel7 :: (Tuply w, Sel7C (Unpack w)) => w -> Sel7T (Unpack w)
+-- | Extract the seventh component of a tuple.
+sel7 :: (TSelect 6 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel7 = N.sel7 . unpack
 {-# INLINE sel7 #-}
-sel7 = sel7w . unpack
 
-sel8 :: (Tuply w, Sel8C (Unpack w)) => w -> Sel8T (Unpack w)
+-- | Extract the eigth component of a tuple.
+sel8 :: (TSelect 7 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel8 = N.sel8 . unpack
 {-# INLINE sel8 #-}
-sel8 = sel8w . unpack
 
-sel9 :: (Tuply w, Sel9C (Unpack w)) => w -> Sel9T (Unpack w)
+-- | Extract the ninth component of a tuple.
+sel9 :: (TSelect 8 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel9 = N.sel9 . unpack
 {-# INLINE sel9 #-}
-sel9 = sel9w . unpack
 
-sel10 :: (Tuply w, Sel10C (Unpack w)) => w -> Sel10T (Unpack w)
+-- | Extract the tenth component of a tuple.
+sel10 :: (TSelect 9 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel10 = N.sel10 . unpack
 {-# INLINE sel10 #-}
-sel10 = sel10w . unpack
 
-sel11 :: (Tuply w, Sel11C (Unpack w)) => w -> Sel11T (Unpack w)
+-- | Extract the eleventh component of a tuple.
+sel11 :: (TSelect 10 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel11 = N.sel11 . unpack
 {-# INLINE sel11 #-}
-sel11 = sel11w . unpack
 
-sel12 :: (Tuply w, Sel12C (Unpack w)) => w -> Sel12T (Unpack w)
+-- | Extract the twelth component of a tuple.
+sel12 :: (TSelect 11 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel12 = N.sel12 . unpack
 {-# INLINE sel12 #-}
-sel12 = sel12w . unpack
 
-sel13 :: (Tuply w, Sel13C (Unpack w)) => w -> Sel13T (Unpack w)
+-- | Extract the thirteenth component of a tuple.
+sel13 :: (TSelect 12 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel13 = N.sel13 . unpack
 {-# INLINE sel13 #-}
-sel13 = sel13w . unpack
 
-sel14 :: (Tuply w, Sel14C (Unpack w)) => w -> Sel14T (Unpack w)
+-- | Extract the fourteenth component of a tuple.
+sel14 :: (TSelect 13 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel14 = N.sel14 . unpack
 {-# INLINE sel14 #-}
-sel14 = sel14w . unpack
 
-sel15 :: (Tuply w, Sel15C (Unpack w)) => w -> Sel15T (Unpack w)
+-- | Extract the fifteenth component of a tuple.
+sel15 :: (TSelect 14 a c, Tuply t, Unpack t ~ Tuple a) => t -> c
+sel15 = N.sel15 . unpack
 {-# INLINE sel15 #-}
-sel15 = sel15w . unpack

--- a/src/Feldspar/SimpleVector/Internal.hs
+++ b/src/Feldspar/SimpleVector/Internal.hs
@@ -44,7 +44,6 @@ import Test.QuickCheck
 
 import Feldspar.Core.Reify (Syntactic(..), resugar)
 import Feldspar.Core.Tuple
-import Feldspar.Core.NestedTuples
 
 import Feldspar.Range (rangeSubSat)
 import qualified Feldspar

--- a/src/Feldspar/Vector.hs
+++ b/src/Feldspar/Vector.hs
@@ -82,7 +82,7 @@ import Feldspar hiding (desugar,sugar,resugar)
 import qualified Feldspar as F
 import Feldspar.Core.Language
 import Feldspar.Core.Tuple
-import Feldspar.Core.NestedTuples
+import Feldspar.Core.NestedTuples (nfst, nsnd, twotup)
 import Feldspar.Vector.Shape
 
 import Control.Monad (zipWithM_)


### PR DESCRIPTION
The tuple support we need can be built on top
of NestedTuple so do that. The reason the initial
implementation of Tuple did not do that was because
the support for NestedTuples was not implemented.