### PR TITLE
Improve onnxToFeld

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -204,6 +204,8 @@ executable onnxToFeld
   build-depends:
     base                        >= 4.13.0  && < 5.9,
     bytestring                  >= 0.10,
+    containers,
+    filepath,
     protocol-buffers            >= 2,
     utf8-string                 >= 0.3.7
 


### PR DESCRIPTION
Add code to write a weight file based on the initializations
in the ONNX model. This avoids putting all of the weights of
the model, whic can amount to gigabytes, in the generated
program.

Generate Feldspar syntax from the nodes in the model graph.