### PR TITLE
Build tuples on nested tuples

### DIFF
--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -235,76 +235,20 @@ untypeType (IntType s n) _          = 1 U.:# U.IntType (convSign s) (convSize n)
 untypeType FloatType _              = 1 U.:# U.FloatType
 untypeType DoubleType _             = 1 U.:# U.DoubleType
 untypeType (ComplexType t) _        = 1 U.:# U.ComplexType (untypeType t (defaultSize t))
-untypeType (Tup2Type a b) (sa,sb)
-  = U.TupType [untypeType a sa, untypeType b sb]
-untypeType (Tup3Type a b c) (sa,sb,sc)
-  = U.TupType [untypeType a sa, untypeType b sb, untypeType c sc]
-untypeType (Tup4Type a b c d) (sa,sb,sc,sd)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd
-              ]
-untypeType (Tup5Type a b c d e) (sa,sb,sc,sd,se)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se
-              ]
-untypeType (Tup6Type a b c d e f) (sa,sb,sc,sd,se,sf)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              ]
-untypeType (Tup7Type a b c d e f g) (sa,sb,sc,sd,se,sf,sg)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg
-              ]
-untypeType (Tup8Type a b c d e f g h) (sa,sb,sc,sd,se,sf,sg,sh)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh
-              ]
-untypeType (Tup9Type a b c d e f g h i) (sa,sb,sc,sd,se,sf,sg,sh,si)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              ]
-untypeType (Tup10Type a b c d e f g h i j) (sa,sb,sc,sd,se,sf,sg,sh,si,sj)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              , untypeType j sj
-              ]
-untypeType (Tup11Type a b c d e f g h i j k) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              , untypeType j sj, untypeType k sk
-              ]
-untypeType (Tup12Type a b c d e f g h i j k l) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              , untypeType j sj, untypeType k sk, untypeType l sl
-              ]
-untypeType (Tup13Type a b c d e f g h i j k l m) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl,sm)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              , untypeType j sj, untypeType k sk, untypeType l sl
-              , untypeType m sm
-              ]
-untypeType (Tup14Type a b c d e f g h i j k l m n) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl,sm,sn)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              , untypeType j sj, untypeType k sk, untypeType l sl
-              , untypeType m sm, untypeType n sn
-              ]
-untypeType (Tup15Type a b c d e f g h i j k l m n o) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl,sm,sn,so)
-  = U.TupType [ untypeType a sa, untypeType b sb, untypeType c sc
-              , untypeType d sd, untypeType e se, untypeType f sf
-              , untypeType g sg, untypeType h sh, untypeType i si
-              , untypeType j sj, untypeType k sk, untypeType l sl
-              , untypeType m sm, untypeType n sn, untypeType o so
-              ]
+untypeType (Tup2Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup3Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup4Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup5Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup6Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup7Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup8Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup9Type t) sz          = U.TupType $ untypeTup t sz
+untypeType (Tup10Type t) sz         = U.TupType $ untypeTup t sz
+untypeType (Tup11Type t) sz         = U.TupType $ untypeTup t sz
+untypeType (Tup12Type t) sz         = U.TupType $ untypeTup t sz
+untypeType (Tup13Type t) sz         = U.TupType $ untypeTup t sz
+untypeType (Tup14Type t) sz         = U.TupType $ untypeTup t sz
+untypeType (Tup15Type t) sz         = U.TupType $ untypeTup t sz
 untypeType (MutType a) sz              = U.MutType (untypeType a sz)
 untypeType (RefType a) sz              = U.RefType (untypeType a sz)
 untypeType (ArrayType a) (rs :> es)    = U.ArrayType rs (untypeType a es)
@@ -333,27 +277,6 @@ literal t@FloatType       sz a = literalConst t sz a
 literal t@DoubleType      sz a = literalConst t sz a
 literal t@ComplexType{}   sz a = literalConst t sz a
 literal t@ArrayType{}     sz a = literalConst t sz a
-literal (Tup2Type ta tb) (sa,sb) (a,b)
-    = LTup [literal ta sa a, literal tb sb b]
-literal (Tup3Type ta tb tc) (sa,sb,sc) (a,b,c)
-    = LTup [literal ta sa a, literal tb sb b, literal tc sc c]
-literal (Tup4Type ta tb tc td) (sa,sb,sc,sd) (a,b,c,d)
-    = LTup [ literal ta sa a, literal tb sb b, literal tc sc c
-           , literal td sd d
-           ]
-literal (Tup5Type ta tb tc td te) (sa,sb,sc,sd,se) (a,b,c,d,e)
-    = LTup [ literal ta sa a, literal tb sb b, literal tc sc c
-           , literal td sd d, literal te se e
-           ]
-literal (Tup6Type ta tb tc td te tf) (sa,sb,sc,sd,se,sf) (a,b,c,d,e,f)
-    = LTup [ literal ta sa a, literal tb sb b, literal tc sc c
-           , literal td sd d, literal te se e, literal tf sf f
-           ]
-literal (Tup7Type ta tb tc td te tf tg) (sa,sb,sc,sd,se,sf,sg) (a,b,c,d,e,f,g)
-    = LTup [ literal ta sa a, literal tb sb b, literal tc sc c
-           , literal td sd d, literal te se e, literal tf sf f
-           , literal tg sg g
-           ]
 literal _ _ _ = error "Missing pattern: FromTyped.hs: literal"
 
 literalConst :: TypeRep a -> T.Size a -> a -> Lit
