### PR TITLE
Remove BPSplit as a pass

### DIFF
--- a/src/Feldspar/Compiler.hs
+++ b/src/Feldspar/Compiler.hs
@@ -337,10 +337,10 @@ splitModule m = (Module (hdr ++ createProcDecls (entities m)), Module body)
 compileModule :: Options -> Module -> SplitModule
 compileModule opts mdl
   = SplitModule
-    { interface = CompiledModule { sourceCode  = compToCWithInfos opts hmdl
+    { interface = CompiledModule { sourceCode  = compToTarget opts hmdl
                                  , debugModule = hmdl
                                  }
-    , implementation = CompiledModule { sourceCode  = compToCWithInfos opts cmdl
+    , implementation = CompiledModule { sourceCode  = compToTarget opts cmdl
                                       , debugModule = cmdl
                                       }
     }
@@ -355,12 +355,14 @@ compileToCCore n opts p = fromMaybe err $ snd p'
         p' = translate opts{functionName = n} p
 
 instance Pretty Module where
-  pretty m = compToCWithInfos defaultOptions m
+  pretty m = compToTarget defaultOptions m
 
 instance Pretty SplitModule where
   pretty (SplitModule impl intf) = "// Interface\n" ++ sourceCode intf ++
                                    "\n// Implementation\n" ++ sourceCode impl
 
+-- FIXME: Move this switch into compToTarget and remove this function by
+--        inlining the "passT" line into frontend.
 codegen :: Options
         -> Prog (Either Module SplitModule) Int
         -> Prog SplitModule Int

--- a/src/Feldspar/Compiler/Backend/C/CodeGeneration.hs
+++ b/src/Feldspar/Compiler/Backend/C/CodeGeneration.hs
@@ -32,7 +32,7 @@
 
 -- | Converts a @Module@ to C Syntax
 module Feldspar.Compiler.Backend.C.CodeGeneration
-  ( compToCWithInfos
+  ( compToTarget
   ) where
 
 import Prelude hiding (Semigroup(..), (<>), init)
@@ -50,9 +50,15 @@ data PrintEnv = PEnv
     , parNestLevel :: Int
     }
 
--- | Convert a @Module@ to C syntax
-compToCWithInfos :: Options -> Module -> String
-compToCWithInfos opts procedure = render $ cgen (penv0 opts) procedure
+-- | Compile a @Module@ to target code
+compToTarget :: Options -> Module -> String
+compToTarget opts procedure
+  | "c" == codeGenerator (platform opts)
+  = render $ cgen (penv0 opts) procedure
+  | "ba" == codeGenerator (platform opts)
+  = error "TODO"
+  | otherwise = error $ "compToTarget: unknown code generator " ++
+                         codeGenerator (platform opts)
 
 penv0 :: Options -> PrintEnv
 penv0 opts = PEnv opts 0

--- a/src/Feldspar/Compiler/Options.hs
+++ b/src/Feldspar/Compiler/Options.hs
@@ -129,7 +129,6 @@ data Pass
   | BPArrayOps
   | BPRename
   | BPAdapt
-  | BPSplit
   | BPCompile
   | BPUnsplit
   deriving (Bounded, Enum, Eq, Lift, Read, Show)


### PR DESCRIPTION
Splitting a module into a header and an implementation
is an internal detail of BPCompile so merge the functionality
in there and remove BPSplit as a pass.

This gives us one pass less to keep track of
and also simplifies the type signatures for frontend
and codegen.