### PR TITLE
Use type level literals as witnesses

### DIFF
--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -137,8 +137,7 @@ class Syntactic a where
     desugar :: a -> ASTF (Internal a)
     sugar   :: ASTF (Internal a) -> a
 
-instance Syntactic (ASTF a)
-  where
+instance Syntactic (ASTF a) where
     {-# SPECIALIZE instance Syntactic (ASTF a) #-}
     type Internal (ASTF a) = a
     desugar = id
@@ -163,18 +162,14 @@ instance (Syntactic a, T.Type (Internal a)) => Syntax a
 -- * Front end
 --------------------------------------------------------------------------------
 
-instance Syntactic ()
-  where
+instance Syntactic () where
     type Internal () = ()
     desugar = value
     sugar _ = ()
 
 newtype Data a = Data { unData :: ASTF a }
 
-deriving instance Typeable Data
-
-instance Syntactic (Data a)
-  where
+instance Syntactic (Data a) where
     type Internal (Data a) = a
     desugar = unData
     sugar   = Data
@@ -183,7 +178,7 @@ instance Eq (Data a) where
     (==) _ _ = error "Eq (Data a): Binding time violation"
 
 instance Show (Data a) where
-    show = render . desugar . unData
+  show = render . desugar
 
 -------------------------------------------------
 -- Functions
@@ -198,8 +193,7 @@ instance (Syntax a, Syntactic b, TypeF (Internal b)) => Syntactic (a -> b) where
           v = Var (fromIntegral i + hashBase) B.empty
 
 -- | User interface to embedded monadic programs
-newtype Mon m a
-  where
+newtype Mon m a where
     Mon
         :: { unMon
               :: forall r . (Monad m, Typeable r, T.Type r, T.Type (m r))
@@ -209,13 +203,11 @@ newtype Mon m a
 
 deriving instance Functor (Mon m)
 
-instance Monad m => Monad (Mon m)
-  where
+instance Monad m => Monad (Mon m) where
     return a = Mon $ return a
     ma >>= f = Mon $ unMon ma >>= unMon . f
 
-instance (Monad m, Applicative m) => Applicative (Mon m)
-  where
+instance (Monad m, Applicative m) => Applicative (Mon m) where
     pure  = return
     (<*>) = ap
 

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -78,6 +78,7 @@ import Data.Char (chr)
 import Data.List (partition)
 import qualified Data.Set as S
 import qualified Data.Map.Strict as M
+import GHC.TypeLits
 
 {-
 
@@ -363,16 +364,11 @@ normalizeTypeRep s = out -- Note [Debugging test output differences].
 instance Hashable a => Hashable (Complex a) where
   hash (re :+ im) = hash re `combine` hash im
 
-instance Hashable (T.Signedness a) where
-  hash T.U = hashInt 1
-  hash T.S = hashInt 2
+instance KnownSymbol a => Hashable (T.Signedness a) where
+  hash = hash . symbolVal
 
-instance Hashable (T.BitWidth a) where
-  hash T.N8      = hashInt 1
-  hash T.N16     = hashInt 2
-  hash T.N32     = hashInt 3
-  hash T.N64     = hashInt 4
-  hash T.NNative = hashInt 5
+instance KnownNat a => Hashable (T.BitWidth a) where
+  hash = hashInt . fromIntegral . natVal
 
 -- This instance is needed to allow nested tuples as literals (by the value function)
 instance HashTup a => Hashable (Tuple a) where

--- a/src/Feldspar/Core/Tuple.hs
+++ b/src/Feldspar/Core/Tuple.hs
@@ -33,7 +33,24 @@
 {-# LANGUAGE TypeApplications #-}
 {-# OPTIONS_GHC -Wall #-}
 
-module Feldspar.Core.Tuple where
+module Feldspar.Core.Tuple
+  ( -- * Taking tuples apart
+    sel1
+  , sel2
+  , sel3
+  , sel4
+  , sel5
+  , sel6
+  , sel7
+  , sel8
+  , sel9
+  , sel10
+  , sel11
+  , sel12
+  , sel13
+  , sel14
+  , sel15
+  ) where
 
 import Feldspar.Core.NestedTuples (TSelect, Tuple(..), build, tuple)
 import qualified Feldspar.Core.NestedTuples as N


### PR DESCRIPTION
This avoids some namespace pollution and moves
us one step closer to being able to define generic
N-bit types without a lot of boilerplate.