### PR TITLE
Use fullRange instead of universal in Range

### DIFF
--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -45,6 +45,7 @@ import Feldspar.Core.Reify
 import Feldspar.Core.Representation as R
 import Feldspar.Core.Types as T
 
+import Feldspar.Lattice (Lattice, universal)
 import Feldspar.Range
 import Feldspar.Core.Collection
 
@@ -991,15 +992,15 @@ cap :: Type a => Size a -> SizeCap a
 cap sz = sizeProp (const sz) (Data $ desugar ())
 
 -- | @notAbove a b@: A guarantee that @b <= a@ holds
-notAbove :: (Type a, Bounded a, Size a ~ Range a) => Data a -> SizeCap a
-notAbove = sizeProp (Range minBound . upperBound)
+notAbove :: (Type a, Lattice (Range a), Size a ~ Range a) => Data a -> SizeCap a
+notAbove = sizeProp (Range (lowerBound universal) . upperBound)
 
 -- | @notBelow a b@: A guarantee that @b >= a@ holds
-notBelow :: (Type a, Bounded a, Size a ~ Range a) => Data a -> SizeCap a
-notBelow = sizeProp (flip Range maxBound . lowerBound)
+notBelow :: (Type a, Lattice (Range a), Size a ~ Range a) => Data a -> SizeCap a
+notBelow = sizeProp (flip Range (upperBound universal) . lowerBound)
 
 -- | @between l u a@: A guarantee that @l <= a <= u@ holds
-between :: (Type a, Bounded a, Size a ~ Range a) =>
+between :: (Type a, Lattice (Range a), Size a ~ Range a) =>
     Data a -> Data a -> SizeCap a
 between l u = notBelow l . notAbove u
 

--- a/src/Feldspar/Core/ValueInfo.hs
+++ b/src/Feldspar/Core/ValueInfo.hs
@@ -55,7 +55,7 @@ module Feldspar.Core.ValueInfo
 
 import Feldspar.Core.Types (WordN)
 import Feldspar.Core.UntypedRepresentation
-import Feldspar.Lattice (empty, universal)
+import Feldspar.Lattice (Lattice, empty, universal)
 import Feldspar.Range
 
 import Data.Int
@@ -115,7 +115,7 @@ elementsVI idx val = VIProd [idx, val]
 
 -- | Forcing a range to an integer type given by a signedness and a size.
 constantIntRange :: Signedness -> Size
-                 -> (forall a . (Bounded a, Ord a) => Range a) -> ValueInfo
+                 -> (forall a . Lattice (Range a) => Range a) -> ValueInfo
 constantIntRange Signed   S8   r = VIInt8 r
 constantIntRange Signed   S16  r = VIInt16 r
 constantIntRange Signed   S32  r = VIInt32 r

--- a/src/Feldspar/Range.hs
+++ b/src/Feldspar/Range.hs
@@ -220,7 +220,7 @@ rangeIntersection = rangeOp2 intersection
 
 -- | @disjoint r1 r2@ returns true when @r1@ and @r2@ have no elements in
 --   common.
-disjoint :: (Bounded a, Ord a) => Range a -> Range a -> Bool
+disjoint :: (Lattice (Range a), Ord a) => Range a -> Range a -> Bool
 disjoint r1 r2 = isEmpty (r1 /\ r2)
 
 -- | @rangeByRange ra rb@: Computes the range of the following set
@@ -684,7 +684,7 @@ instance Ord a => Ord (Range a)
 
 -- | Propagates range information through 'mod'.
 -- Note that we assume Haskell semantics for 'mod'.
-rangeMod :: (Bounded a, Ord a, Enum a, Num a, Bits a)
+rangeMod :: (Bounded a, Ord a, Enum a, Num a, Bits a, Lattice (Range a))
          => Range a -> Range a -> Range a
 rangeMod d r
     | isSigned (lowerBound d) &&
@@ -700,7 +700,7 @@ rangeMod _ (Range l u) = Range (succ l) (pred u)
 
 -- | Propagates range information through 'rem'.
 -- Note that we assume Haskell semantics for 'rem'.
-rangeRem :: (Bounded a, Ord a, Enum a, Num a, Bits a)
+rangeRem :: (Bounded a, Ord a, Enum a, Num a, Bits a, Lattice (Range a))
          => Range a -> Range a -> Range a
 rangeRem d r
     | isSigned (lowerBound d) &&

--- a/src/Feldspar/Range.hs
+++ b/src/Feldspar/Range.hs
@@ -44,7 +44,7 @@ import Data.Int
 import Data.Word
 import Language.Haskell.TH.Syntax (Lift(..))
 
-import Feldspar.Lattice (Lattice(..))
+import Feldspar.Lattice (Lattice(..), universal)
 
 --------------------------------------------------------------------------------
 -- * Definition
@@ -57,12 +57,11 @@ data Range a = Range
   }
     deriving (Eq, Lift)
 
-instance (Show a, Bounded a, Eq a) => Show (Range a)
-  where
-    show (Range l u) = "[" ++ sl ++ "," ++ su ++ "]"
-      where
-        sl = if l == minBound then "*" else show l
-        su = if u == maxBound then "*" else show u
+instance (Show a, Lattice (Range a), Eq a) => Show (Range a) where
+  show (Range l u) = "[" ++ sl ++ "," ++ su ++ "]"
+    where
+      sl = if l == lowerBound universal then "*" else show l
+      su = if u == upperBound universal then "*" else show u
 
 -- | Type family to determine the bit representation of a type
 type family UnsignedRep a where


### PR DESCRIPTION
This is in preparation for having multiple
Lattice (Range a) instances with different
implementations.