@@ -385,76 +308,20 @@ toValueInfo (IntType T.S T.N64)     r       = VIInt64   r
 toValueInfo FloatType         _             = VIFloat
 toValueInfo DoubleType        _             = VIDouble
 toValueInfo (ComplexType _)   _             = VIProd []
-toValueInfo (Tup2Type a b) (sa,sb)
-  = VIProd [toValueInfo a sa, toValueInfo b sb]
-toValueInfo (Tup3Type a b c) (sa,sb,sc)
-  = VIProd [toValueInfo a sa, toValueInfo b sb, toValueInfo c sc]
-toValueInfo (Tup4Type a b c d) (sa,sb,sc,sd)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd
-           ]
-toValueInfo (Tup5Type a b c d e) (sa,sb,sc,sd,se)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se
-           ]
-toValueInfo (Tup6Type a b c d e f) (sa,sb,sc,sd,se,sf)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           ]
-toValueInfo (Tup7Type a b c d e f g) (sa,sb,sc,sd,se,sf,sg)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg
-           ]
-toValueInfo (Tup8Type a b c d e f g h) (sa,sb,sc,sd,se,sf,sg,sh)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh
-           ]
-toValueInfo (Tup9Type a b c d e f g h i) (sa,sb,sc,sd,se,sf,sg,sh,si)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-            ]
-toValueInfo (Tup10Type a b c d e f g h i j) (sa,sb,sc,sd,se,sf,sg,sh,si,sj)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-           , toValueInfo j sj
-           ]
-toValueInfo (Tup11Type a b c d e f g h i j k) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-           , toValueInfo j sj, toValueInfo k sk
-           ]
-toValueInfo (Tup12Type a b c d e f g h i j k l) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-           , toValueInfo j sj, toValueInfo k sk, toValueInfo l sl
-           ]
-toValueInfo (Tup13Type a b c d e f g h i j k l m) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl,sm)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-           , toValueInfo j sj, toValueInfo k sk, toValueInfo l sl
-           , toValueInfo m sm
-           ]
-toValueInfo (Tup14Type a b c d e f g h i j k l m n) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl,sm,sn)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-           , toValueInfo j sj, toValueInfo k sk, toValueInfo l sl
-           , toValueInfo m sm, toValueInfo n sn
-           ]
-toValueInfo (Tup15Type a b c d e f g h i j k l m n o) (sa,sb,sc,sd,se,sf,sg,sh,si,sj,sk,sl,sm,sn,so)
-  = VIProd [ toValueInfo a sa, toValueInfo b sb, toValueInfo c sc
-           , toValueInfo d sd, toValueInfo e se, toValueInfo f sf
-           , toValueInfo g sg, toValueInfo h sh, toValueInfo i si
-           , toValueInfo j sj, toValueInfo k sk, toValueInfo l sl
-           , toValueInfo m sm, toValueInfo n sn, toValueInfo o so
-           ]
+toValueInfo (Tup2Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup3Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup4Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup5Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup6Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup7Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup8Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup9Type t) sz                 = toValueInfo t sz
+toValueInfo (Tup10Type t) sz                = toValueInfo t sz
+toValueInfo (Tup11Type t) sz                = toValueInfo t sz
+toValueInfo (Tup12Type t) sz                = toValueInfo t sz
+toValueInfo (Tup13Type t) sz                = toValueInfo t sz
+toValueInfo (Tup14Type t) sz                = toValueInfo t sz
+toValueInfo (Tup15Type t) sz                = toValueInfo t sz
 toValueInfo (MutType a) sz                  = toValueInfo a sz
 toValueInfo (RefType a) sz                  = toValueInfo a sz
 toValueInfo (ArrayType a) (Range l r :> es)

--- a/src/Feldspar/Core/Reify.hs
+++ b/src/Feldspar/Core/Reify.hs
@@ -387,28 +387,21 @@ instance Hashable (T.TypeRep a) where
   hash T.DoubleType                 = hashInt 5
   hash (T.ComplexType t)            = hashInt 6 # t
   hash (T.ArrayType t)              = hashInt 7 # t
