### PR TITLE
Stop including the RTS in libHSFeldspar.a

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -143,10 +143,6 @@ library
   default-extensions:
     MonoLocalBinds
 
-  if os(linux)
-    extra-libraries: gcc_s pthread
-      -- pthread needed on Emil's Ubuntu (15.04), but apparently not on Travis
-
   include-dirs:
     ./src/clib/include
 

--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -132,10 +132,6 @@ library
     data-hash                   >= 0.2.0.1 && < 100,
     tree-view
 
-  c-sources:
-    src/clib/include/taskpool.c
-    src/clib/include/ivar.c
-
   cc-options: -std=c99 -Wall -fPIC
 
   -- MonoLocalBinds is the "Let should not be generalized" paper. Our binds


### PR DESCRIPTION
This does not work so remove it. The relevant
parts of the RTS should be spliced into the same
output file as the rest of the program.