### PR TITLE
Use fshow to speed up onnxToFeld

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -207,6 +207,7 @@ executable onnxToFeld
     bytestring                  >= 0.10,
     containers,
     filepath,
+    floatshow,
     protocol-buffers            >= 2,
     utf8-string                 >= 0.3.7
 


### PR DESCRIPTION
The show instances for Float/Double work hard
print the shortest string that represents
the number. Use a different show instance
to save ~50 Gb of allocations on resnet50-v2-7.onnx
and speed things up.