-  -- Index 8 available.
-  hash (T.Tup2Type a b)             = hashInt 9 # a # b
-  hash (T.Tup3Type a b c)           = hashInt 10 # a # b # c
-  hash (T.Tup4Type a b c d)         = hashInt 11 # a # b # c # d
-  hash (T.Tup5Type a b c d e)       = hashInt 12 # a # b # c # d # e
-  hash (T.Tup6Type a b c d e f)     = hashInt 13 # a # b # c # d # e # f
-  hash (T.Tup7Type a b c d e f g)   = hashInt 14 # a # b # c # d # e # f # g
-  hash (T.Tup8Type a b c d e f g h) = hashInt 15 # a # b # c # d # e # f # g # h
-  hash (T.Tup9Type a b c d e f g h i)
-       = hashInt 16 # a # b # c # d # e # f # g # h # i
-  hash (T.Tup10Type a b c d e f g h i j)
-       = hashInt 17 # a # b # c # d # e # f # g # h # i # j
-  hash (T.Tup11Type a b c d e f g h i j k)
-       = hashInt 18 # a # b # c # d # e # f # g # h # i # j # k
-  hash (T.Tup12Type a b c d e f g h i j k l)
-       = hashInt 19 # a # b # c # d # e # f # g # h # i # j # k # l
-  hash (T.Tup13Type a b c d e f g h i j k l m)
-       = hashInt 20 # a # b # c # d # e # f # g # h # i # j # k # l # m
-  hash (T.Tup14Type a b c d e f g h i j k l m n)
-       = hashInt 21 # a # b # c # d # e # f # g # h # i # j # k # l # m # n
-  hash (T.Tup15Type a b c d e f g h i j k l m n o)
-       = hashInt 22 # a # b # c # d # e # f # g # h # i # j # k # l # m # n # o
+  hash (T.Tup2Type t)               = hashInt 8 # t
+  hash (T.Tup3Type t)               = hashInt 9 # t
+  hash (T.Tup4Type t)               = hashInt 10 # t
+  hash (T.Tup5Type t)               = hashInt 11 # t
+  hash (T.Tup6Type t)               = hashInt 12 # t
+  hash (T.Tup7Type t)               = hashInt 13 # t
+  hash (T.Tup8Type t)               = hashInt 14 # t
+  hash (T.Tup9Type t)               = hashInt 15 # t
+  hash (T.Tup10Type t)              = hashInt 16 # t
+  hash (T.Tup11Type t)              = hashInt 17 # t
+  hash (T.Tup12Type t)              = hashInt 18 # t
+  hash (T.Tup13Type t)              = hashInt 19 # t
+  hash (T.Tup14Type t)              = hashInt 20 # t
+  hash (T.Tup15Type t)              = hashInt 21 # t
+  -- Index 22 available.
   hash (T.FunType a b)    = hashInt 23 # a # b
   hash (T.MutType t)      = hashInt 24 # t
   hash (T.RefType t)      = hashInt 25 # t

