### PR TITLE
Shrink Integral contexts

### DIFF
--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -147,8 +147,9 @@ infixr 0 $<
 infixl 5 .<<.,.>>.
 infixl 4 ⊕
 
-class (Type a, B.Bits a, Integral a, Bounded a, Size a ~ Range a) => Bits a
-  where
+class (Type a, Bounded a, B.FiniteBits a, Integral a, Size a ~ Range a,
+       P.Integral (UnsignedRep a), B.FiniteBits (UnsignedRep a))
+      => Bits a where
     -- * Logical operations
     (.&.)         :: Data a -> Data a -> Data a
     (.&.)         = sugarSym2 BAnd
@@ -556,7 +557,7 @@ await = sugarSym1 Await
 -- Integral.hs
 --------------------------------------------------
 
-class (Ord a, Numeric a, BoundedInt a, P.Integral a, Size a ~ Range a) => Integral a
+class (Bounded a, B.FiniteBits a, Ord a, Numeric a, P.Integral a, Size a ~ Range a) => Integral a
   where
     quot :: Data a -> Data a -> Data a
     quot = sugarSym2 Quot

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -74,7 +74,7 @@ import Data.Hash (Hashable)
 import qualified Data.Set as S
 import qualified Data.Map.Strict as M
 
-import Data.Bits (Bits)
+import Data.Bits (Bits, FiniteBits)
 import Data.Complex (Complex)
 import Data.Ix
 import Data.IORef (IORef)
@@ -280,11 +280,11 @@ data Op a where
     Await    :: Type a => Op (FVal a :-> Full a)
 
     -- | Integral
-    Quot :: (Type a, BoundedInt a, Size a ~ Range a) => Op (a :-> a :-> Full a)
-    Rem  :: (Type a, BoundedInt a, Size a ~ Range a) => Op (a :-> a :-> Full a)
-    Div  :: (Type a, BoundedInt a, Size a ~ Range a) => Op (a :-> a :-> Full a)
-    Mod  :: (Type a, BoundedInt a, Size a ~ Range a) => Op (a :-> a :-> Full a)
-    IExp :: (Type a, BoundedInt a, Size a ~ Range a) => Op (a :-> a :-> Full a)
+    Quot :: (Type a, Bits a, Bounded a, Integral a, Size a ~ Range a) => Op (a :-> a :-> Full a)
+    Rem  :: (Type a, Bits a, Bounded a, Integral a, Size a ~ Range a) => Op (a :-> a :-> Full a)
+    Div  :: (Type a, Bits a, Bounded a, Integral a, Size a ~ Range a) => Op (a :-> a :-> Full a)
+    Mod  :: (Type a, Bits a, Bounded a, Integral a, Size a ~ Range a) => Op (a :-> a :-> Full a)
+    IExp :: (Type a, Bounded a, Integral a, FiniteBits a, Size a ~ Range a) => Op (a :-> a :-> Full a)
 
     -- | Literal
     Literal :: (Type a, Hashable a) => a -> Op (Full a)


### PR DESCRIPTION
This removes FiniteBits a and Integral/FiniteBits
for UnsignedRep a.