### PR TITLE
Make tags shorter for some generated structs.

### DIFF
--- a/src/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore.hs
@@ -61,7 +61,7 @@ module Feldspar.Compiler.Imperative.FromCore
 import Control.Arrow hiding (arr)
 import Control.Monad.RWS hiding ((<>))
 import Data.Char (toLower)
-import Data.List (find, intercalate, isPrefixOf, nub)
+import Data.List (find, isPrefixOf, nub)
 import Data.Maybe (fromJust, isJust)
 
 import Feldspar.Core.UntypedRepresentation
@@ -117,12 +117,6 @@ instance Monoid CodeParts where
 --------------------------------------------------------------------------------
 -- * Utility functions
 --------------------------------------------------------------------------------
-
--- | Make a struct type from a list of field names and their types
-mkStructType :: [(String, Type)] -> Type
-mkStructType trs = StructType n trs
-  where
-    n = "s_" ++ intercalate "_" (show (length trs):map (encodeType . snd) trs)
 
 -- | Construct an array indexing expression
 mkArrayElem :: Expression -> [Expression] -> Expression

--- a/tests/gold/arrayInStruct.c
+++ b/tests/gold/arrayInStruct.c
@@ -3,8 +3,8 @@
 
 void arrayInStruct(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out)
 {
-  struct s_2_unsignedS32_awl_unsignedS32 e0 = { 0 };
-  struct s_2_unsignedS32_awl_unsignedS32 v6 = { 0 };
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 e0 = { 0 };
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 v6 = { 0 };
   uint32_t len1;
   struct awl_unsignedS32 e2 = { 0 };
   bool v3;

--- a/tests/gold/arrayInStruct.h
+++ b/tests/gold/arrayInStruct.h
@@ -9,7 +9,7 @@ struct awl_unsignedS32
   uint32_t length;
 };
 