--- a/src/Feldspar/Core/Tuple.hs
+++ b/src/Feldspar/Core/Tuple.hs
@@ -34,8 +34,10 @@
 {-# OPTIONS_GHC -Wall #-}
 
 module Feldspar.Core.Tuple
-  ( -- * Taking tuples apart
-    sel1
+  ( -- * Converting tuples to nested tuples
+    Tuply(..)
+    -- * Taking tuples apart
+  , sel1
   , sel2
   , sel3
   , sel4

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -60,6 +60,7 @@ import GHC.TypeLits
 
 import Data.Patch
 
+import Feldspar.Core.Tuple (Tuply(..))
 import Feldspar.Lattice
 import Feldspar.Range
 import Feldspar.Core.NestedTuples
@@ -232,20 +233,30 @@ data TypeRep a
     DoubleType    :: TypeRep Double
     ComplexType   :: RealFloat a => TypeRep a -> TypeRep (Complex a)
     ArrayType     :: TypeRep a -> TypeRep [a]
-    Tup2Type      :: TypeRep a -> TypeRep b -> TypeRep (a,b)
-    Tup3Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep (a,b,c)
-    Tup4Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep (a,b,c,d)
-    Tup5Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep (a,b,c,d,e)
-    Tup6Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep (a,b,c,d,e,f)
-    Tup7Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep (a,b,c,d,e,f,g)
-    Tup8Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep (a,b,c,d,e,f,g,h)
-    Tup9Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep (a,b,c,d,e,f,g,h,i)
-    Tup10Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep j -> TypeRep (a,b,c,d,e,f,g,h,i,j)
-    Tup11Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep j -> TypeRep k -> TypeRep (a,b,c,d,e,f,g,h,i,j,k)
-    Tup12Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep j -> TypeRep k -> TypeRep l -> TypeRep (a,b,c,d,e,f,g,h,i,j,k,l)
-    Tup13Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep j -> TypeRep k -> TypeRep l -> TypeRep m -> TypeRep (a,b,c,d,e,f,g,h,i,j,k,l,m)
-    Tup14Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep j -> TypeRep k -> TypeRep l -> TypeRep m -> TypeRep n -> TypeRep (a,b,c,d,e,f,g,h,i,j,k,l,m,n)
-    Tup15Type      :: TypeRep a -> TypeRep b -> TypeRep c -> TypeRep d -> TypeRep e -> TypeRep f -> TypeRep g -> TypeRep h -> TypeRep i -> TypeRep j -> TypeRep k -> TypeRep l -> TypeRep m -> TypeRep n -> TypeRep o -> TypeRep (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o)
+    Tup2Type      :: TypeRep (Tuple '[a, b]) -> TypeRep (a,b)
+    Tup3Type      :: TypeRep (Tuple '[a, b, c]) -> TypeRep (a,b,c)
+    Tup4Type      :: TypeRep (Tuple '[a, b, c, d]) -> TypeRep (a, b, c, d)
+    Tup5Type      :: TypeRep (Tuple '[a, b, c, d, e]) -> TypeRep (a, b, c, d, e)
+    Tup6Type      :: TypeRep (Tuple '[a, b, c, d, e, f])
+                  -> TypeRep (a, b, c, d, e, f)
+    Tup7Type      :: TypeRep (Tuple '[a, b, c, d, e, f, g])
+                  -> TypeRep (a, b, c, d, e, f, g)
+    Tup8Type      :: TypeRep (Tuple '[a, b, c, d, e, f, g, h])
+                  -> TypeRep (a, b, c, d, e, f, g, h)
+    Tup9Type      :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i)
+    Tup10Type     :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i, j])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i, j)
+    Tup11Type     :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i, j, k])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i, j, k)
+    Tup12Type     :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i, j, k, l)
+    Tup13Type     :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i, j, k, l, m)
+    Tup14Type     :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m, n])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+    Tup15Type     :: TypeRep (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o])
+                  -> TypeRep (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
     FunType       :: TypeRep a -> TypeRep b -> TypeRep (a -> b)
     MutType       :: TypeRep a -> TypeRep (Mut a)
     RefType       :: TypeRep a -> TypeRep (IORef a)
@@ -269,20 +280,20 @@ instance Show (TypeRep a)
     show DoubleType          = "Double"
     show (ComplexType t)     = "(Complex " ++ show t ++ ")"
     show (ArrayType t)       = "[" ++ show t ++ "]"
-    show (Tup2Type ta tb)                = showTup [show ta, show tb]
-    show (Tup3Type ta tb tc)             = showTup [show ta, show tb, show tc]
-    show (Tup4Type ta tb tc td)          = showTup [show ta, show tb, show tc, show td]
-    show (Tup5Type ta tb tc td te)       = showTup [show ta, show tb, show tc, show td, show te]
-    show (Tup6Type ta tb tc td te tf)    = showTup [show ta, show tb, show tc, show td, show te, show tf]
-    show (Tup7Type ta tb tc td te tf tg) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg]
-    show (Tup8Type ta tb tc td te tf tg th) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th]
-    show (Tup9Type ta tb tc td te tf tg th ti) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti]
-    show (Tup10Type ta tb tc td te tf tg th ti tj) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti, show tj]
-    show (Tup11Type ta tb tc td te tf tg th ti tj tk) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti, show tj, show tk]
-    show (Tup12Type ta tb tc td te tf tg th ti tj tk tl) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti, show tj, show tk, show tl]
-    show (Tup13Type ta tb tc td te tf tg th ti tj tk tl tm) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti, show tj, show tk, show tl, show tm]
-    show (Tup14Type ta tb tc td te tf tg th ti tj tk tl tm tn) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti, show tj, show tk, show tl, show tm, show tn]
-    show (Tup15Type ta tb tc td te tf tg th ti tj tk tl tm tn to) = showTup [show ta, show tb, show tc, show td, show te, show tf, show tg, show th, show ti, show tj, show tk, show tl, show tm, show tn, show to]
+    show (Tup2Type t)        = show t
+    show (Tup3Type t)        = show t
+    show (Tup4Type t)        = show t
+    show (Tup5Type t)        = show t
+    show (Tup6Type t)        = show t
+    show (Tup7Type t)        = show t
+    show (Tup8Type t)        = show t
+    show (Tup9Type t)        = show t
+    show (Tup10Type t)       = show t
+    show (Tup11Type t)       = show t
+    show (Tup12Type t)       = show t
+    show (Tup13Type t)       = show t
+    show (Tup14Type t)       = show t
+    show (Tup15Type t)       = show t
     show (FunType ta tb)                 = show ta ++ " -> " ++ show tb
     show (MutType ta)                    = unwords ["Mut", show ta]
     show (RefType ta)                    = unwords ["Ref", show ta]
