### PR TITLE
Stop exporting internal functions from Compiler

### DIFF
--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -48,10 +48,6 @@ module Feldspar.Compiler
   , program
   , programOpts
   , programOptsArgs
-  -- * Internal functions
-  , writeFiles
-  , CompiledModule(..)
-  , SplitModule(..)
   ) where
 
 import Control.Monad (when, unless)


### PR DESCRIPTION
These are no longer used outside the module so stop
exporting them.