### PR TITLE
Fix GHC 8.8 warnings

### DIFF
--- a/src/Feldspar/Compiler/Imperative/ArrayOps.hs
+++ b/src/Feldspar/Compiler/Imperative/ArrayOps.hs
@@ -45,7 +45,7 @@ import Feldspar.Compiler.Options (Options(..))
 import Feldspar.Lattice (universal)
 
 import Control.Monad.Writer (censor, runWriter, tell)
-import Data.List (concatMap, isPrefixOf, nub)
+import Data.List (isPrefixOf, nub)
 
 -- | Main interface for adding needed array operations to a module.
 arrayOps :: Options -> Module -> Module

--- a/src/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore.hs
@@ -63,7 +63,6 @@ import Control.Monad.RWS hiding ((<>))
 import Data.Char (toLower)
 import Data.List (find, intercalate, isPrefixOf, nub)
 import Data.Maybe (fromJust, isJust)
-import Data.Semigroup (Semigroup(..))
 
 import Feldspar.Core.UntypedRepresentation
          ( VarId(..), UntypedFeld, Term(..), Lit(..)

--- a/src/Feldspar/Compiler/Imperative/Representation.hs
+++ b/src/Feldspar/Compiler/Imperative/Representation.hs
@@ -60,7 +60,6 @@ module Feldspar.Compiler.Imperative.Representation (
 
 import Data.List (nub)
 import Data.Maybe (fromMaybe)
-import Data.Semigroup (Semigroup(..))
 import Language.Haskell.TH.Syntax (Lift(..))
 
 import Feldspar.Range (Range)

--- a/src/Feldspar/Core/Semantics.hs
+++ b/src/Feldspar/Core/Semantics.hs
@@ -40,7 +40,6 @@ import Control.Monad
 import Control.Monad.Par.Scheds.TraceInternal (yield)
 import Data.Array.IArray
 import Data.Array.IO
-import Data.Array.MArray (freeze)
 import Data.Array.Unsafe (unsafeFreeze)
 import Data.Bits
 import Data.Complex


### PR DESCRIPTION
Things have moved around in the Prelude since GHC 8.0
so we had double imports/hides in some places. Remove
those now that we only support 8.8 and later.