@@ -302,147 +313,20 @@ defaultSize FloatType = universal
 defaultSize DoubleType = universal
 defaultSize (ComplexType _) = universal
 defaultSize (ArrayType t) = universal :> defaultSize t
-defaultSize (Tup2Type ta tb) =  ( defaultSize ta
-                                , defaultSize tb
-                                )
-defaultSize (Tup3Type ta tb tc) = ( defaultSize ta
-                                  , defaultSize tb
-                                  , defaultSize tc
-                                  )
-defaultSize (Tup4Type ta tb tc td) = ( defaultSize ta
-                                     , defaultSize tb
-                                     , defaultSize tc
-                                     , defaultSize td
-                                     )
-defaultSize (Tup5Type ta tb tc td te) = ( defaultSize ta
-                                        , defaultSize tb
-                                        , defaultSize tc
-                                        , defaultSize td
-                                        , defaultSize te
-                                        )
-defaultSize (Tup6Type ta tb tc td te tf) = ( defaultSize ta
-                                           , defaultSize tb
-                                           , defaultSize tc
-                                           , defaultSize td
-                                           , defaultSize te
-                                           , defaultSize tf
-                                           )
-defaultSize (Tup7Type ta tb tc td te tf tg) = ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              )
-defaultSize (Tup8Type ta tb tc td te tf tg th) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              )
-defaultSize (Tup9Type ta tb tc td te tf tg th ti) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              )
-defaultSize (Tup10Type ta tb tc td te tf tg th ti tj) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              , defaultSize tj
-                                              )
-defaultSize (Tup11Type ta tb tc td te tf tg th ti tj tk) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              , defaultSize tj
-                                              , defaultSize tk
-                                              )
-defaultSize (Tup12Type ta tb tc td te tf tg th ti tj tk tl) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              , defaultSize tj
-                                              , defaultSize tk
-                                              , defaultSize tl
-                                              )
-defaultSize (Tup13Type ta tb tc td te tf tg th ti tj tk tl tm) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              , defaultSize tj
-                                              , defaultSize tk
-                                              , defaultSize tl
-                                              , defaultSize tm
-                                              )
-defaultSize (Tup14Type ta tb tc td te tf tg th ti tj tk tl tm tn) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              , defaultSize tj
-                                              , defaultSize tk
-                                              , defaultSize tl
-                                              , defaultSize tm
-                                              , defaultSize tn
-                                              )
-defaultSize (Tup15Type ta tb tc td te tf tg th ti tj tk tl tm tn to) =
-                                              ( defaultSize ta
-                                              , defaultSize tb
-                                              , defaultSize tc
-                                              , defaultSize td
-                                              , defaultSize te
-                                              , defaultSize tf
-                                              , defaultSize tg
-                                              , defaultSize th
-                                              , defaultSize ti
-                                              , defaultSize tj
-                                              , defaultSize tk
-                                              , defaultSize tl
-                                              , defaultSize tm
-                                              , defaultSize tn
-                                              , defaultSize to
-                                              )
+defaultSize (Tup2Type t) = defaultSize t
+defaultSize (Tup3Type t) = defaultSize t
+defaultSize (Tup4Type t) = defaultSize t
+defaultSize (Tup5Type t) = defaultSize t
+defaultSize (Tup6Type t) = defaultSize t
+defaultSize (Tup7Type t) = defaultSize t
+defaultSize (Tup8Type t) = defaultSize t
+defaultSize (Tup9Type t) = defaultSize t
+defaultSize (Tup10Type t) = defaultSize t
+defaultSize (Tup11Type t) = defaultSize t
+defaultSize (Tup12Type t) = defaultSize t
+defaultSize (Tup13Type t) = defaultSize t
+defaultSize (Tup14Type t) = defaultSize t
+defaultSize (Tup15Type t) = defaultSize t
 defaultSize (FunType ta tb) = (defaultSize ta, defaultSize tb)
 defaultSize (MutType ta) = defaultSize ta
 defaultSize (RefType ta) = defaultSize ta
@@ -453,9 +337,6 @@ defaultSize (ConsType ta tb) = (defaultSize ta, defaultSize tb)
 defaultSize NilType = universal
 defaultSize (IVarType ta) = defaultSize ta
 defaultSize (FValType ta) = defaultSize ta
-
-showTup :: [String] -> String
-showTup as =  "(" ++ intercalate "," as ++ ")"
 
 -- | The set of supported types
 class (Eq a, Show a, Typeable a, Show (Size a), Lattice (Size a), TypeF a) => Type a
