### PR TITLE
Use the model name in onnxToFeld

### DIFF
--- a/src/Feldspar/Onnx/onnxToFeld.hs
+++ b/src/Feldspar/Onnx/onnxToFeld.hs
@@ -128,9 +128,9 @@ mkProgramFile gr
             , ""
             , name <> " " <> L.unwords params <> " = " <> tuplify (map (mangle . vipName) $ D.toList $ G.output gr)
             , "  where "
-              <> L.intercalate "\n        " ("-- Nodes " : D.concatMap mkNode (G.node gr))
+              <> L.intercalate "\n        " ("-- Nodes" : D.concatMap mkNode (G.node gr))
             ]
-  where name = "model" -- strFromJ $ G.name gr
+  where name = mangle $ fromJust $ G.name gr
         wName = "weights"
         initVs = map (fromJust . TP.name) $ D.toList $ G.initializer gr
         initSet = S.fromList initVs


### PR DESCRIPTION
There is a model name in ONNX, it just happens
to be "main" for resnet50. Mangle the name to
avoid clashing with the main function
of the program.