### PR TITLE
Use System.FilePath to construct paths

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -260,6 +260,7 @@ test-suite regression
     feldspar-language,
     mtl,
     base,
+    filepath,
     ghc-paths,
     process,
     bytestring       >= 0.9 && < 0.11,

--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -244,7 +244,7 @@ programComp pc opts args = do
       forM_ mProgs (writeFiles opts1)
 
 optsFromName :: Options -> String -> Options
-optsFromName opts name' = opts{ passFileName = name' ++ ".passes"
+optsFromName opts name' = opts{ passFileName = name' <.> "passes"
                               , outFileName = name'
                               , functionName = name'}
 

--- a/src/Feldspar/Compiler/Plugin.hs
+++ b/src/Feldspar/Compiler/Plugin.hs
@@ -34,7 +34,7 @@ import Control.Monad (join, (>=>), when, unless)
 import Language.Haskell.TH
 
 import System.Directory (doesFileExist, removeFile, createDirectoryIfMissing)
-import System.FilePath ((</>))
+import System.FilePath ((</>), (<.>))
 import System.Process (readProcessWithExitCode)
 import System.Info (os)
 
@@ -169,8 +169,8 @@ feldsparBuilder fopts Config{..} fun = do
 
 compileAndLoad :: Options -> String -> [String] -> IO ()
 compileAndLoad opts name args = do
-    let cname = name ++ ".c"
-        oname = name ++ ".o"
+    let cname = name <.> "c"
+        oname = name <.> "o"
     exists <- doesFileExist oname
     when exists $ removeFile oname
     compileC opts cname oname args


### PR DESCRIPTION
This gives us the right platform behavior/output
with respect to slashes in paths.