### PR TITLE
CI: add Github action to build/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        cabal: ["3.4"]
+        ghc: ["8.8.4", "8.10.7"]
+    env:
+      CONFIG: "--enable-tests --enable-benchmarks"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1.2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - run: cabal v2-update
+      - run: cabal v2-freeze $CONFIG
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal v2-build -j4 $CONFIG
+      - run: |
+         export feldspar_language_libdir="$PWD/src/clib"
+         cabal v2-test $CONFIG
+        #      - run: cabal v2-haddock $CONFIG
+      - run: cabal check
+      - run: cabal v2-sdist


### PR DESCRIPTION
This more or less corresponds to the Travis
configuration we were using earlier. The main
differences are that we only use one version of
Cabal and more advanced caching of build artefacts.