### PR TITLE
cabal: enable -O2 for onnxToFeld

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -202,6 +202,8 @@ executable onnxToFeld
 
   default-language: Haskell2010
 
+  ghc-options: -O2
+
   build-depends:
     base                        >= 4.13.0  && < 5.9,
     bytestring                  >= 0.10,


### PR DESCRIPTION
This speeds up writing the data file
for resnet50-v2-7.onnx with a couple
of seconds on my computer.