### PR TITLE
stack: update to LTS-16.12

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -17,8 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-16.8
-compiler: ghc-8.8.4
+resolver: lts-16.12
 
 ghc-options:
     # Somewhere deep inside there is a call to ghc --make, pass -j3 to


### PR DESCRIPTION
We were already using GHC 8.8.4 so switch
to a version that uses it by default.