### PR TITLE
Add an entity for include files

### DIFF
--- a/src/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/src/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -67,6 +67,7 @@ instance CodeGen Module where
     cgenList env = vcat . map (cgen env)
 
 instance CodeGen Entity where
+    cgen _ Include{..} = text "#include \"" <> text includeFile <> char '"'
     cgen env StructDef{..} = text "struct"   <+> text structName     $+$ block env (cgenList env structMembers) <> semi
     cgen env TypeDef{..}   = text "typedef"  <+> cgen env actualType <+> text typeName <> semi
     cgen env Proc{..}

--- a/src/Feldspar/Compiler/Imperative/FromCore.hs
+++ b/src/Feldspar/Compiler/Imperative/FromCore.hs
@@ -379,7 +379,8 @@ fromCoreUT opt uast = Module defs
     Block ds p = block results
     outDecl    = Declaration outParam Nothing
     paramTypes = getTypeDefs $ map (`Declaration` Nothing) formals
-    defs       = nub (def results ++ paramTypes) ++ topProc
+    inc        = Include "feldspar_c99.h"
+    defs       = inc:nub (def results ++ paramTypes) ++ topProc
     funname    = encodeFunctionName $ functionName opt
 
     (rtype, outs, ds', returns) -- Note [Fast returns].

--- a/src/Feldspar/Compiler/Imperative/Representation.hs
+++ b/src/Feldspar/Compiler/Imperative/Representation.hs
@@ -78,7 +78,10 @@ data Module = Module
     deriving (Eq, Show)
 
 data Entity
-    = StructDef
+    = Include
+        { includeFile              :: FilePath
+        }
+     | StructDef
         { structName                :: String
         , structMembers             :: [StructMember]
         }


### PR DESCRIPTION
This removes the ad-hoc handling of appending
some extra strings for include files
in compileSplitModule by adding an entity to
represent include files.