-struct s_2_unsignedS32_awl_unsignedS32
+struct s_2_1xunsignedS32_1xawl_unsignedS32
 {
   uint32_t member1;
   struct awl_unsignedS32 member2;

--- a/tests/gold/arrayInStructInStruct.c
+++ b/tests/gold/arrayInStructInStruct.c
@@ -1,7 +1,7 @@
 #include "arrayInStructInStruct.h"
 
 
-void arrayInStructInStruct(struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * v0, struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * out)
+void arrayInStructInStruct(struct s_2_1xunsignedS32_1xs_2_1xunsignedS32_1xawl_unsignedS32 * v0, struct s_2_1xunsignedS32_1xs_2_1xunsignedS32_1xawl_unsignedS32 * out)
 {
   (*out).member1 = (*v0).member1;
   ((*out).member2).member1 = ((*v0).member2).member1;

--- a/tests/gold/arrayInStructInStruct.h
+++ b/tests/gold/arrayInStructInStruct.h
@@ -9,18 +9,18 @@ struct awl_unsignedS32
   uint32_t length;
 };
 
-struct s_2_unsignedS32_awl_unsignedS32
+struct s_2_1xunsignedS32_1xawl_unsignedS32
 {
   uint32_t member1;
   struct awl_unsignedS32 member2;
 };
 
-struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32
+struct s_2_1xunsignedS32_1xs_2_1xunsignedS32_1xawl_unsignedS32
 {
   uint32_t member1;
-  struct s_2_unsignedS32_awl_unsignedS32 member2;
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 member2;
 };
 
-void arrayInStructInStruct(struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * v0, struct s_2_unsignedS32_s_2_unsignedS32_awl_unsignedS32 * out);
+void arrayInStructInStruct(struct s_2_1xunsignedS32_1xs_2_1xunsignedS32_1xawl_unsignedS32 * v0, struct s_2_1xunsignedS32_1xs_2_1xunsignedS32_1xawl_unsignedS32 * out);
 
 #endif // TMP2_ARRAYINSTRUCTINSTRUCT_H

--- a/tests/gold/arrayInStruct_openMP.c
+++ b/tests/gold/arrayInStruct_openMP.c
@@ -3,8 +3,8 @@
 
 void arrayInStruct__openMP(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out)
 {
-  struct s_2_unsignedS32_awl_unsignedS32 e0 = { 0 };
-  struct s_2_unsignedS32_awl_unsignedS32 v6 = { 0 };
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 e0 = { 0 };
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 v6 = { 0 };
   bool v3;
   
   (e0).member1 = (*v0).length;

--- a/tests/gold/arrayInStruct_openMP.h
+++ b/tests/gold/arrayInStruct_openMP.h
@@ -9,7 +9,7 @@ struct awl_unsignedS32
   uint32_t length;
 };
 
-struct s_2_unsignedS32_awl_unsignedS32
+struct s_2_1xunsignedS32_1xawl_unsignedS32
 {
   uint32_t member1;
   struct awl_unsignedS32 member2;

--- a/tests/gold/arrayInStruct_wool.c
+++ b/tests/gold/arrayInStruct_wool.c
@@ -5,9 +5,9 @@ LOOP_BODY_2(wool0,
             LARGE_BODY,
             uint32_t,
             v10,
-            struct s_2_unsignedS32_awl_unsignedS32,
+            struct s_2_1xunsignedS32_1xawl_unsignedS32,
             e0,
-            struct s_2_unsignedS32_awl_unsignedS32,
+            struct s_2_1xunsignedS32_1xawl_unsignedS32,
             v6)
 {
   ((v6).member2).buffer[v10] = (((e0).member2).buffer[v10] + 5);
@@ -15,8 +15,8 @@ LOOP_BODY_2(wool0,
 
 void arrayInStruct__wool(struct awl_unsignedS32 * v0, struct awl_unsignedS32 * out)
 {
-  struct s_2_unsignedS32_awl_unsignedS32 e0 = { 0 };
-  struct s_2_unsignedS32_awl_unsignedS32 v6 = { 0 };
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 e0 = { 0 };
+  struct s_2_1xunsignedS32_1xawl_unsignedS32 v6 = { 0 };
   bool v3;
   
   (e0).member1 = (*v0).length;

--- a/tests/gold/arrayInStruct_wool.h
+++ b/tests/gold/arrayInStruct_wool.h
@@ -9,7 +9,7 @@ struct awl_unsignedS32
   uint32_t length;
 };
 
-struct s_2_unsignedS32_awl_unsignedS32
+struct s_2_1xunsignedS32_1xawl_unsignedS32
 {
   uint32_t member1;
   struct awl_unsignedS32 member2;

--- a/tests/gold/complexWhileCond.c
+++ b/tests/gold/complexWhileCond.c
@@ -1,10 +1,10 @@
 #include "complexWhileCond.h"
 
 
-void complexWhileCond(int32_t v0, struct s_2_signedS32_signedS32 * out)
+void complexWhileCond(int32_t v0, struct s_2_2xsignedS32 * out)
 {
-  struct s_2_signedS32_signedS32 e0 = { 0 };
-  struct s_2_signedS32_signedS32 v9 = { 0 };
+  struct s_2_2xsignedS32 e0 = { 0 };
+  struct s_2_2xsignedS32 v9 = { 0 };
   int32_t v4;
   int32_t v6;
   bool v2;

--- a/tests/gold/complexWhileCond.h
+++ b/tests/gold/complexWhileCond.h
@@ -3,12 +3,12 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_signedS32_signedS32
+struct s_2_2xsignedS32
 {
   int32_t member1;
   int32_t member2;
 };
 
-void complexWhileCond(int32_t v0, struct s_2_signedS32_signedS32 * out);
+void complexWhileCond(int32_t v0, struct s_2_2xsignedS32 * out);
 
 #endif // TMP2_COMPLEXWHILECOND_H

--- a/tests/gold/deepArrayCopy.c
+++ b/tests/gold/deepArrayCopy.c
@@ -119,7 +119,7 @@ void freeArray_awl_unsignedS32(struct awl_unsignedS32 * src, int32_t srcLen)
   freeArray(src);
 }
 
-void deepArrayCopy(struct awl_awl_awl_unsignedS32 * v0, struct s_2_awl_awl_awl_unsignedS32_awl_awl_awl_unsignedS32 * out)
+void deepArrayCopy(struct awl_awl_awl_unsignedS32 * v0, struct s_2_2xawl_awl_awl_unsignedS32 * out)
 {
   ((*out).member1).buffer = initCopyArray_awl_awl_unsignedS32(((*out).member1).buffer, ((*out).member1).length, (*v0).buffer, (*v0).length);
   ((*out).member1).length = (*v0).length;

--- a/tests/gold/deepArrayCopy.h
+++ b/tests/gold/deepArrayCopy.h
@@ -21,7 +21,7 @@ struct awl_awl_awl_unsignedS32
   uint32_t length;
 };
 
-struct s_2_awl_awl_awl_unsignedS32_awl_awl_awl_unsignedS32
+struct s_2_2xawl_awl_awl_unsignedS32
 {
   struct awl_awl_awl_unsignedS32 member1;
   struct awl_awl_awl_unsignedS32 member2;
@@ -47,6 +47,6 @@ struct awl_unsignedS32 * initArray_awl_unsignedS32(struct awl_unsignedS32 * dst,
 
 void freeArray_awl_unsignedS32(struct awl_unsignedS32 * src, int32_t srcLen);
 
-void deepArrayCopy(struct awl_awl_awl_unsignedS32 * v0, struct s_2_awl_awl_awl_unsignedS32_awl_awl_awl_unsignedS32 * out);
+void deepArrayCopy(struct awl_awl_awl_unsignedS32 * v0, struct s_2_2xawl_awl_awl_unsignedS32 * out);
 
 #endif // TMP2_DEEPARRAYCOPY_H

--- a/tests/gold/ivartest2.c
+++ b/tests/gold/ivartest2.c
@@ -1,24 +1,24 @@
 #include "ivartest2.h"
 
 
-void task_core0(struct s_2_unsignedS32_unsignedS32 * v0, struct ivar e0)
+void task_core0(struct s_2_2xunsignedS32 * v0, struct ivar e0)
 {
-  ivar_put(struct s_2_unsignedS32_unsignedS32, e0, &*v0);
+  ivar_put(struct s_2_2xunsignedS32, e0, &*v0);
 }
 
 void task0(void * params)
 {
-  run2(task_core0, struct s_2_unsignedS32_unsignedS32 *, struct ivar);
+  run2(task_core0, struct s_2_2xunsignedS32 *, struct ivar);
 }
 
-void ivartest2(struct s_2_unsignedS32_unsignedS32 * v0, struct s_2_unsignedS32_unsignedS32 * out)
+void ivartest2(struct s_2_2xunsignedS32 * v0, struct s_2_2xunsignedS32 * out)
 {
   struct ivar e0;
   
   taskpool_init(4, 4, 4);
   ivar_init(&e0);
-  spawn2(task0, struct s_2_unsignedS32_unsignedS32 *, v0, struct ivar, e0);
-  ivar_get_nontask(struct s_2_unsignedS32_unsignedS32, &*out, e0);
+  spawn2(task0, struct s_2_2xunsignedS32 *, v0, struct ivar, e0);
+  ivar_get_nontask(struct s_2_2xunsignedS32, &*out, e0);
   taskpool_shutdown();
   ivar_destroy(&e0);
 }

--- a/tests/gold/ivartest2.h
+++ b/tests/gold/ivartest2.h
@@ -3,16 +3,16 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_unsignedS32_unsignedS32
+struct s_2_2xunsignedS32
 {
   uint32_t member1;
   uint32_t member2;
 };
 
-void task_core0(struct s_2_unsignedS32_unsignedS32 * v0, struct ivar e0);
+void task_core0(struct s_2_2xunsignedS32 * v0, struct ivar e0);
 
 void task0(void * params);
 
-void ivartest2(struct s_2_unsignedS32_unsignedS32 * v0, struct s_2_unsignedS32_unsignedS32 * out);
+void ivartest2(struct s_2_2xunsignedS32 * v0, struct s_2_2xunsignedS32 * out);
 
 #endif // TMP2_IVARTEST2_H

--- a/tests/gold/metrics.c
+++ b/tests/gold/metrics.c
@@ -36,7 +36,7 @@ void freeArray_awl_signedS32(struct awl_signedS32 * src, int32_t srcLen)
   freeArray(src);
 }
 
-void metrics(struct awl_signedS32 * v1, struct awl_signedS32 * v2, struct awl_awl_s_2_unsignedS32_unsignedS32 * v3, struct awl_awl_signedS32 * out)
+void metrics(struct awl_signedS32 * v1, struct awl_signedS32 * v2, struct awl_awl_s_2_2xunsignedS32 * v3, struct awl_awl_signedS32 * out)
 {
   uint32_t v10;
   uint32_t v9;

--- a/tests/gold/metrics.h
+++ b/tests/gold/metrics.h
@@ -15,21 +15,21 @@ struct awl_awl_signedS32
   uint32_t length;
 };
 
-struct s_2_unsignedS32_unsignedS32
+struct s_2_2xunsignedS32
 {
   uint32_t member1;
   uint32_t member2;
 };
 
-struct awl_s_2_unsignedS32_unsignedS32
+struct awl_s_2_2xunsignedS32
 {
-  struct s_2_unsignedS32_unsignedS32 * buffer;
+  struct s_2_2xunsignedS32 * buffer;
   uint32_t length;
 };
 
-struct awl_awl_s_2_unsignedS32_unsignedS32
+struct awl_awl_s_2_2xunsignedS32
 {
-  struct awl_s_2_unsignedS32_unsignedS32 * buffer;
+  struct awl_s_2_2xunsignedS32 * buffer;
   uint32_t length;
 };
 
@@ -37,6 +37,6 @@ struct awl_signedS32 * initArray_awl_signedS32(struct awl_signedS32 * dst, uint3
 
 void freeArray_awl_signedS32(struct awl_signedS32 * src, int32_t srcLen);
 
-void metrics(struct awl_signedS32 * v1, struct awl_signedS32 * v2, struct awl_awl_s_2_unsignedS32_unsignedS32 * v3, struct awl_awl_signedS32 * out);
+void metrics(struct awl_signedS32 * v1, struct awl_signedS32 * v2, struct awl_awl_s_2_2xunsignedS32 * v3, struct awl_awl_signedS32 * out);
 
 #endif // TMP2_METRICS_H

--- a/tests/gold/pairParam.c
+++ b/tests/gold/pairParam.c
@@ -1,7 +1,7 @@
 #include "pairParam.h"
 
 
-void pairParam(struct s_2_unsignedS32_unsignedS32 * v0, uint32_t * out)
+void pairParam(struct s_2_2xunsignedS32 * v0, uint32_t * out)
 {
   *out = (*v0).member1;
 }

--- a/tests/gold/pairParam.h
+++ b/tests/gold/pairParam.h
@@ -3,12 +3,12 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_unsignedS32_unsignedS32
+struct s_2_2xunsignedS32
 {
   uint32_t member1;
   uint32_t member2;
 };
 
-void pairParam(struct s_2_unsignedS32_unsignedS32 * v0, uint32_t * out);
+void pairParam(struct s_2_2xunsignedS32 * v0, uint32_t * out);
 
 #endif // TMP2_PAIRPARAM_H

--- a/tests/gold/pairParam2.c
+++ b/tests/gold/pairParam2.c
@@ -1,7 +1,7 @@
 #include "pairParam2.h"
 
 
-void pairParam2(struct s_2_signedS16_signedS16 * v0, struct s_2_s_2_signedS16_signedS16_s_2_signedS16_signedS16 * out)
+void pairParam2(struct s_2_2xsignedS16 * v0, struct s_2_2xs_2_2xsignedS16 * out)
 {
   ((*out).member1).member1 = (*v0).member1;
   ((*out).member1).member2 = (*v0).member2;

--- a/tests/gold/pairParam2.h
+++ b/tests/gold/pairParam2.h
@@ -3,18 +3,18 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_signedS16_signedS16
+struct s_2_2xsignedS16
 {
   int16_t member1;
   int16_t member2;
 };
 
-struct s_2_s_2_signedS16_signedS16_s_2_signedS16_signedS16
+struct s_2_2xs_2_2xsignedS16
 {
-  struct s_2_signedS16_signedS16 member1;
-  struct s_2_signedS16_signedS16 member2;
+  struct s_2_2xsignedS16 member1;
+  struct s_2_2xsignedS16 member2;
 };
 
-void pairParam2(struct s_2_signedS16_signedS16 * v0, struct s_2_s_2_signedS16_signedS16_s_2_signedS16_signedS16 * out);
+void pairParam2(struct s_2_2xsignedS16 * v0, struct s_2_2xs_2_2xsignedS16 * out);
 
 #endif // TMP2_PAIRPARAM2_H

--- a/tests/gold/pairParam_ret.c
+++ b/tests/gold/pairParam_ret.c
@@ -1,7 +1,7 @@
 #include "pairParam_ret.h"
 
 
-uint32_t pairParam__ret(struct s_2_unsignedS32_unsignedS32 * v0)
+uint32_t pairParam__ret(struct s_2_2xunsignedS32 * v0)
 {
   uint32_t out;
   

--- a/tests/gold/pairParam_ret.h
+++ b/tests/gold/pairParam_ret.h
@@ -3,12 +3,12 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_unsignedS32_unsignedS32
+struct s_2_2xunsignedS32
 {
   uint32_t member1;
   uint32_t member2;
 };
 
-uint32_t pairParam__ret(struct s_2_unsignedS32_unsignedS32 * v0);
+uint32_t pairParam__ret(struct s_2_2xunsignedS32 * v0);
 
 #endif // TMP2_PAIRPARAM_RET_H

--- a/tests/gold/pairRet.c
+++ b/tests/gold/pairRet.c
@@ -1,7 +1,7 @@
 #include "pairRet.h"
 
 
-void pairRet(uint32_t v1, struct s_2_unsignedS32_unsignedS32 * out)
+void pairRet(uint32_t v1, struct s_2_2xunsignedS32 * out)
 {
   if ((v1 > 3))
   {

--- a/tests/gold/pairRet.h
+++ b/tests/gold/pairRet.h
@@ -3,12 +3,12 @@
 
 #include "feldspar_c99.h"
 
-struct s_2_unsignedS32_unsignedS32
+struct s_2_2xunsignedS32
 {
   uint32_t member1;
   uint32_t member2;
 };
 
-void pairRet(uint32_t v1, struct s_2_unsignedS32_unsignedS32 * out);
+void pairRet(uint32_t v1, struct s_2_2xunsignedS32 * out);
 
 #endif // TMP2_PAIRRET_H


### PR DESCRIPTION
Struct types with many fields get very long tags in the generated code.
This is a problem for the weight dictionaries created by onnxToFeld. We
solve the problem by abbreviating sequences of fields with the same type
using run length encoding.