### PR TITLE
hie: remove special onnxToFeld path

### DIFF
--- a/hie.yaml
+++ b/hie.yaml
@@ -4,8 +4,6 @@ cradle:
       component: "feldspar-language:lib"
     - path: "./.stack-work/dist/x86_64-linux/Cabal-3.0.1.0/build/autogen"
       component: "feldspar-language:lib"
-    - path: "./src/Feldspar/Onnx/onnxToFeld.hs"
-      component: "feldspar-language:exe:onnxToFeld"
     - path: "./src/Onnx"
       component: "feldspar-language:exe:onnxToFeld"
     - path: "./tests"


### PR DESCRIPTION
The file is moved into the right place so remove
the special entry.