### PR TITLE
Make explicit return from worker()

### DIFF
--- a/src/clib/include/taskpool.c
+++ b/src/clib/include/taskpool.c
@@ -160,5 +160,5 @@ void *worker() {
          , self, pool->act_threads, pool->num_threads);
     pthread_mutex_unlock(&(pool->mutex));
     log_1("worker %d - leave\n", self);
-    pthread_exit(NULL);
+    return NULL;
 }


### PR DESCRIPTION
Returning from the function is the same as
calling pthread_exit() but avoids warnings
from GCC about the function not having
a return value.