@@ -487,222 +368,78 @@ instance Type a => Type [a]
     typeRep       = ArrayType typeRep
     sizeOf as     = singletonRange (genericLength as) :> unions (map sizeOf as)
 
-instance (Type a, Type b) => Type (a,b)
-  where
-    typeRep = Tup2Type typeRep typeRep
+instance (Type a, Type b) => Type (a, b) where
+  typeRep = Tup2Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b) =
-        ( sizeOf a
-        , sizeOf b
-        )
+instance (Type a, Type b, Type c) => Type (a, b, c) where
+  typeRep = Tup3Type typeRep
+  sizeOf = sizeOf . unpack
 
-instance (Type a, Type b, Type c) => Type (a,b,c)
-  where
-    typeRep = Tup3Type typeRep typeRep typeRep
+instance (Type a, Type b, Type c, Type d) => Type (a, b, c, d) where
+  typeRep = Tup4Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b,c) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        )
+instance (Type a, Type b, Type c, Type d, Type e) => Type (a, b, c, d, e) where
+  typeRep = Tup5Type typeRep
+  sizeOf = sizeOf . unpack
 
-instance (Type a, Type b, Type c, Type d) => Type (a,b,c,d)
-  where
-    typeRep = Tup4Type typeRep typeRep typeRep typeRep
+instance (Type a, Type b, Type c, Type d, Type e, Type f)
+         => Type (a, b, c, d, e, f) where
+  typeRep = Tup6Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b,c,d) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        )
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g)
+         => Type (a, b, c, d, e, f, g) where
+  typeRep = Tup7Type typeRep
+  sizeOf = sizeOf . unpack
 
-instance (Type a, Type b, Type c, Type d, Type e) => Type (a,b,c,d,e)
-  where
-    typeRep = Tup5Type typeRep typeRep typeRep typeRep typeRep
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h)
+         => Type (a, b, c, d, e, f, g, h) where
+  typeRep = Tup8Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b,c,d,e) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        )
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i)
+         => Type (a, b, c, d, e, f, g, h, i) where
+  typeRep = Tup9Type typeRep
+  sizeOf = sizeOf . unpack
 
