### PR TITLE
tests: enable more cores

### DIFF
--- a/feldspar-language.cabal
+++ b/feldspar-language.cabal
@@ -236,7 +236,7 @@ test-suite tutorial
     base,
     bytestring         >= 0.9 && < 0.11
 
-  ghc-options: -threaded -with-rtsopts=-maxN4
+  ghc-options: -threaded -with-rtsopts=-maxN12
 
 test-suite regression
   type: exitcode-stdio-1.0
@@ -278,7 +278,7 @@ test-suite regression
   if os(windows)
     build-depends: Win32
 
-  ghc-options: -threaded -with-rtsopts=-maxN4
+  ghc-options: -threaded -with-rtsopts=-maxN12
 
 benchmark crc
   type: exitcode-stdio-1.0


### PR DESCRIPTION
The regression tests get a speedup
when using more cores, the balance
currently seems to be the number
of real cores+some. Use 12 since
the Travis instances has 16 "cores"
available.