### PR TITLE
Add Range information for Float/Double

### DIFF
--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -54,7 +54,7 @@ import Feldspar.Range (Range(..))
 import qualified Feldspar.Core.Representation as R
 import Feldspar.Core.Representation (AExpr(..), Expr(..))
 import Data.Complex (Complex(..))
-import Feldspar.Lattice (universal)
+import Feldspar.Lattice (Lattice, universal)
 
 toU :: AExpr a -> UntypedFeld ValueInfo
 toU (((R.Info i) :: R.Info a) :& e)
@@ -231,7 +231,7 @@ convSize T.N32     = U.S32
 convSize T.N64     = U.S64
 
 -- | Default size for numeric types
-defaultNumSize :: TypeRep a -> T.Size a
+defaultNumSize :: Lattice (Range a) => TypeRep a -> T.Size a
 defaultNumSize IntType{} = universal
 defaultNumSize FloatType = universal
 defaultNumSize DoubleType = universal

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -297,8 +297,8 @@ instance Type Word32  where typeRep = IntType U N32;     sizeOf = singletonRange
 instance Type Int32   where typeRep = IntType S N32;     sizeOf = singletonRange
 instance Type Word64  where typeRep = IntType U N64;     sizeOf = singletonRange
 instance Type Int64   where typeRep = IntType S N64;     sizeOf = singletonRange
-instance Type Float   where typeRep = FloatType;         sizeOf _ = AnySize
-instance Type Double  where typeRep = DoubleType;        sizeOf _ = AnySize
+instance Type Float   where typeRep = FloatType;         sizeOf = singletonRange
+instance Type Double  where typeRep = DoubleType;        sizeOf = singletonRange
 
 instance (Type a, RealFloat a) => Type (Complex a)
   where
@@ -474,8 +474,8 @@ type family Size a where
   Size Int32           = Range Int32
   Size Word64          = Range Word64
   Size Int64           = Range Int64
-  Size Float           = AnySize
-  Size Double          = AnySize
+  Size Float           = Range Float
+  Size Double          = Range Double
   Size (Complex a)     = AnySize
   Size [a]             = Range Length :> Size a
   Size (a, b)          = Size (Tuple '[a, b])

--- a/tests/Feldspar/Range/Test.hs
+++ b/tests/Feldspar/Range/Test.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE ConstraintKinds #-}
@@ -173,7 +174,9 @@ instance (Bounded a, Ord a, Enum a, Arbitrary a) => Arbitrary (Range a)
       [ Range x y' | y' <- shrink y ]
 
 newtype EmptyRange a = EmptyRange {getEmpty :: Range a}
-  deriving (Eq, Show)
+  deriving Eq
+
+deriving instance (Eq a, Lattice (Range a), Show a) => Show (EmptyRange a)
 
 instance (Arbitrary a, Random a, Ord a, Bounded a) => Arbitrary (EmptyRange a) where
     arbitrary = do
@@ -181,7 +184,9 @@ instance (Arbitrary a, Random a, Ord a, Bounded a) => Arbitrary (EmptyRange a) w
       return $ EmptyRange $ Range l minBound
 
 newtype NonEmptyRange a = NonEmptyRange {getNonEmpty :: Range a}
-  deriving (Eq, Show)
+  deriving Eq
+
+deriving instance (Eq a, Lattice (Range a), Show a) => Show (NonEmptyRange a)
 
 instance (Arbitrary a, Random a, Ord a, Bounded a) => Arbitrary (NonEmptyRange a) where
     arbitrary = do


### PR DESCRIPTION
The ranges are not yet useful since they contain
-Inf..Inf, but we have at least started carrying
them around.