-instance (Type a, Type b, Type c, Type d, Type e, Type f) => Type (a,b,c,d,e,f)
-  where
-    typeRep = Tup6Type typeRep typeRep typeRep typeRep typeRep typeRep
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i, Type j)
+         => Type (a, b, c, d, e, f, g, h, i, j) where
+  typeRep = Tup10Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b,c,d,e,f) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        )
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i, Type j, Type k)
+         => Type (a, b, c, d, e, f, g, h, i, j, k) where
+  typeRep = Tup11Type typeRep
+  sizeOf = sizeOf . unpack
 
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g) => Type (a,b,c,d,e,f,g)
-  where
-    typeRep = Tup7Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i, Type j, Type k, Type l)
+         => Type (a, b, c, d, e, f, g, h, i, j, k, l) where
+  typeRep = Tup12Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b,c,d,e,f,g) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        )
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i, Type j, Type k, Type l, Type m)
+         => Type (a, b, c, d, e, f, g, h, i, j, k, l, m) where
+  typeRep = Tup13Type typeRep
+  sizeOf = sizeOf . unpack
 
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h) => Type (a,b,c,d,e,f,g,h)
-  where
-    typeRep = Tup8Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i, Type j, Type k, Type l, Type m, Type n')
+         => Type (a, b, c, d, e, f, g, h, i, j, k, l, m, n') where
+  typeRep = Tup14Type typeRep
+  sizeOf = sizeOf . unpack
 
-    sizeOf (a,b,c,d,e,f,g,h) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i) => Type (a,b,c,d,e,f,g,h,i)
-  where
-    typeRep = Tup9Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i, Type j) => Type (a,b,c,d,e,f,g,h,i,j)
-  where
-    typeRep = Tup10Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i,j) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        , sizeOf j
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i, Type j, Type k) => Type (a,b,c,d,e,f,g,h,i,j,k)
-  where
-    typeRep = Tup11Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i,j,k) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        , sizeOf j
-        , sizeOf k
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i, Type j, Type k, Type l) => Type (a,b,c,d,e,f,g,h,i,j,k,l)
-  where
-    typeRep = Tup12Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i,j,k,l) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        , sizeOf j
-        , sizeOf k
-        , sizeOf l
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i, Type j, Type k, Type l, Type m) => Type (a,b,c,d,e,f,g,h,i,j,k,l,m)
-  where
-    typeRep = Tup13Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i,j,k,l,m) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        , sizeOf j
-        , sizeOf k
-        , sizeOf l
-        , sizeOf m
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i, Type j, Type k, Type l, Type m,Type n') => Type (a,b,c,d,e,f,g,h,i,j,k,l,m,n')
-  where
-    typeRep = Tup14Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i,j,k,l,m,n') =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        , sizeOf j
-        , sizeOf k
-        , sizeOf l
-        , sizeOf m
-        , sizeOf n'
-        )
-
-instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h, Type i, Type j, Type k, Type l, Type m, Type n', Type o) => Type (a,b,c,d,e,f,g,h,i,j,k,l,m,n',o)
-  where
-    typeRep = Tup15Type typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep typeRep
-
-    sizeOf (a,b,c,d,e,f,g,h,i,j,k,l,m,n',o) =
-        ( sizeOf a
-        , sizeOf b
-        , sizeOf c
-        , sizeOf d
-        , sizeOf e
-        , sizeOf f
-        , sizeOf g
-        , sizeOf h
-        , sizeOf i
-        , sizeOf j
-        , sizeOf k
-        , sizeOf l
-        , sizeOf m
-        , sizeOf n'
-        , sizeOf o
-        )
+instance (Type a, Type b, Type c, Type d, Type e, Type f, Type g, Type h,
+          Type i, Type j, Type k, Type l, Type m, Type n', Type o)
+         => Type (a, b, c, d, e, f, g, h, i, j, k, l, m, n', o) where
+  typeRep = Tup15Type typeRep
+  sizeOf = sizeOf . unpack
 
 instance Type a => Type (IORef a)
   where
@@ -799,20 +536,26 @@ type family Size a where
   Size Double          = AnySize
   Size (Complex a)     = AnySize
   Size [a]             = Range Length :> Size a
-  Size (a,b)           = (Size a, Size b)
-  Size (a,b,c)         = (Size a, Size b, Size c)
-  Size (a,b,c,d)       = (Size a, Size b, Size c, Size d)
-  Size (a,b,c,d,e)     = (Size a, Size b, Size c, Size d, Size e)
-  Size (a,b,c,d,e,f)   = (Size a, Size b, Size c, Size d, Size e, Size f)
-  Size (a,b,c,d,e,f,g) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g)
-  Size (a,b,c,d,e,f,g,h) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h)
-  Size (a,b,c,d,e,f,g,h,i) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i)
-  Size (a,b,c,d,e,f,g,h,i,j) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i, Size j)
-  Size (a,b,c,d,e,f,g,h,i,j,k) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i, Size j, Size k)
-  Size (a,b,c,d,e,f,g,h,i,j,k,l) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i, Size j, Size k, Size l)
-  Size (a,b,c,d,e,f,g,h,i,j,k,l,m) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i, Size j, Size k, Size l, Size m)
-  Size (a,b,c,d,e,f,g,h,i,j,k,l,m,n) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i, Size j, Size k, Size l, Size m, Size n)
-  Size (a,b,c,d,e,f,g,h,i,j,k,l,m,n,o) = (Size a, Size b, Size c, Size d, Size e, Size f, Size g, Size h, Size i, Size j, Size k, Size l, Size m, Size n, Size o)
+  Size (a, b)          = Size (Tuple '[a, b])
+  Size (a, b, c)       = Size (Tuple '[a, b, c])
+  Size (a, b, c, d)    = Size (Tuple '[a, b, c, d])
+  Size (a, b, c, d, e) = Size (Tuple '[a, b, c, d, e])
+  Size (a, b, c, d, e, f) = Size (Tuple '[a, b, c, d, e, f])
+  Size (a, b, c, d, e, f, g) = Size (Tuple '[a, b, c, d, e, f, g])
+  Size (a, b, c, d, e, f, g, h) = Size (Tuple '[a, b, c, d, e, f, g, h])
+  Size (a, b, c, d, e, f, g, h, i) = Size (Tuple '[a, b, c, d, e, f, g, h, i])
+  Size (a, b, c, d, e, f, g, h, i, j)
+    = Size (Tuple '[a, b, c, d, e, f, g, h, i, j])
+  Size (a, b, c, d, e, f, g, h, i, j, k)
+    = Size (Tuple '[a, b, c, d, e, f, g, h, i, j, k])
+  Size (a, b, c, d, e, f, g, h, i, j, k, l)
+    = Size (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l])
+  Size (a, b, c, d, e, f, g, h, i, j, k, l, m)
+    = Size (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m])
+  Size (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
+    = Size (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m, n])
+  Size (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o)
+    = Size (Tuple '[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o])
   Size (a -> b)        = (Size a, Size b)
   Size (Mut a)         = Size a
   Size (IORef a)       = Size a

--- a/tests/RegressionTests.hs
+++ b/tests/RegressionTests.hs
@@ -72,6 +72,9 @@ pairParam2 :: (Data Int16, Data Int16) ->
               ((Data Int16, Data Int16), (Data Int16, Data Int16))
 pairParam2 c = (c, c)
 
+pairRet :: Data Index -> (Data Index, Data Index)
+pairRet x = x > 3 ? (3, 9) $ (7, 5)
+
 -- One test starting.
 metrics :: Pull1 IntN -> Pull1 IntN
             -> Pull DIM1 (Pull DIM1 (Data Index, Data Index)) -> Pull DIM1 (Pull1 IntN)
@@ -296,6 +299,7 @@ loadFun ['shTest]
 loadFun ['arrayInStruct]
 loadFun ['pairParam]
 loadFun ['pairParam2]
+loadFun ['pairRet]
 loadFun ['copyPush]
 loadFun ['complexWhileCond]
 loadFun ['deepArrayCopy]
@@ -325,6 +329,7 @@ prop_arrayInStruct =
       eval arrayInStruct xs ==== c_arrayInStruct xs
 prop_pairParam = eval pairParam ==== c_pairParam
 prop_pairParam2 = eval pairParam2 ==== c_pairParam2
+prop_pairRet = eval pairRet ==== c_pairRet
 prop_copyPush = eval copyPush ==== c_copyPush
 prop_complexWhileCond (NonNegative n) = eval complexWhileCond n ==== c_complexWhileCond n
 
@@ -370,6 +375,7 @@ callingConventionTests = testGroup "CallingConvention"
     , testProperty "arrayInStruct" prop_arrayInStruct
     , testProperty "pairParam" prop_pairParam
     , testProperty "pairParam2" prop_pairParam2
+    , testProperty "pairRet" prop_pairRet
     , testProperty "copyPush" prop_copyPush
     , testProperty "complexWhileCond" prop_complexWhileCond
     , testProperty "deepArrayCopy" prop_deepArrayCopy
@@ -389,6 +395,7 @@ compilerTests = testGroup "Compiler-RegressionTests"
     , mkGoldTest pairParam "pairParam" defaultOptions
     , mkGoldTest pairParam "pairParam_ret" nativeRetOpts
     , mkGoldTest pairParam2 "pairParam2" defaultOptions
+    , mkGoldTest pairRet "pairRet" defaultOptions
     , mkGoldTest concatV "concatV" defaultOptions
     , mkGoldTest concatVM "concatVM" defaultOptions
     , mkGoldTest complexWhileCond "complexWhileCond" defaultOptions
@@ -418,6 +425,7 @@ compilerTests = testGroup "Compiler-RegressionTests"
    -- Build tests.
     , mkBuildTest pairParam "pairParam" defaultOptions
     , mkBuildTest pairParam "pairParam_ret" nativeRetOpts
+    , mkBuildTest pairRet "pairRet" defaultOptions
     , mkBuildTest concatV "concatV" defaultOptions
     , mkBuildTest concatVM "concatVM" defaultOptions
     , mkBuildTest topLevelConsts "topLevelConsts" defaultOptions
@@ -448,6 +456,7 @@ externalProgramTests = testGroup "ExternalProgram-RegressionTests"
     , mkParseTest "pairParam" defaultOptions
     , mkParseTest "pairParam_ret" defaultOptions
     , mkParseTest "pairParam2" defaultOptions
+    , mkParseTest "pairRet" defaultOptions
     , mkParseTest "concatV" defaultOptions
     , mkParseTest "concatVM" defaultOptions
     , mkParseTest "complexWhileCond" defaultOptions

--- a/tests/gold/pairRet.c
+++ b/tests/gold/pairRet.c
@@ -1,0 +1,16 @@
+#include "pairRet.h"
+
+
+void pairRet(uint32_t v1, struct s_2_unsignedS32_unsignedS32 * out)
+{
+  if ((v1 > 3))
+  {
+    (*out).member1 = 3;
+    (*out).member2 = 9;
+  }
+  else
+  {
+    (*out).member1 = 7;
+    (*out).member2 = 5;
+  }
+}

--- a/tests/gold/pairRet.h
+++ b/tests/gold/pairRet.h
@@ -1,0 +1,14 @@
+#ifndef TESTS_PAIRRET_H
+#define TESTS_PAIRRET_H
+
+#include "feldspar_c99.h"
+
+struct s_2_unsignedS32_unsignedS32
+{
+  uint32_t member1;
+  uint32_t member2;
+};
+
+void pairRet(uint32_t v1, struct s_2_unsignedS32_unsignedS32 * out);
+
+#endif // TESTS_PAIRRET_H


### PR DESCRIPTION
We can build tuples from nested tuples by changing
TypeRep for tuples from taking k type parameters
into taking a Tuple with k type variables. This
makes Size and Type instances trivial since they
just need to forward to the same mechanics
for Tuple.