### PR TITLE
Export nested tuples from Feldspar

### DIFF
--- a/src/Feldspar.hs
+++ b/src/Feldspar.hs
@@ -46,6 +46,7 @@ module Feldspar
 
   -- * Frontend
   , module Feldspar.Core.Frontend
+  , module Feldspar.Core.NestedTuples
   , module Feldspar.Core.Collection
   ) where
 
@@ -60,6 +61,10 @@ import Data.Int hiding (Int)
 import Data.Word
 
 import Feldspar.Range
+-- The names for selectors collide with the ones for ordinary tuples.
+import Feldspar.Core.NestedTuples hiding (sel1, sel2, sel3, sel4, sel5, sel6,
+                                          sel7, sel8, sel9, sel10, sel11, sel12,
+                                          sel13, sel14, sel15)
 import Feldspar.Core.Types
 import Feldspar.Core.Frontend
 import Feldspar.Core.Collection

--- a/src/Feldspar/Core/Language.hs
+++ b/src/Feldspar/Core/Language.hs
@@ -41,6 +41,7 @@
 
 module Feldspar.Core.Language where
 
+import Feldspar.Core.NestedTuples (Tuple(..), build, tuple)
 import Feldspar.Core.Reify
 import Feldspar.Core.Representation as R
 import Feldspar.Core.Types as T

--- a/src/Feldspar/Core/Middleend/FromTyped.hs
+++ b/src/Feldspar/Core/Middleend/FromTyped.hs
@@ -46,6 +46,7 @@ module Feldspar.Core.Middleend.FromTyped
   ) where
 
 import qualified Feldspar.Core.UntypedRepresentation as U
+import qualified Feldspar.Core.NestedTuples as T
 import Feldspar.Core.Types (TypeRep(..), TypeF(..), (:>)(..))
 import qualified Feldspar.Core.Types as T
 import Feldspar.Core.UntypedRepresentation hiding (Type(..), ScalarType(..))

--- a/src/Feldspar/Core/Representation.hs
+++ b/src/Feldspar/Core/Representation.hs
@@ -63,8 +63,9 @@ module Feldspar.Core.Representation
   ) where
 
 import Feldspar.Compiler.Options (Pretty(..))
+import Feldspar.Core.NestedTuples (Tuple)
 import Feldspar.Core.Types (BoundedInt, Elements, FVal, Length, Index,
-                            IntN, IV, MArr, Mut, Par, Size, Tuple(..), Type(..),
+                            IntN, IV, MArr, Mut, Par, Size, Type(..),
                             TypeF(..), TypeRep(..))
 import Feldspar.Range (Range)
 

--- a/src/Feldspar/Core/Types.hs
+++ b/src/Feldspar/Core/Types.hs
@@ -43,7 +43,6 @@
 
 module Feldspar.Core.Types
        ( module Feldspar.Core.Types
-       , Tuple(..), build, tuple -- From NestedTuples
        ) where
 
 

--- a/src/Feldspar/Option.hs
+++ b/src/Feldspar/Option.hs
@@ -40,8 +40,6 @@ import Control.Applicative (Applicative(..))
 import Control.Monad
 
 import Feldspar.Core.Reify (Syntactic(..), resugar)
-import Feldspar.Core.NestedTuples
-
 import Feldspar hiding (sugar,desugar,resugar)
 import Feldspar.Mutable
 

--- a/src/Feldspar/Repa.hs
+++ b/src/Feldspar/Repa.hs
@@ -39,7 +39,6 @@ import qualified Prelude as P
 
 import Feldspar.Core.Reify (Syntactic(..), resugar)
 import Feldspar hiding (desugar,sugar,resugar)
-import Feldspar.Core.NestedTuples
 
 -- | * Shapes
 

--- a/src/Feldspar/Vector.hs
+++ b/src/Feldspar/Vector.hs
@@ -82,7 +82,6 @@ import Feldspar hiding (desugar,sugar,resugar)
 import qualified Feldspar as F
 import Feldspar.Core.Language
 import Feldspar.Core.Tuple
-import Feldspar.Core.NestedTuples (nfst, nsnd, twotup)
 import Feldspar.Vector.Shape
 
 import Control.Monad (zipWithM_)


### PR DESCRIPTION
Tuples are an essential part of the core language
and nested tuples are just a different implementation.
Provide the nested tuples by default when importing
Feldspar. Also stop re-exporting nested tuples from type
to reduce dependencies within Feldspar.